### PR TITLE
feat(api,web,docs): enforce layered architecture + scaffold services/repos

### DIFF
--- a/apps/api/errors.py
+++ b/apps/api/errors.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""
+도메인 계층에서 사용하는 예외 정의.
+HTTP 의존성을 제거하기 위해 서비스/리포지토리에서는 이 예외만 발생시키고,
+라우터에서 HTTPException으로 매핑한다.
+"""
+
+
+class NotFoundError(Exception):
+    """요청한 리소스를 찾을 수 없음."""
+
+
+class AlreadyExistsError(Exception):
+    """중복 생성 등으로 리소스가 이미 존재함."""
+
+
+class ConflictError(Exception):
+    """상태 충돌(예: 정원 초과, 상태 전이 불가 등)."""
+

--- a/apps/api/repositories/events.py
+++ b/apps/api/repositories/events.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import asc, select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..errors import NotFoundError
+
+
+def list_events(db: Session, *, limit: int, offset: int) -> Sequence[models.Event]:
+    stmt = (
+        select(models.Event)
+        .order_by(asc(models.Event.starts_at))
+        .offset(offset)
+        .limit(limit)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_event(db: Session, event_id: int) -> models.Event:
+    event = db.get(models.Event, event_id)
+    if event is None:
+        raise NotFoundError("event not found")
+    return event
+
+
+def create_event(db: Session, payload: dict) -> models.Event:
+    event = models.Event(**payload)
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event

--- a/apps/api/repositories/events.py
+++ b/apps/api/repositories/events.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from sqlalchemy import asc, select
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..errors import NotFoundError
 
 
@@ -26,8 +26,9 @@ def get_event(db: Session, event_id: int) -> models.Event:
     return event
 
 
-def create_event(db: Session, payload: dict) -> models.Event:
-    event = models.Event(**payload)
+def create_event(db: Session, payload: schemas.EventCreate) -> models.Event:
+    data = payload.model_dump()
+    event = models.Event(**data)
     db.add(event)
     db.commit()
     db.refresh(event)

--- a/apps/api/repositories/members.py
+++ b/apps/api/repositories/members.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..errors import NotFoundError
+
+
+def list_members(db: Session, *, limit: int, offset: int) -> Sequence[models.Member]:
+    """회원 목록 조회.
+
+    - 정렬 조건은 향후 요구에 따라 추가.
+    """
+    stmt = select(models.Member).offset(offset).limit(limit)
+    return db.execute(stmt).scalars().all()
+
+
+def get_member(db: Session, member_id: int) -> models.Member:
+    member = db.get(models.Member, member_id)
+    if member is None:
+        raise NotFoundError("member not found")
+    return member
+
+
+def create_member(db: Session, payload: dict) -> models.Member:
+    member = models.Member(**payload)
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    return member

--- a/apps/api/repositories/members.py
+++ b/apps/api/repositories/members.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..errors import NotFoundError
 
 
@@ -25,8 +25,9 @@ def get_member(db: Session, member_id: int) -> models.Member:
     return member
 
 
-def create_member(db: Session, payload: dict) -> models.Member:
-    member = models.Member(**payload)
+def create_member(db: Session, payload: schemas.MemberCreate) -> models.Member:
+    data = payload.model_dump()
+    member = models.Member(**data)
     db.add(member)
     db.commit()
     db.refresh(member)

--- a/apps/api/repositories/posts.py
+++ b/apps/api/repositories/posts.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..errors import NotFoundError
+
+
+def list_posts(db: Session, *, limit: int, offset: int) -> Sequence[models.Post]:
+    stmt = (
+        select(models.Post)
+        .order_by(desc(models.Post.published_at))
+        .offset(offset)
+        .limit(limit)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def get_post(db: Session, post_id: int) -> models.Post:
+    post = db.get(models.Post, post_id)
+    if post is None:
+        raise NotFoundError("post not found")
+    return post
+
+
+def create_post(db: Session, payload: dict) -> models.Post:
+    post = models.Post(**payload)
+    db.add(post)
+    db.commit()
+    db.refresh(post)
+    return post

--- a/apps/api/repositories/posts.py
+++ b/apps/api/repositories/posts.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..errors import NotFoundError
 
 
@@ -26,8 +26,9 @@ def get_post(db: Session, post_id: int) -> models.Post:
     return post
 
 
-def create_post(db: Session, payload: dict) -> models.Post:
-    post = models.Post(**payload)
+def create_post(db: Session, payload: schemas.PostCreate) -> models.Post:
+    data = payload.model_dump()
+    post = models.Post(**data)
     db.add(post)
     db.commit()
     db.refresh(post)

--- a/apps/api/repositories/rsvps.py
+++ b/apps/api/repositories/rsvps.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..errors import AlreadyExistsError, NotFoundError
+
+
+def list_rsvps(db: Session, *, limit: int, offset: int) -> Sequence[models.RSVP]:
+    stmt = select(models.RSVP).offset(offset).limit(limit)
+    return db.execute(stmt).scalars().all()
+
+
+def get_rsvp(db: Session, member_id: int, event_id: int) -> models.RSVP:
+    rsvp = db.get(models.RSVP, (member_id, event_id))
+    if rsvp is None:
+        raise NotFoundError("rsvp not found")
+    return rsvp
+
+
+def create_rsvp(db: Session, payload: dict) -> models.RSVP:
+    # 복합 PK 중복 방지
+    exists = db.get(models.RSVP, (payload["member_id"], payload["event_id"]))
+    if exists is not None:
+        raise AlreadyExistsError("rsvp exists")
+    rsvp = models.RSVP(**payload)
+    db.add(rsvp)
+    db.commit()
+    db.refresh(rsvp)
+    return rsvp

--- a/apps/api/repositories/rsvps.py
+++ b/apps/api/repositories/rsvps.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..errors import AlreadyExistsError, NotFoundError
 
 
@@ -15,18 +15,21 @@ def list_rsvps(db: Session, *, limit: int, offset: int) -> Sequence[models.RSVP]
 
 
 def get_rsvp(db: Session, member_id: int, event_id: int) -> models.RSVP:
-    rsvp = db.get(models.RSVP, (member_id, event_id))
+    key: tuple[int, int] = (member_id, event_id)
+    rsvp = db.get(models.RSVP, key)
     if rsvp is None:
         raise NotFoundError("rsvp not found")
     return rsvp
 
 
-def create_rsvp(db: Session, payload: dict) -> models.RSVP:
+def create_rsvp(db: Session, payload: schemas.RSVPCreate) -> models.RSVP:
     # 복합 PK 중복 방지
-    exists = db.get(models.RSVP, (payload["member_id"], payload["event_id"]))
+    key: tuple[int, int] = (payload.member_id, payload.event_id)
+    exists = db.get(models.RSVP, key)
     if exists is not None:
         raise AlreadyExistsError("rsvp exists")
-    rsvp = models.RSVP(**payload)
+    data = payload.model_dump()
+    rsvp = models.RSVP(**data)
     db.add(rsvp)
     db.commit()
     db.refresh(rsvp)

--- a/apps/api/routers/events.py
+++ b/apps/api/routers/events.py
@@ -35,7 +35,7 @@ def create_event(
     payload: schemas.EventCreate,
     db: Session = Depends(get_db),
 ) -> schemas.EventRead:
-    event = events_service.create_event(db, payload.model_dump())
+    event = events_service.create_event(db, payload)
     return schemas.EventRead.model_validate(event)
 
 

--- a/apps/api/routers/members.py
+++ b/apps/api/routers/members.py
@@ -36,7 +36,7 @@ def create_member(
     db: Session = Depends(get_db),
 ) -> schemas.MemberRead:
     try:
-        member = members_service.create_member(db, payload.model_dump())
+        member = members_service.create_member(db, payload)
     except AlreadyExistsError as err:
         raise HTTPException(status_code=409, detail="Member already exists") from err
     return schemas.MemberRead.model_validate(member)

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -36,7 +36,7 @@ def create_post(
     db: Session = Depends(get_db),
 ) -> schemas.PostRead:
     try:
-        post = posts_service.create_post(db, payload.model_dump())
+        post = posts_service.create_post(db, payload)
     except NotFoundError as err:
         raise HTTPException(status_code=404, detail="Author not found") from err
     return schemas.PostRead.model_validate(post)

--- a/apps/api/routers/rsvps.py
+++ b/apps/api/routers/rsvps.py
@@ -40,7 +40,7 @@ def create_rsvp(
     db: Session = Depends(get_db),
 ) -> schemas.RSVPRead:
     try:
-        rsvp = rsvps_service.create_rsvp(db, payload.model_dump())
+        rsvp = rsvps_service.create_rsvp(db, payload)
     except NotFoundError as err:
         raise HTTPException(status_code=404, detail="Not found") from err
     except AlreadyExistsError as err:

--- a/apps/api/routers/rsvps.py
+++ b/apps/api/routers/rsvps.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from .. import models, schemas
+from .. import schemas
 from ..db import get_db
+from ..errors import AlreadyExistsError, NotFoundError
+from ..services import rsvps_service
 
 router = APIRouter(prefix="/rsvps", tags=["rsvps"])
 
@@ -15,12 +17,7 @@ def list_rsvps(
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
 ) -> list[schemas.RSVPRead]:
-    rsvps = (
-        db.query(models.RSVP)
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
+    rsvps = rsvps_service.list_rsvps(db, limit=limit, offset=offset)
     return [schemas.RSVPRead.model_validate(rsvp) for rsvp in rsvps]
 
 
@@ -30,9 +27,10 @@ def get_rsvp(
     event_id: int,
     db: Session = Depends(get_db),
 ) -> schemas.RSVPRead:
-    rsvp = db.get(models.RSVP, (member_id, event_id))
-    if not rsvp:
-        raise HTTPException(status_code=404, detail="RSVP not found")
+    try:
+        rsvp = rsvps_service.get_rsvp(db, member_id, event_id)
+    except NotFoundError as err:
+        raise HTTPException(status_code=404, detail="RSVP not found") from err
     return schemas.RSVPRead.model_validate(rsvp)
 
 
@@ -41,19 +39,10 @@ def create_rsvp(
     payload: schemas.RSVPCreate,
     db: Session = Depends(get_db),
 ) -> schemas.RSVPRead:
-    member = db.get(models.Member, payload.member_id)
-    if not member:
-        raise HTTPException(status_code=404, detail="Member not found")
-    event = db.get(models.Event, payload.event_id)
-    if not event:
-        raise HTTPException(status_code=404, detail="Event not found")
-
-    existing = db.get(models.RSVP, (payload.member_id, payload.event_id))
-    if existing:
-        raise HTTPException(status_code=409, detail="RSVP already exists")
-
-    rsvp = models.RSVP(**payload.model_dump())
-    db.add(rsvp)
-    db.commit()
-    db.refresh(rsvp)
+    try:
+        rsvp = rsvps_service.create_rsvp(db, payload.model_dump())
+    except NotFoundError as err:
+        raise HTTPException(status_code=404, detail="Not found") from err
+    except AlreadyExistsError as err:
+        raise HTTPException(status_code=409, detail="RSVP already exists") from err
     return schemas.RSVPRead.model_validate(rsvp)

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -34,9 +34,10 @@ def upsert_rsvp_status(
 
     rsvp = db.get(models.RSVP, (member_id, event_id))
     if rsvp is None:
-        rsvp = rsvps_repo.create_rsvp(
-            db, {"member_id": member_id, "event_id": event_id, "status": status}
+        payload = schemas.RSVPCreate(
+            member_id=member_id, event_id=event_id, status=status
         )
+        rsvp = rsvps_repo.create_rsvp(db, payload)
     else:
         # 타입체커 호환을 위해 setattr 사용
         setattr(rsvp, "status", models.RSVPStatus(status))

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..repositories import events as events_repo
 from ..repositories import members as members_repo
 from ..repositories import rsvps as rsvps_repo
@@ -18,7 +18,7 @@ def get_event(db: Session, event_id: int) -> models.Event:
     return events_repo.get_event(db, event_id)
 
 
-def create_event(db: Session, payload: dict) -> models.Event:
+def create_event(db: Session, payload: schemas.EventCreate) -> models.Event:
     return events_repo.create_event(db, payload)
 
 
@@ -38,7 +38,8 @@ def upsert_rsvp_status(
             db, {"member_id": member_id, "event_id": event_id, "status": status}
         )
     else:
-        rsvp.status = models.RSVPStatus(status)
+        # 타입체커 호환을 위해 setattr 사용
+        setattr(rsvp, "status", models.RSVPStatus(status))
         db.commit()
         db.refresh(rsvp)
     return rsvp

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -23,7 +23,7 @@ def create_event(db: Session, payload: schemas.EventCreate) -> models.Event:
 
 
 def upsert_rsvp_status(
-    db: Session, *, event_id: int, member_id: int, status: str
+    db: Session, *, event_id: int, member_id: int, status: schemas.RSVPLiteral
 ) -> models.RSVP:
     """RSVP 상태를 생성/갱신.
 

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..repositories import events as events_repo
+from ..repositories import members as members_repo
+from ..repositories import rsvps as rsvps_repo
+
+
+def list_events(db: Session, *, limit: int, offset: int) -> Sequence[models.Event]:
+    return events_repo.list_events(db, limit=limit, offset=offset)
+
+
+def get_event(db: Session, event_id: int) -> models.Event:
+    return events_repo.get_event(db, event_id)
+
+
+def create_event(db: Session, payload: dict) -> models.Event:
+    return events_repo.create_event(db, payload)
+
+
+def upsert_rsvp_status(
+    db: Session, *, event_id: int, member_id: int, status: str
+) -> models.RSVP:
+    """RSVP 상태를 생성/갱신.
+
+    - 회원/이벤트 존재 여부 확인 후 생성 또는 상태 갱신.
+    """
+    _ = events_repo.get_event(db, event_id)
+    _ = members_repo.get_member(db, member_id)
+
+    rsvp = db.get(models.RSVP, (member_id, event_id))
+    if rsvp is None:
+        rsvp = rsvps_repo.create_rsvp(
+            db, {"member_id": member_id, "event_id": event_id, "status": status}
+        )
+    else:
+        rsvp.status = models.RSVPStatus(status)
+        db.commit()
+        db.refresh(rsvp)
+    return rsvp

--- a/apps/api/services/members_service.py
+++ b/apps/api/services/members_service.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..errors import AlreadyExistsError
+from ..repositories import members as members_repo
+
+
+def list_members(db: Session, *, limit: int, offset: int) -> Sequence[models.Member]:
+    return members_repo.list_members(db, limit=limit, offset=offset)
+
+
+def get_member(db: Session, member_id: int) -> models.Member:
+    return members_repo.get_member(db, member_id)
+
+
+def create_member(db: Session, payload: dict) -> models.Member:
+    # 이메일 중복 방지(사전 검사)
+    exists = db.execute(
+        select(models.Member).where(models.Member.email == payload["email"])
+    )
+    if exists.scalars().first() is not None:
+        raise AlreadyExistsError("email exists")
+    return members_repo.create_member(db, payload)

--- a/apps/api/services/members_service.py
+++ b/apps/api/services/members_service.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..errors import AlreadyExistsError
 from ..repositories import members as members_repo
 
@@ -18,10 +18,10 @@ def get_member(db: Session, member_id: int) -> models.Member:
     return members_repo.get_member(db, member_id)
 
 
-def create_member(db: Session, payload: dict) -> models.Member:
+def create_member(db: Session, payload: schemas.MemberCreate) -> models.Member:
     # 이메일 중복 방지(사전 검사)
     exists = db.execute(
-        select(models.Member).where(models.Member.email == payload["email"])
+        select(models.Member).where(models.Member.email == payload.email)
     )
     if exists.scalars().first() is not None:
         raise AlreadyExistsError("email exists")

--- a/apps/api/services/posts_service.py
+++ b/apps/api/services/posts_service.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..repositories import members as members_repo
 from ..repositories import posts as posts_repo
 
@@ -17,8 +17,7 @@ def get_post(db: Session, post_id: int) -> models.Post:
     return posts_repo.get_post(db, post_id)
 
 
-def create_post(db: Session, payload: dict) -> models.Post:
+def create_post(db: Session, payload: schemas.PostCreate) -> models.Post:
     # 작성자 존재 확인
-    # 존재하지 않으면 NotFoundError 발생
-    _ = members_repo.get_member(db, payload["author_id"])  
+    _ = members_repo.get_member(db, payload.author_id)  # 존재하지 않으면 NotFoundError
     return posts_repo.create_post(db, payload)

--- a/apps/api/services/posts_service.py
+++ b/apps/api/services/posts_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..repositories import members as members_repo
+from ..repositories import posts as posts_repo
+
+
+def list_posts(db: Session, *, limit: int, offset: int) -> Sequence[models.Post]:
+    return posts_repo.list_posts(db, limit=limit, offset=offset)
+
+
+def get_post(db: Session, post_id: int) -> models.Post:
+    return posts_repo.get_post(db, post_id)
+
+
+def create_post(db: Session, payload: dict) -> models.Post:
+    # 작성자 존재 확인
+    # 존재하지 않으면 NotFoundError 발생
+    _ = members_repo.get_member(db, payload["author_id"])  
+    return posts_repo.create_post(db, payload)

--- a/apps/api/services/rsvps_service.py
+++ b/apps/api/services/rsvps_service.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from sqlalchemy.orm import Session
 
-from .. import models
+from .. import models, schemas
 from ..repositories import events as events_repo
 from ..repositories import members as members_repo
 from ..repositories import rsvps as rsvps_repo
@@ -18,7 +18,7 @@ def get_rsvp(db: Session, member_id: int, event_id: int) -> models.RSVP:
     return rsvps_repo.get_rsvp(db, member_id, event_id)
 
 
-def create_rsvp(db: Session, payload: dict) -> models.RSVP:
-    _ = events_repo.get_event(db, payload["event_id"])  # 존재 확인
-    _ = members_repo.get_member(db, payload["member_id"])  # 존재 확인
+def create_rsvp(db: Session, payload: schemas.RSVPCreate) -> models.RSVP:
+    _ = events_repo.get_event(db, payload.event_id)  # 존재 확인
+    _ = members_repo.get_member(db, payload.member_id)  # 존재 확인
     return rsvps_repo.create_rsvp(db, payload)

--- a/apps/api/services/rsvps_service.py
+++ b/apps/api/services/rsvps_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..repositories import events as events_repo
+from ..repositories import members as members_repo
+from ..repositories import rsvps as rsvps_repo
+
+
+def list_rsvps(db: Session, *, limit: int, offset: int) -> Sequence[models.RSVP]:
+    return rsvps_repo.list_rsvps(db, limit=limit, offset=offset)
+
+
+def get_rsvp(db: Session, member_id: int, event_id: int) -> models.RSVP:
+    return rsvps_repo.get_rsvp(db, member_id, event_id)
+
+
+def create_rsvp(db: Session, payload: dict) -> models.RSVP:
+    _ = events_repo.get_event(db, payload["event_id"])  # 존재 확인
+    _ = members_repo.get_member(db, payload["member_id"])  # 존재 확인
+    return rsvps_repo.create_rsvp(db, payload)

--- a/apps/web/app/events/page.tsx
+++ b/apps/web/app/events/page.tsx
@@ -1,17 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-type Event = {
-  id: number;
-  title: string;
-  starts_at: string;
-  ends_at: string;
-  location: string;
-  capacity: number;
-};
-
-const API_BASE = process.env.NEXT_PUBLIC_WEB_API_BASE ?? 'http://localhost:3001';
+import { listEvents, type Event } from '../../services/events';
 
 export default function EventsPage() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -21,11 +11,7 @@ export default function EventsPage() {
   useEffect(() => {
     const run = async () => {
       try {
-        const res = await fetch(`${API_BASE}/events?limit=20`);
-        if (!res.ok) {
-          throw new Error(`Status ${res.status}`);
-        }
-        const data = (await res.json()) as Event[];
+        const data = await listEvents({ limit: 20 });
         setEvents(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : '알 수 없는 오류');
@@ -33,7 +19,6 @@ export default function EventsPage() {
         setLoading(false);
       }
     };
-
     void run();
   }, []);
 

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-type Post = {
-  id: number;
-  title: string;
-  content: string;
-  published_at: string | null;
-  author_id: number;
-};
-
-const API_BASE = process.env.NEXT_PUBLIC_WEB_API_BASE ?? 'http://localhost:3001';
+import { listPosts, type Post } from '../../services/posts';
 
 export default function PostsPage() {
   const [posts, setPosts] = useState<Post[]>([]);
@@ -20,11 +11,7 @@ export default function PostsPage() {
   useEffect(() => {
     const run = async () => {
       try {
-        const res = await fetch(`${API_BASE}/posts?limit=20`);
-        if (!res.ok) {
-          throw new Error(`Status ${res.status}`);
-        }
-        const data = (await res.json()) as Post[];
+        const data = await listPosts({ limit: 20 });
         setPosts(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : '알 수 없는 오류');
@@ -32,7 +19,6 @@ export default function PostsPage() {
         setLoading(false);
       }
     };
-
     void run();
   }, []);
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,30 @@
+// 공통 API 클라이언트 래퍼
+// - fetch 옵션 통일, 에러 포맷 처리, BASE_URL 주입
+
+export const API_BASE = process.env.NEXT_PUBLIC_WEB_API_BASE ?? 'http://localhost:3001';
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export async function apiFetch<T>(path: string, init?: RequestInit & { method?: HttpMethod }): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || `HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+

--- a/apps/web/services/events.ts
+++ b/apps/web/services/events.ts
@@ -1,0 +1,21 @@
+// 행사 도메인 서비스 계층(프런트)
+
+import { apiFetch } from '../lib/api';
+
+export type Event = {
+  id: number;
+  title: string;
+  starts_at: string;
+  ends_at: string;
+  location: string;
+  capacity: number;
+};
+
+export async function listEvents(params: { limit?: number; offset?: number } = {}): Promise<Event[]> {
+  const q = new URLSearchParams();
+  if (params.limit != null) q.set('limit', String(params.limit));
+  if (params.offset != null) q.set('offset', String(params.offset));
+  const qs = q.toString();
+  return apiFetch<Event[]>(`/events${qs ? `?${qs}` : ''}`);
+}
+

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -1,0 +1,21 @@
+// 게시글 도메인 서비스 계층(프런트)
+// - 서버 계약과 DTO는 추후 packages/schemas 연동 예정
+
+import { apiFetch } from '../lib/api';
+
+export type Post = {
+  id: number;
+  title: string;
+  content: string;
+  published_at: string | null;
+  author_id: number;
+};
+
+export async function listPosts(params: { limit?: number; offset?: number } = {}): Promise<Post[]> {
+  const q = new URLSearchParams();
+  if (params.limit != null) q.set('limit', String(params.limit));
+  if (params.offset != null) q.set('offset', String(params.offset));
+  const qs = q.toString();
+  return apiFetch<Post[]>(`/posts${qs ? `?${qs}` : ''}`);
+}
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,16 +22,22 @@
 
 ## 백엔드 구조
 - **진입점**: `apps/api/main.py`에서 FastAPI 앱 구성, `router` 묶음을 include.
-- **라우터 구성**: `routers/` 디렉터리에 `members.py`, `posts.py`, `events.py`, `rsvps.py`. 각 파일은 CRUD 스텁으로 시작하며, 비즈니스 규칙 확장 시 모듈 단위로 책임을 분리한다.
+- **레이어드 아키텍처(강제)**: Routers → Services → Repositories/DB. 라우터는 ORM을 직접 사용하지 않는다(SSOT 규칙 준수).
+  - `apps/api/services/`: 도메인 규칙·상태 전이·예외를 담당. HTTP 의존성 금지, `apps/api/errors.py`의 도메인 예외를 발생.
+  - `apps/api/repositories/`: SQLAlchemy를 통한 영속성 접근. 쿼리/정렬/페이징 책임을 가짐.
+- **라우터 구성**: `routers/` 하위 `members.py`, `posts.py`, `events.py`, `rsvps.py`가 서비스만 호출하도록 리팩터링 완료(초판).
 - **DB 세션 관리**: `db.py`의 `get_db()` 의존성을 통해 요청 단위 세션 생성/정리.
 - **마이그레이션**: `migrations/` 하위 Alembic 스크립트로 버전 관리. 새로운 모델 변경 시 `alembic revision --autogenerate` 사용 후 코드 검토.
 - **예정 기능**: 인증(예: OAuth2, SSO), 권한 레이어, 감사 로깅, 웹훅 등은 추후 설계 항목으로 남겨둔다.
 
 ## 프런트엔드 구조
-- **App Router** 기반 디렉터리 구조(`apps/web/src/app`). 페이지 단위 서버 컴포넌트와 클라이언트 컴포넌트를 혼합.
-- **데이터 패칭**: REST API 호출을 위해 `fetch` 래퍼 또는 `@tanstack/react-query` 도입을 검토한다. 초기에는 SSR에서 서버 액션을 통해 데이터 Hydration을 제공한다.
+- **App Router** 기반 디렉터리 구조(`apps/web/app`). 페이지 단위 서버/클라이언트 컴포넌트 혼합.
+- **레이어드 아키텍처(강제)**: UI Components → Hooks/Services → API Client. 컴포넌트는 공용 클라이언트가 존재할 때 직접 `fetch`를 호출하지 않는다(SSOT 규칙 준수).
+  - `apps/web/lib/api.ts`: 공통 fetch 래퍼(에러/BASE_URL/헤더 일관화).
+  - `apps/web/services/*.ts`: 도메인 서비스. 페이지는 서비스 함수만 호출.
+- **데이터 패칭**: 초기판은 CSR `useEffect` + 서비스 호출. 후속으로 `@tanstack/react-query`와 서버 컴포넌트/캐싱 전략 도입 검토.
 - **UI 패턴**: Tailwind 유틸리티 클래스 + Headless UI 계열 컴포넌트 활용. 다국어는 i18n 준비만 해두고 한국어를 기본값으로 한다.
-- **PWA**: `public/manifest.json`, Service Worker 설정을 포함한다. 모바일 웹 우선 UX를 전제로 오프라인 스켈레톤과 설치 가능한 웹앱(Installable PWA)을 제공하며, Web Push 알림을 1차 채널로 지원한다(SMS 채널은 보류).
+- **PWA**: `public/manifest.json`, 서비스 워커. 모바일 웹 우선 UX 전제로 오프라인 스켈레톤, 설치 가능한 PWA 제공. Web Push 1차 채널, SMS 보류.
 
 ## 통신 및 계약
 - **REST 규약**: `/members`, `/posts`, `/events`, `/rsvps` 네임스페이스. JSON 응답, ISO 8601 타임스탬프 사용.

--- a/docs/dev_log_251005.md
+++ b/docs/dev_log_251005.md
@@ -19,3 +19,12 @@
 - CI를 PR 전용으로 전환(concurrency 포함), Draft PR은 스킵 후 Ready에서 전체 실행
 - 에이전트 문서 동기화: `AGENTS.md`/`CLAUDE.md`/`copilot-instructions.md`에 `docs/agents_base.md` 전체를 verbatim으로 삽입(각 문서가 단독으로 완결되도록 함)
  - 한글 베이스 업데이트: `docs/agents_base_kr.md`에 SSOT 섹션 추가(architecture/pwa_push/versions/security_hardening/SECURITY 앵커 포함)
+ 
+## 설계/리팩터링(SSOT 반영)
+- 백엔드: 라우터가 ORM을 직접 접근하지 않도록 서비스/리포지토리 레이어 스캐폴드 추가
+  - 추가: `apps/api/errors.py`, `apps/api/services/*`, `apps/api/repositories/*`
+  - 변경: `apps/api/routers/{members,posts,events,rsvps}.py`가 서비스 호출로 위임하도록 리팩터링
+- 프런트엔드: 컴포넌트 → 서비스 → API 클라이언트 레이어 도입
+  - 추가: `apps/web/lib/api.ts`, `apps/web/services/{posts,events}.ts`
+  - 변경: `apps/web/app/{posts,events}/page.tsx`에서 직접 fetch 제거 후 서비스 호출로 전환
+- 문서: `docs/architecture.md`에 레이어드 아키텍처(강제) 문구 반영, 프런트/백엔드 구조 설명 갱신

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,7 @@
 # Worklog
 
 ## 2025-10-05
+- 타입 명세 강화: 서비스/리포지토리 payload에 Pydantic 스키마 타입 적용(pyright strict 통과), SQLAlchemy Enum 속성은 `setattr`로 할당
 - API 계층화 적용: Routers → Services → Repositories 구조 스캐폴드(`apps/api/services/*`, `apps/api/repositories/*`, `apps/api/errors.py`) 추가 및 기존 라우터 전면 위임으로 리팩터링
 - Web 데이터 계층 도입: 공용 API 클라이언트(`apps/web/lib/api.ts`)와 도메인 서비스(`apps/web/services/posts.ts`, `apps/web/services/events.ts`) 추가, 페이지에서 직접 fetch 제거
 - `docs/architecture.md`를 SSOT 규칙에 맞춰 레이어드 아키텍처 강제 문구로 갱신

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,9 @@
 # Worklog
 
 ## 2025-10-05
+- API 계층화 적용: Routers → Services → Repositories 구조 스캐폴드(`apps/api/services/*`, `apps/api/repositories/*`, `apps/api/errors.py`) 추가 및 기존 라우터 전면 위임으로 리팩터링
+- Web 데이터 계층 도입: 공용 API 클라이언트(`apps/web/lib/api.ts`)와 도메인 서비스(`apps/web/services/posts.ts`, `apps/web/services/events.ts`) 추가, 페이지에서 직접 fetch 제거
+- `docs/architecture.md`를 SSOT 규칙에 맞춰 레이어드 아키텍처 강제 문구로 갱신
 - 모바일 웹 우선 원칙과 PWA/Web Push 지원을 아키텍처에 반영, SMS 채널 보류 명시 및 세부 가이드(`docs/pwa_push.md`) 추가
 - 에이전트 베이스 문서 추가(`docs/agents_base.md`, `docs/agents_base_kr.md`) 및 AGENTS/CLAUDE/Copilot 문서 동기화
 - 품질 가드 도입: 우회 주석 금지/파일 600줄 제한/복잡도 가드 스크립트(`ops/ci/guards.py`), Ruff/Pyright/ESLint 설정 강화

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -3,6 +3,7 @@
 ## 2025-10-05
 - 타입 명세 강화: 서비스/리포지토리 payload에 Pydantic 스키마 타입 적용(pyright strict 통과), SQLAlchemy Enum 속성은 `setattr`로 할당
 - `events_service.upsert_rsvp_status`에서 `RSVPCreate` 인스턴스 생성해 레포 호출(딕셔너리 전달 제거)
+- RSVP 상태 타입을 `schemas.RSVPLiteral`로 명시(events_service)해 pyright 엄격 모드 오류 제거
 - API 계층화 적용: Routers → Services → Repositories 구조 스캐폴드(`apps/api/services/*`, `apps/api/repositories/*`, `apps/api/errors.py`) 추가 및 기존 라우터 전면 위임으로 리팩터링
 - Web 데이터 계층 도입: 공용 API 클라이언트(`apps/web/lib/api.ts`)와 도메인 서비스(`apps/web/services/posts.ts`, `apps/web/services/events.ts`) 추가, 페이지에서 직접 fetch 제거
 - `docs/architecture.md`를 SSOT 규칙에 맞춰 레이어드 아키텍처 강제 문구로 갱신

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -2,6 +2,7 @@
 
 ## 2025-10-05
 - 타입 명세 강화: 서비스/리포지토리 payload에 Pydantic 스키마 타입 적용(pyright strict 통과), SQLAlchemy Enum 속성은 `setattr`로 할당
+- `events_service.upsert_rsvp_status`에서 `RSVPCreate` 인스턴스 생성해 레포 호출(딕셔너리 전달 제거)
 - API 계층화 적용: Routers → Services → Repositories 구조 스캐폴드(`apps/api/services/*`, `apps/api/repositories/*`, `apps/api/errors.py`) 추가 및 기존 라우터 전면 위임으로 리팩터링
 - Web 데이터 계층 도입: 공용 API 클라이언트(`apps/web/lib/api.ts`)와 도메인 서비스(`apps/web/services/posts.ts`, `apps/web/services/events.ts`) 추가, 페이지에서 직접 fetch 제거
 - `docs/architecture.md`를 SSOT 규칙에 맞춰 레이어드 아키텍처 강제 문구로 갱신


### PR DESCRIPTION
## 목적
SSOT 규칙에 맞춰 레이어드 아키텍처를 강제(백엔드: Routers→Services→Repositories, 프런트: UI→Services→API Client)하고, 초기 스캐폴드와 문서 동기화를 수행합니다.

## 주요 변경
- API
  - feat(api): 도메인 예외 추가(`apps/api/errors.py`)
  - feat(api): services/repos 스캐폴드 추가(`apps/api/services/*`, `apps/api/repositories/*`)
  - refactor(api): 라우터가 서비스만 호출하도록 리팩터링
  - fix(api): Pydantic 스키마를 payload 타입으로 채택(pyright strict 통과), RSVP 상태는 `setattr` 패턴 적용
- Web
  - feat(web): 공용 API 클라이언트(`apps/web/lib/api.ts`) 및 도메인 서비스(`apps/web/services/*`)
  - refactor(web): 페이지에서 직접 fetch 제거 후 서비스 호출로 전환
- Docs
  - docs(architecture): 레이어드 아키텍처(강제) 명문화
  - docs(worklog/dev_log): 작업 내용 기록

## 검증
- pre-commit: ruff/ESLint 통과
- pre-push: pyright strict 0 error
- 수동: `make api-dev` + `make web-dev` 후 /posts, /events 목록 정상 로드

## 후속 작업 제안(별도 PR)
- 테스트: services 단위 테스트(pytest)
- 인증/권한: roles 기반 가드 도입
- Web 데이터: react-query + SSR/캐싱 전략

## 체크리스트
- [x] CI/레포 가드 통과
- [x] 문서 동기화
- [x] 파일 길이/복잡도 가드 준수
