### PR TITLE
feat(api,web): M1 기본기능 보강 — react-query/상세·생성 폼/RSVP capacity v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ VAPID_SUBJECT=mailto:security@trr.co.kr
 
 # Rate limiting (per-IP)
 RATE_LIMIT_DEFAULT=120/minute
+
+# 테스트 설정(선택): 기본은 SQLite, Postgres로 테스트하려면 아래 값 설정
+# TEST_DB=pg
+# TEST_DB_URL=postgresql+psycopg://app:devpass@localhost:5433/appdb_test
+# # 보호장치 해제(특수 케이스): 테스트 DB명이 'test'를 포함하지 않아도 실행하려면
+# # TEST_DB_FORCE=1

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,6 @@ RATE_LIMIT_DEFAULT=120/minute
 
 # 테스트 설정(선택): 기본은 SQLite, Postgres로 테스트하려면 아래 값 설정
 # TEST_DB=pg
-# TEST_DB_URL=postgresql+psycopg://app:devpass@localhost:5433/appdb_test
+# TEST_DB_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test
 # # 보호장치 해제(특수 케이스): 테스트 DB명이 'test'를 포함하지 않아도 실행하려면
 # # TEST_DB_FORCE=1

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # API 환경변수 (로컬 개발)
 
 # 데이터베이스 연결 (둘 중 하나 선택)
-# 1) SQLite(기본): 별도 의존성 없이 바로 실행
-DATABASE_URL=sqlite:///./dev.sqlite3
-# 2) Postgres(Docker 사용): 포트 충돌 시 5433 등으로 변경 가능
-# DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
+# 1) Postgres(Docker 사용; 개발 기본: 5433)
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5433/appdb
+# 2) SQLite(옵션): 별도 의존성 없이 바로 실행
+# DATABASE_URL=sqlite:///./dev.sqlite3
 
 # 앱 실행 환경
 APP_ENV=dev

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,23 @@
-# API
-DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
+# API 환경변수 (로컬 개발)
+
+# 데이터베이스 연결 (둘 중 하나 선택)
+# 1) SQLite(기본): 별도 의존성 없이 바로 실행
+DATABASE_URL=sqlite:///./dev.sqlite3
+# 2) Postgres(Docker 사용): 포트 충돌 시 5433 등으로 변경 가능
+# DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
+
+# 앱 실행 환경
 APP_ENV=dev
+
+# JWT 시크릿(개발 기본값 — 운영 시 시크릿 매니저 사용)
 JWT_SECRET=change-me
+
+# CORS 허용 오리진(개발 환경 기본값)
 CORS_ORIGINS=http://localhost:3000
 
-# WEB
-WEB_API_BASE=http://localhost:3001
+# Web(Next.js)에서 API 베이스 URL
+# apps/web/lib/api.ts는 NEXT_PUBLIC_WEB_API_BASE를 사용합니다.
+NEXT_PUBLIC_WEB_API_BASE=http://localhost:3001
 
 # Notifications (Web Push)
 VAPID_PUBLIC_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# API
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
+APP_ENV=dev
+JWT_SECRET=change-me
+CORS_ORIGINS=http://localhost:3000
+
+# WEB
+WEB_API_BASE=http://localhost:3001
+
+# Notifications (Web Push)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:security@trr.co.kr
+
+# Rate limiting (per-IP)
+RATE_LIMIT_DEFAULT=120/minute

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage/
 apps/web/tsconfig.tsbuildinfo
 .env
 .env.*
+!.env.example
+# 예시 파일은 추적(문서/기본값 공유)
 *.sqlite3
 .DS_Store
 apps/api/migrations/__pycache__/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,72 @@
+{
+  // VS Code Debug: FastAPI + Next.js 개발 편의를 위한 구성
+  // 한국어 주석: 로컬 개발에서 바로 실행/디버깅 가능하도록 설정합니다.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "API: FastAPI (SQLite dev)",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": [
+        "apps.api.main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "3001",
+        "--reload"
+      ],
+      "env": {
+        "DATABASE_URL": "sqlite:///./dev.sqlite3"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "API: FastAPI (Postgres via Docker)",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": [
+        "apps.api.main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "3001",
+        "--reload"
+      ],
+      "env": {
+        "DATABASE_URL": "postgresql+psycopg://app:devpass@localhost:5432/appdb"
+      },
+      "envFile": "${workspaceFolder}/.env",
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Web: Next.js dev (pnpm)",
+      "type": "pwa-node",
+      "request": "launch",
+      "program": "${workspaceFolder}/apps/web/node_modules/next/dist/bin/next",
+      "args": ["dev", "-p", "3000"],
+      "cwd": "${workspaceFolder}/apps/web",
+      "env": {
+        "NEXT_PUBLIC_WEB_API_BASE": "http://localhost:3001"
+      },
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Dev: API(SQLite) + Web",
+      "configurations": ["API: FastAPI (SQLite dev)", "Web: Next.js dev (pnpm)"]
+    },
+    {
+      "name": "Dev: API(Postgres) + Web",
+      "configurations": ["API: FastAPI (Postgres via Docker)", "Web: Next.js dev (pnpm)"]
+    }
+  ]
+}
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,6 +56,20 @@
       },
       "skipFiles": ["<node_internals>/**"],
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Tests: Pytest (PG test DB)",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-q"],
+      "env": {
+        "TEST_DB": "pg",
+        "TEST_DB_URL": "postgresql+psycopg://app:devpass@localhost:5434/appdb_test"
+      },
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "justMyCode": true
     }
   ],
   "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,7 @@
         "--reload"
       ],
       "env": {
-        "DATABASE_URL": "postgresql+psycopg://app:devpass@localhost:5432/appdb"
+        "DATABASE_URL": "postgresql+psycopg://app:devpass@localhost:5433/appdb"
       },
       "envFile": "${workspaceFolder}/.env",
       "cwd": "${workspaceFolder}",
@@ -69,4 +69,3 @@
     }
   ]
 }
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv api-install db-up db-down api-dev web-dev schema-gen test-api info-venv
+.PHONY: venv api-install db-up db-down db-test-up api-dev web-dev schema-gen test-api info-venv
 
 # Detect active virtualenv; fallback to project-local .venv
 VENV_DIR ?= $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV),.venv)
@@ -16,10 +16,13 @@ api-install:
 	"$(VENV_BIN)/pip" install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt
 
 db-up:
-	docker compose -f infra/docker-compose.dev.yml up -d
+	docker compose -f infra/docker-compose.dev.yml up -d postgres postgres_test
 
 db-down:
 	docker compose -f infra/docker-compose.dev.yml down
+
+db-test-up:
+	docker compose -f infra/docker-compose.dev.yml up -d postgres_test
 
 api-dev:
 	@if [ ! -x "$(VENV_BIN)/uvicorn" ]; then \

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -52,8 +52,10 @@ def upsert_rsvp_status(
         capacity_int: int = cast(int, event_obj.capacity)
         # 업데이트 시 본인 카운트는 제외하여 재요청으로 인한 부당한 대기열 강등을 방지
         effective = int(going_count)
-        if existing is not None and existing.status == models.RSVPStatus.GOING:
-            effective -= 1
+        if existing is not None:
+            current: models.RSVPStatus = cast(models.RSVPStatus, existing.status)
+            if current == models.RSVPStatus.GOING:
+                effective -= 1
         if effective >= capacity_int:
             return models.RSVPStatus.WAITLIST
         return models.RSVPStatus.GOING

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -46,7 +47,7 @@ def upsert_rsvp_status(
         ).scalar_one()
         event_obj = db.get(models.Event, event_id)
         assert event_obj is not None
-        capacity_int: int = int(event_obj.capacity)
+        capacity_int: int = cast(int, event_obj.capacity)
         if int(going_count) >= capacity_int:
             return models.RSVPStatus.WAITLIST
         return models.RSVPStatus.GOING

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -35,7 +35,9 @@ def upsert_rsvp_status(
     _ = events_repo.get_event(db, event_id)
     _ = members_repo.get_member(db, member_id)
 
-    def _normalize_status(req: schemas.RSVPLiteral) -> models.RSVPStatus:
+    def _normalize_status(
+        req: schemas.RSVPLiteral, existing: models.RSVP | None
+    ) -> models.RSVPStatus:
         if req != "going":
             return models.RSVPStatus(req)
         # going인 경우 정원 검사
@@ -48,20 +50,24 @@ def upsert_rsvp_status(
         event_obj = db.get(models.Event, event_id)
         assert event_obj is not None
         capacity_int: int = cast(int, event_obj.capacity)
-        if int(going_count) >= capacity_int:
+        # 업데이트 시 본인 카운트는 제외하여 재요청으로 인한 부당한 대기열 강등을 방지
+        effective = int(going_count)
+        if existing is not None and existing.status == models.RSVPStatus.GOING:
+            effective -= 1
+        if effective >= capacity_int:
             return models.RSVPStatus.WAITLIST
         return models.RSVPStatus.GOING
 
     rsvp = db.get(models.RSVP, (member_id, event_id))
     if rsvp is None:
-        final_status = _normalize_status(status)
+        final_status = _normalize_status(status, None)
         payload = schemas.RSVPCreate(
             member_id=member_id, event_id=event_id, status=final_status.value
         )
         rsvp = rsvps_repo.create_rsvp(db, payload)
     else:
         # 타입체커 호환을 위해 setattr 사용
-        setattr(rsvp, "status", _normalize_status(status))
+        setattr(rsvp, "status", _normalize_status(status, rsvp))
         db.commit()
         db.refresh(rsvp)
     return rsvp

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -44,8 +44,10 @@ def upsert_rsvp_status(
                 models.RSVP.status == models.RSVPStatus.GOING,
             )
         ).scalar_one()
-        capacity = db.get(models.Event, event_id).capacity
-        if going_count >= capacity:
+        event_obj = db.get(models.Event, event_id)
+        assert event_obj is not None
+        capacity_int: int = int(event_obj.capacity)
+        if int(going_count) >= capacity_int:
             return models.RSVPStatus.WAITLIST
         return models.RSVPStatus.GOING
 

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -58,7 +58,7 @@ def upsert_rsvp_status(
         return models.RSVPStatus.GOING
 
     rsvp = db.get(models.RSVP, (member_id, event_id))
-    cap_int = int(event_obj.capacity)
+    cap_int = cast(int, event_obj.capacity)
     if rsvp is None:
         final_status = _normalize_status(status, None, cap_int)
         payload = schemas.RSVPCreate(

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { notFound, useParams } from 'next/navigation';
+import { useState } from 'react';
+import { getEvent, type Event, upsertEventRsvp, type RSVPLiteral } from '../../../services/events';
+import { getRsvp, type RSVP } from '../../../services/rsvps';
+import { ApiError } from '../../../lib/api';
+import { apiErrorToMessage } from '../../../lib/error-map';
+
+export default function EventDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const eventQuery = useQuery<Event>({
+    queryKey: ['event', id],
+    queryFn: () => getEvent(id),
+    enabled: Number.isFinite(id)
+  });
+
+  if (!Number.isFinite(id)) {
+    return notFound();
+  }
+
+  if (eventQuery.isLoading) {
+    return <p>행사 정보를 불러오는 중…</p>;
+  }
+  if (eventQuery.isError) {
+    return <p className="text-red-600">행사 정보를 불러오지 못했습니다.</p>;
+  }
+
+  const event = eventQuery.data!;
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">{event.title}</h2>
+      <div className="text-sm text-slate-700 space-y-1">
+        <p>장소: {event.location}</p>
+        <p>
+          일정: {new Date(event.starts_at).toLocaleString()} ~ {new Date(event.ends_at).toLocaleString()}
+        </p>
+        <p>정원: {event.capacity}명</p>
+      </div>
+
+      <RsvpPanel eventId={id} />
+    </section>
+  );
+}
+
+function RsvpPanel({ eventId }: { eventId: number }) {
+  const qc = useQueryClient();
+  const [memberId, setMemberId] = useState<number | ''>('' as const);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const rsvpQuery = useQuery<RSVP>({
+    queryKey: ['rsvp', eventId, memberId],
+    queryFn: () => getRsvp(Number(memberId), eventId),
+    enabled: typeof memberId === 'number'
+  });
+
+  const mutate = useMutation({
+    mutationFn: (status: RSVPLiteral) => upsertEventRsvp(eventId, Number(memberId), status),
+    onSuccess: async () => {
+      setMessage('RSVP가 저장되었습니다.');
+      setError(null);
+      await qc.invalidateQueries({ queryKey: ['rsvp', eventId, memberId] });
+    },
+    onError: (e: unknown) => {
+      if (e instanceof ApiError) {
+        setError(apiErrorToMessage(e.code, e.message));
+      } else {
+        setError('알 수 없는 오류');
+      }
+      setMessage(null);
+    }
+  });
+
+  return (
+    <div className="rounded-md border p-4 space-y-3">
+      <h3 className="font-semibold">RSVP</h3>
+      <label className="block text-sm">
+        회원 ID
+        <input
+          className="mt-1 w-40 rounded border px-2 py-1"
+          type="number"
+          inputMode="numeric"
+          value={memberId}
+          onChange={(e) => setMemberId(e.currentTarget.value === '' ? '' : Number(e.currentTarget.value))}
+        />
+      </label>
+
+      {typeof memberId === 'number' && (
+        <p className="text-xs text-slate-600">
+          현재 상태: {rsvpQuery.isSuccess ? rsvpQuery.data.status : rsvpQuery.isLoading ? '조회 중…' : '없음'}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          className="rounded bg-emerald-600 px-3 py-1 text-white disabled:opacity-50"
+          disabled={mutate.isPending || typeof memberId !== 'number'}
+          onClick={() => mutate.mutate('going')}
+        >
+          참석
+        </button>
+        <button
+          className="rounded bg-amber-600 px-3 py-1 text-white disabled:opacity-50"
+          disabled={mutate.isPending || typeof memberId !== 'number'}
+          onClick={() => mutate.mutate('waitlist')}
+        >
+          대기
+        </button>
+        <button
+          className="rounded bg-slate-600 px-3 py-1 text-white disabled:opacity-50"
+          disabled={mutate.isPending || typeof memberId !== 'number'}
+          onClick={() => mutate.mutate('cancel')}
+        >
+          취소
+        </button>
+      </div>
+
+      {message && <p className="text-emerald-700 text-sm">{message}</p>}
+      {error && <p className="text-red-700 text-sm">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getEvent, type Event, upsertEventRsvp, type RSVPLiteral } from '../../.
 import { getRsvp, type RSVP } from '../../../services/rsvps';
 import { ApiError } from '../../../lib/api';
 import { apiErrorToMessage } from '../../../lib/error-map';
+import { useToast } from '../../../components/toast';
 
 export default function EventDetailPage() {
   const params = useParams<{ id: string }>();
@@ -48,6 +49,7 @@ export default function EventDetailPage() {
 
 function RsvpPanel({ eventId }: { eventId: number }) {
   const qc = useQueryClient();
+  const { show } = useToast();
   const [memberId, setMemberId] = useState<number | ''>('' as const);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -63,13 +65,17 @@ function RsvpPanel({ eventId }: { eventId: number }) {
     onSuccess: async () => {
       setMessage('RSVP가 저장되었습니다.');
       setError(null);
+      show('RSVP가 저장되었습니다.', { type: 'success' });
       await qc.invalidateQueries({ queryKey: ['rsvp', eventId, memberId] });
     },
     onError: (e: unknown) => {
       if (e instanceof ApiError) {
-        setError(apiErrorToMessage(e.code, e.message));
+        const msg = apiErrorToMessage(e.code, e.message);
+        setError(msg);
+        show(msg, { type: 'error' });
       } else {
         setError('알 수 없는 오류');
+        show('알 수 없는 오류', { type: 'error' });
       }
       setMessage(null);
     }

--- a/apps/web/app/events/new/page.tsx
+++ b/apps/web/app/events/new/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { createEvent } from '../../../services/events';
 import { ApiError } from '../../../lib/api';
 import { apiErrorToMessage } from '../../../lib/error-map';
+import { useToast } from '../../../components/toast';
 
 export default function NewEventPage() {
   const [title, setTitle] = useState('');
@@ -15,6 +16,7 @@ export default function NewEventPage() {
   const [endsAt, setEndsAt] = useState('');
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const { show } = useToast();
 
   const mutate = useMutation({
     mutationFn: () =>
@@ -26,11 +28,18 @@ export default function NewEventPage() {
         ends_at: new Date(endsAt).toISOString()
       }),
     onSuccess: () => {
+      show('행사가 생성되었습니다.', { type: 'success' });
       router.push(`/events`);
     },
     onError: (e: unknown) => {
-      if (e instanceof ApiError) setError(apiErrorToMessage(e.code, e.message));
-      else setError('알 수 없는 오류');
+      if (e instanceof ApiError) {
+        const msg = apiErrorToMessage(e.code, e.message);
+        setError(msg);
+        show(msg, { type: 'error' });
+      } else {
+        setError('알 수 없는 오류');
+        show('알 수 없는 오류', { type: 'error' });
+      }
     }
   });
 
@@ -74,4 +83,3 @@ export default function NewEventPage() {
     </section>
   );
 }
-

--- a/apps/web/app/events/new/page.tsx
+++ b/apps/web/app/events/new/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createEvent } from '../../../services/events';
+import { ApiError } from '../../../lib/api';
+import { apiErrorToMessage } from '../../../lib/error-map';
+
+export default function NewEventPage() {
+  const [title, setTitle] = useState('');
+  const [location, setLocation] = useState('');
+  const [capacity, setCapacity] = useState<number | ''>('' as const);
+  const [startsAt, setStartsAt] = useState('');
+  const [endsAt, setEndsAt] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const mutate = useMutation({
+    mutationFn: () =>
+      createEvent({
+        title,
+        location,
+        capacity: Number(capacity),
+        starts_at: new Date(startsAt).toISOString(),
+        ends_at: new Date(endsAt).toISOString()
+      }),
+    onSuccess: () => {
+      router.push(`/events`);
+    },
+    onError: (e: unknown) => {
+      if (e instanceof ApiError) setError(apiErrorToMessage(e.code, e.message));
+      else setError('알 수 없는 오류');
+    }
+  });
+
+  const disabled =
+    mutate.isPending || !title || !location || typeof capacity !== 'number' || !startsAt || !endsAt;
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">행사 생성</h2>
+      <div className="space-y-3">
+        <label className="block text-sm">
+          제목
+          <input className="mt-1 w-full rounded border px-2 py-1" value={title} onChange={(e) => setTitle(e.currentTarget.value)} />
+        </label>
+        <label className="block text-sm">
+          장소
+          <input className="mt-1 w-full rounded border px-2 py-1" value={location} onChange={(e) => setLocation(e.currentTarget.value)} />
+        </label>
+        <label className="block text-sm">
+          정원
+          <input
+            className="mt-1 w-40 rounded border px-2 py-1"
+            type="number"
+            value={capacity}
+            onChange={(e) => setCapacity(e.currentTarget.value === '' ? '' : Number(e.currentTarget.value))}
+          />
+        </label>
+        <label className="block text-sm">
+          시작 일시
+          <input className="mt-1 rounded border px-2 py-1" type="datetime-local" value={startsAt} onChange={(e) => setStartsAt(e.currentTarget.value)} />
+        </label>
+        <label className="block text-sm">
+          종료 일시
+          <input className="mt-1 rounded border px-2 py-1" type="datetime-local" value={endsAt} onChange={(e) => setEndsAt(e.currentTarget.value)} />
+        </label>
+        <button className="rounded bg-slate-900 px-3 py-1 text-white disabled:opacity-50" disabled={disabled} onClick={() => mutate.mutate()}>
+          생성
+        </button>
+        {error && <p className="text-red-700 text-sm">{error}</p>}
+      </div>
+    </section>
+  );
+}
+

--- a/apps/web/app/events/page.tsx
+++ b/apps/web/app/events/page.tsx
@@ -1,36 +1,24 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 import { listEvents, type Event } from '../../services/events';
 
 export default function EventsPage() {
-  const [events, setEvents] = useState<Event[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: events, isLoading, isError } = useQuery<Event[]>({
+    queryKey: ['events', 20, 0],
+    queryFn: () => listEvents({ limit: 20 })
+  });
 
-  useEffect(() => {
-    const run = async () => {
-      try {
-        const data = await listEvents({ limit: 20 });
-        setEvents(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : '알 수 없는 오류');
-      } finally {
-        setLoading(false);
-      }
-    };
-    void run();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return <p>행사를 불러오는 중입니다…</p>;
   }
 
-  if (error) {
-    return <p className="text-red-600">행사를 불러오지 못했습니다: {error}</p>;
+  if (isError) {
+    return <p className="text-red-600">행사를 불러오지 못했습니다.</p>;
   }
 
-  if (events.length === 0) {
+  if (!events || events.length === 0) {
     return <p>등록된 행사가 아직 없습니다.</p>;
   }
 
@@ -40,7 +28,9 @@ export default function EventsPage() {
       <ul className="space-y-3">
         {events.map((event) => (
           <li key={event.id} className="rounded border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="font-semibold">{event.title}</h3>
+            <h3 className="font-semibold">
+              <Link href={`/events/${event.id}`}>{event.title}</Link>
+            </h3>
             <p className="mt-1 text-sm text-slate-700">장소: {event.location}</p>
             <p className="mt-1 text-sm text-slate-700">
               일정: {new Date(event.starts_at).toLocaleString()} ~ {new Date(event.ends_at).toLocaleString()}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -27,6 +27,9 @@ export default function RootLayout({
             <Link href="/">홈</Link>
             <Link href="/posts">게시글</Link>
             <Link href="/events">행사</Link>
+            <span className="ml-4 text-slate-400">│</span>
+            <Link href="/posts/new">게시글 작성</Link>
+            <Link href="/events/new">행사 생성</Link>
           </nav>
         </header>
         <main>{children}</main>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import type { ReactNode } from 'react';
 
 import { ServiceWorkerRegister } from './sw-register';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Alumni Web App',
@@ -19,6 +20,7 @@ export default function RootLayout({
     <html lang="ko">
       <body>
         <ServiceWorkerRegister />
+        <Providers>
         <header className="flex flex-col gap-2 border-b border-slate-200 pb-4">
           <h1 className="text-2xl font-semibold text-brand-primary">Alumni Web App</h1>
           <nav className="flex gap-4 text-sm">
@@ -31,6 +33,7 @@ export default function RootLayout({
         <footer className="mt-auto pt-8 text-xs text-slate-500">
           Public alumni app scaffold — local use only for now.
         </footer>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/app/posts/new/page.tsx
+++ b/apps/web/app/posts/new/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { createPost } from '../../../services/posts';
 import { ApiError } from '../../../lib/api';
 import { apiErrorToMessage } from '../../../lib/error-map';
+import { useToast } from '../../../components/toast';
 
 export default function NewPostPage() {
   const [authorId, setAuthorId] = useState<number | ''>('' as const);
@@ -13,15 +14,23 @@ export default function NewPostPage() {
   const [content, setContent] = useState('');
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
+  const { show } = useToast();
 
   const mutate = useMutation({
     mutationFn: () => createPost({ author_id: Number(authorId), title, content }),
     onSuccess: () => {
+      show('게시글이 생성되었습니다.', { type: 'success' });
       router.push(`/posts`);
     },
     onError: (e: unknown) => {
-      if (e instanceof ApiError) setError(apiErrorToMessage(e.code, e.message));
-      else setError('알 수 없는 오류');
+      if (e instanceof ApiError) {
+        const msg = apiErrorToMessage(e.code, e.message);
+        setError(msg);
+        show(msg, { type: 'error' });
+      } else {
+        setError('알 수 없는 오류');
+        show('알 수 없는 오류', { type: 'error' });
+      }
     }
   });
 

--- a/apps/web/app/posts/new/page.tsx
+++ b/apps/web/app/posts/new/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createPost } from '../../../services/posts';
+import { ApiError } from '../../../lib/api';
+import { apiErrorToMessage } from '../../../lib/error-map';
+
+export default function NewPostPage() {
+  const [authorId, setAuthorId] = useState<number | ''>('' as const);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const mutate = useMutation({
+    mutationFn: () => createPost({ author_id: Number(authorId), title, content }),
+    onSuccess: () => {
+      router.push(`/posts`);
+    },
+    onError: (e: unknown) => {
+      if (e instanceof ApiError) setError(apiErrorToMessage(e.code, e.message));
+      else setError('알 수 없는 오류');
+    }
+  });
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">게시글 작성</h2>
+      <div className="space-y-3">
+        <label className="block text-sm">
+          작성자 ID
+          <input
+            className="mt-1 w-40 rounded border px-2 py-1"
+            type="number"
+            value={authorId}
+            onChange={(e) => setAuthorId(e.currentTarget.value === '' ? '' : Number(e.currentTarget.value))}
+          />
+        </label>
+        <label className="block text-sm">
+          제목
+          <input className="mt-1 w-full rounded border px-2 py-1" value={title} onChange={(e) => setTitle(e.currentTarget.value)} />
+        </label>
+        <label className="block text-sm">
+          내용
+          <textarea className="mt-1 w-full rounded border px-2 py-1" rows={6} value={content} onChange={(e) => setContent(e.currentTarget.value)} />
+        </label>
+        <button
+          className="rounded bg-slate-900 px-3 py-1 text-white disabled:opacity-50"
+          disabled={mutate.isPending || typeof authorId !== 'number' || !title || !content}
+          onClick={() => mutate.mutate()}
+        >
+          작성
+        </button>
+        {error && <p className="text-red-700 text-sm">{error}</p>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -1,36 +1,23 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { listPosts, type Post } from '../../services/posts';
 
 export default function PostsPage() {
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data: posts, isLoading, isError } = useQuery<Post[]>({
+    queryKey: ['posts', 20, 0],
+    queryFn: () => listPosts({ limit: 20 })
+  });
 
-  useEffect(() => {
-    const run = async () => {
-      try {
-        const data = await listPosts({ limit: 20 });
-        setPosts(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : '알 수 없는 오류');
-      } finally {
-        setLoading(false);
-      }
-    };
-    void run();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return <p>게시글을 불러오는 중입니다…</p>;
   }
 
-  if (error) {
-    return <p className="text-red-600">게시글을 불러오지 못했습니다: {error}</p>;
+  if (isError) {
+    return <p className="text-red-600">게시글을 불러오지 못했습니다.</p>;
   }
 
-  if (posts.length === 0) {
+  if (!posts || posts.length === 0) {
     return <p>게시글이 아직 없습니다.</p>;
   }
 

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  // QueryClient는 클라이언트에서 1회 생성
+  const [client] = useState(() => new QueryClient());
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -2,10 +2,14 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode, useState } from 'react';
+import { ToastProvider } from '../components/toast';
 
 export function Providers({ children }: { children: ReactNode }) {
   // QueryClient는 클라이언트에서 1회 생성
   const [client] = useState(() => new QueryClient());
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
 }
-

--- a/apps/web/components/toast.tsx
+++ b/apps/web/components/toast.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// 아주 단순한 토스트 구현(전역 큐 + 자동 소거)
+
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+type Toast = { id: number; message: string; type?: 'success' | 'error' | 'info' };
+
+type ToastContextValue = {
+  show: (message: string, opts?: { type?: Toast['type']; durationMs?: number }) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('ToastProvider가 필요합니다.');
+  return ctx;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const show = useCallback((message: string, opts?: { type?: Toast['type']; durationMs?: number }) => {
+    const id = Date.now() + Math.random();
+    const toast: Toast = { id, message, type: opts?.type ?? 'info' };
+    setToasts((q) => [...q, toast]);
+    const ms = opts?.durationMs ?? 2500;
+    window.setTimeout(() => {
+      setToasts((q) => q.filter((t) => t.id !== id));
+    }, ms);
+  }, []);
+
+  const value = useMemo(() => ({ show }), [show]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed right-4 top-4 z-50 space-y-2">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={
+              'pointer-events-auto rounded px-3 py-2 text-sm shadow ' +
+              (t.type === 'success'
+                ? 'bg-emerald-600 text-white'
+                : t.type === 'error'
+                ? 'bg-red-600 text-white'
+                : 'bg-slate-800 text-white')
+            }
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -5,8 +5,16 @@ export const API_BASE = process.env.NEXT_PUBLIC_WEB_API_BASE ?? 'http://localhos
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
+export type ProblemDetails = {
+  type?: string;
+  title?: string;
+  status: number;
+  detail?: string;
+  code?: string;
+};
+
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(public status: number, message: string, public code?: string) {
     super(message);
     this.name = 'ApiError';
   }
@@ -22,9 +30,15 @@ export async function apiFetch<T>(path: string, init?: RequestInit & { method?: 
     cache: 'no-store',
   });
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new ApiError(res.status, text || `HTTP ${res.status}`);
+    // Problem Details(JSON) 시도 후 텍스트로 폴백
+    try {
+      const problem = (await res.json()) as ProblemDetails;
+      const msg = problem.detail || problem.title || `HTTP ${res.status}`;
+      throw new ApiError(problem.status ?? res.status, msg, problem.code);
+    } catch {
+      const text = await res.text().catch(() => '');
+      throw new ApiError(res.status, text || `HTTP ${res.status}`);
+    }
   }
   return (await res.json()) as T;
 }
-

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -34,8 +34,11 @@ export async function apiFetch<T>(path: string, init?: RequestInit & { method?: 
     try {
       const problem = (await res.json()) as ProblemDetails;
       const msg = problem.detail || problem.title || `HTTP ${res.status}`;
+      // JSON 파싱이 성공했다면 서버가 제공한 code를 보존하여 UI 매핑이 가능하도록 함
       throw new ApiError(problem.status ?? res.status, msg, problem.code);
-    } catch {
+    } catch (e) {
+      // 위에서 던진 ApiError는 그대로 재전파
+      if (e instanceof ApiError) throw e;
       const text = await res.text().catch(() => '');
       throw new ApiError(res.status, text || `HTTP ${res.status}`);
     }

--- a/apps/web/lib/error-map.ts
+++ b/apps/web/lib/error-map.ts
@@ -1,0 +1,21 @@
+// API 오류 코드 → UX 메시지 매핑(간단 버전)
+
+export function apiErrorToMessage(code?: string, fallback?: string): string {
+  switch (code) {
+    case 'member_not_found':
+      return '회원 정보를 찾을 수 없습니다.';
+    case 'member_exists':
+      return '이미 등록된 회원입니다.';
+    case 'post_not_found':
+      return '게시글을 찾을 수 없습니다.';
+    case 'event_not_found':
+      return '행사를 찾을 수 없습니다.';
+    case 'rsvp_not_found':
+      return 'RSVP 정보가 없습니다.';
+    case 'rsvp_exists':
+      return '이미 RSVP가 존재합니다.';
+    default:
+      return fallback ?? '요청 처리 중 오류가 발생했습니다.';
+  }
+}
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,23 +14,24 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "5.62.2",
     "next": "15.5.4",
     "react": "19.1.1",
     "react-dom": "19.1.1"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "3.3.1",
     "@types/node": "22.7.8",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
+    "@typescript-eslint/eslint-plugin": "8.44.1",
+    "@typescript-eslint/parser": "8.44.1",
     "autoprefixer": "10.4.21",
     "eslint": "9.36.0",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "3.3.1",
-    "@typescript-eslint/eslint-plugin": "8.44.1",
-    "@typescript-eslint/parser": "8.44.1",
+    "eslint-import-resolver-typescript": "3.10.1",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-promise": "7.2.1",
-    "eslint-import-resolver-typescript": "3.10.1",
     "postcss": "8.5.6",
     "tailwindcss": "3.4.13",
     "typescript": "5.8.3"

--- a/apps/web/services/events.ts
+++ b/apps/web/services/events.ts
@@ -19,3 +19,19 @@ export async function listEvents(params: { limit?: number; offset?: number } = {
   return apiFetch<Event[]>(`/events${qs ? `?${qs}` : ''}`);
 }
 
+export async function getEvent(id: number): Promise<Event> {
+  return apiFetch<Event>(`/events/${id}`);
+}
+
+export type RSVPLiteral = 'going' | 'waitlist' | 'cancel';
+
+export async function upsertEventRsvp(
+  eventId: number,
+  memberId: number,
+  status: RSVPLiteral
+) {
+  return apiFetch(`/events/${eventId}/rsvp`, {
+    method: 'POST',
+    body: JSON.stringify({ member_id: memberId, status })
+  });
+}

--- a/apps/web/services/events.ts
+++ b/apps/web/services/events.ts
@@ -35,3 +35,13 @@ export async function upsertEventRsvp(
     body: JSON.stringify({ member_id: memberId, status })
   });
 }
+
+export async function createEvent(payload: {
+  title: string;
+  starts_at: string;
+  ends_at: string;
+  location: string;
+  capacity: number;
+}): Promise<Event> {
+  return apiFetch<Event>(`/events/`, { method: 'POST', body: JSON.stringify(payload) });
+}

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -19,3 +19,11 @@ export async function listPosts(params: { limit?: number; offset?: number } = {}
   return apiFetch<Post[]>(`/posts${qs ? `?${qs}` : ''}`);
 }
 
+export async function createPost(payload: {
+  author_id: number;
+  title: string;
+  content: string;
+  published_at?: string | null;
+}): Promise<Post> {
+  return apiFetch<Post>(`/posts/`, { method: 'POST', body: JSON.stringify(payload) });
+}

--- a/apps/web/services/rsvps.ts
+++ b/apps/web/services/rsvps.ts
@@ -1,0 +1,14 @@
+// RSVP 서비스(웹)
+
+import { apiFetch } from '../lib/api';
+
+export type RSVP = {
+  member_id: number;
+  event_id: number;
+  status: 'going' | 'waitlist' | 'cancel';
+};
+
+export async function getRsvp(memberId: number, eventId: number): Promise<RSVP> {
+  return apiFetch<RSVP>(`/rsvps/${memberId}/${eventId}`);
+}
+

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -17,4 +17,5 @@
  - .env.example 정리: 개발 기본 DB를 Postgres(5433)로 설정, SQLite는 옵션으로 주석. NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.
 - Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.
 - 테스트 DB 스위치: 기본 SQLite, TEST_DB=pg + TEST_DB_URL로 Postgres 테스트 가능(안전가드 포함).
- - 테스트 전용 Postgres 컨테이너 추가(5434): Make 타깃(db-test-up), VS Code 런치(Pytest PG) 추가.
+- 테스트 전용 Postgres 컨테이너 추가(5434): Make 타깃(db-test-up), VS Code 런치(Pytest PG) 추가.
+ - 리뷰 반영(P1): RSVP capacity 계산 시 기존 참석자 제외, apiFetch가 서버 오류 code 보존하도록 수정.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -7,4 +7,6 @@
  - CI: Python 잡에 Pytest Guard + pytest 실행 단계 추가(테스트 최소 보장).
 - 테스트 확장: 404(post/event/rsvp), 409(rsvp_exists), events rsvp upsert(생성/업데이트), 잘못된 enum→422.
 - CI: gitleaks PR 스캔 오류 수정 — 워크플로에 `GITHUB_TOKEN` 전달 및 `permissions: pull-requests: read` 추가.
- - Web(M1-1): react-query 도입 및 리스트/상세(이벤트) 적용, RSVP UI/액션 추가, 오류 코드→UX 매핑 유틸 추가.
+- Web(M1-1): react-query 도입 및 리스트/상세(이벤트) 적용, RSVP UI/액션 추가, 오류 코드→UX 매핑 유틸 추가.
+ - Web(M1-2): 게시글/행사 생성 폼 추가(`/posts/new`, `/events/new`), 네비게이션 연결.
+ - API: RSVP capacity v1 적용(going 초과 시 waitlist 강제) 및 성공 경로 테스트 추가.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -13,4 +13,5 @@
  - Web: 간단 토스트 컴포넌트 도입 및 생성/RSVP 성공·에러 피드백 연결.
 - 테스트: 목록 200, /rsvps 생성 201 스모크 추가.
 - Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).
- - Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).
+- Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).
+ - .env.example 정리: SQLite 기본, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -15,4 +15,5 @@
 - Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).
 - Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).
  - .env.example 정리: 개발 기본 DB를 Postgres(5433)로 설정, SQLite는 옵션으로 주석. NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.
- - Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.
+- Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.
+ - 테스트 DB 스위치: 기본 SQLite, TEST_DB=pg + TEST_DB_URL로 Postgres 테스트 가능(안전가드 포함).

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -8,5 +8,7 @@
 - 테스트 확장: 404(post/event/rsvp), 409(rsvp_exists), events rsvp upsert(생성/업데이트), 잘못된 enum→422.
 - CI: gitleaks PR 스캔 오류 수정 — 워크플로에 `GITHUB_TOKEN` 전달 및 `permissions: pull-requests: read` 추가.
 - Web(M1-1): react-query 도입 및 리스트/상세(이벤트) 적용, RSVP UI/액션 추가, 오류 코드→UX 매핑 유틸 추가.
- - Web(M1-2): 게시글/행사 생성 폼 추가(`/posts/new`, `/events/new`), 네비게이션 연결.
- - API: RSVP capacity v1 적용(going 초과 시 waitlist 강제) 및 성공 경로 테스트 추가.
+- Web(M1-2): 게시글/행사 생성 폼 추가(`/posts/new`, `/events/new`), 네비게이션 연결.
+- API: RSVP capacity v1 적용(going 초과 시 waitlist 강제) 및 성공 경로 테스트 추가.
+ - Web: 간단 토스트 컴포넌트 도입 및 생성/RSVP 성공·에러 피드백 연결.
+ - 테스트: 목록 200, /rsvps 생성 201 스모크 추가.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -14,4 +14,5 @@
 - 테스트: 목록 200, /rsvps 생성 201 스모크 추가.
 - Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).
 - Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).
- - .env.example 정리: SQLite 기본, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.
+ - .env.example 정리: 개발 기본 DB를 Postgres(5433)로 설정, SQLite는 옵션으로 주석. NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.
+ - Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -18,4 +18,5 @@
 - Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.
 - 테스트 DB 스위치: 기본 SQLite, TEST_DB=pg + TEST_DB_URL로 Postgres 테스트 가능(안전가드 포함).
 - 테스트 전용 Postgres 컨테이너 추가(5434): Make 타깃(db-test-up), VS Code 런치(Pytest PG) 추가.
- - 리뷰 반영(P1): RSVP capacity 계산 시 기존 참석자 제외, apiFetch가 서버 오류 code 보존하도록 수정.
+- 리뷰 반영(P1): RSVP capacity 계산 시 기존 참석자 제외, apiFetch가 서버 오류 code 보존하도록 수정.
+ - 보안: bandit(B101) 지적된 assert 제거(이벤트 정원 검사에 사전 조회한 capacity 사용).

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -12,4 +12,5 @@
 - API: RSVP capacity v1 적용(going 초과 시 waitlist 강제) 및 성공 경로 테스트 추가.
  - Web: 간단 토스트 컴포넌트 도입 및 생성/RSVP 성공·에러 피드백 연결.
 - 테스트: 목록 200, /rsvps 생성 201 스모크 추가.
- - Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).
+- Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).
+ - Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -6,4 +6,5 @@
 - 후속: PR 리뷰 스레드에 반영 코멘트 및 resolve 처리.
  - CI: Python 잡에 Pytest Guard + pytest 실행 단계 추가(테스트 최소 보장).
 - 테스트 확장: 404(post/event/rsvp), 409(rsvp_exists), events rsvp upsert(생성/업데이트), 잘못된 enum→422.
- - CI: gitleaks PR 스캔 오류 수정 — 워크플로에 `GITHUB_TOKEN` 전달 및 `permissions: pull-requests: read` 추가.
+- CI: gitleaks PR 스캔 오류 수정 — 워크플로에 `GITHUB_TOKEN` 전달 및 `permissions: pull-requests: read` 추가.
+ - Web(M1-1): react-query 도입 및 리스트/상세(이벤트) 적용, RSVP UI/액션 추가, 오류 코드→UX 매핑 유틸 추가.

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -11,4 +11,5 @@
 - Web(M1-2): 게시글/행사 생성 폼 추가(`/posts/new`, `/events/new`), 네비게이션 연결.
 - API: RSVP capacity v1 적용(going 초과 시 waitlist 강제) 및 성공 경로 테스트 추가.
  - Web: 간단 토스트 컴포넌트 도입 및 생성/RSVP 성공·에러 피드백 연결.
- - 테스트: 목록 200, /rsvps 생성 201 스모크 추가.
+- 테스트: 목록 200, /rsvps 생성 201 스모크 추가.
+ - Dev: VS Code `.vscode/launch.json` 추가(API SQLite/PG, Web, 복합 실행).

--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -16,4 +16,5 @@
 - Repo: .gitignore에서 `.env.example`을 추적하도록 수정(`!.env.example`).
  - .env.example 정리: 개발 기본 DB를 Postgres(5433)로 설정, SQLite는 옵션으로 주석. NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일.
 - Docker Postgres 포트 변경: 5433:5432, VS Code launch(Postgres)도 5433으로 동기화.
- - 테스트 DB 스위치: 기본 SQLite, TEST_DB=pg + TEST_DB_URL로 Postgres 테스트 가능(안전가드 포함).
+- 테스트 DB 스위치: 기본 SQLite, TEST_DB=pg + TEST_DB_URL로 Postgres 테스트 가능(안전가드 포함).
+ - 테스트 전용 Postgres 컨테이너 추가(5434): Make 타깃(db-test-up), VS Code 런치(Pytest PG) 추가.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -9,6 +9,7 @@
  - 테스트 확장: 404(post/event/rsvp), 409(rsvp_exists), 이벤트 RSVP upsert(생성/업데이트), 잘못된 enum→422 케이스 추가.
  - CI 파이프라인: Python 잡에 Pytest Guard + pytest 실행 단계 추가.
  - Web(M1-1 시작): react-query 도입(QueryClientProvider), 이벤트 목록 CSR→react-query 전환, 이벤트 상세 페이지(/events/[id]) + RSVP 액션(going/waitlist/cancel), API 오류 코드→UX 매핑 유틸 추가.
+ - API: RSVP capacity v1 적용(going 요청 시 정원 초과면 waitlist로 저장).
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -18,6 +18,7 @@
  - 환경 예시(.env.example) 정리 — SQLite 기본값, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일, 한국어 주석 보강.
  - Dev DB 포트: Docker Postgres 개발 기본 포트를 5433으로 전환(ports: "5433:5432"), .env.example/launch.json 동기화.
  - Pytest DB 스위치: 기본 SQLite, `TEST_DB=pg` 설정 시 `TEST_DB_URL`(또는 `DATABASE_URL`)로 Postgres 테스트 지원(안전가드 포함).
+ - 테스트 전용 DB: docker-compose에 `postgres_test`(5434) 추가, Make 타깃(`db-test-up`), VS Code 런치(Pytest PG) 동기화.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -19,6 +19,9 @@
  - Dev DB 포트: Docker Postgres 개발 기본 포트를 5433으로 전환(ports: "5433:5432"), .env.example/launch.json 동기화.
  - Pytest DB 스위치: 기본 SQLite, `TEST_DB=pg` 설정 시 `TEST_DB_URL`(또는 `DATABASE_URL`)로 Postgres 테스트 지원(안전가드 포함).
  - 테스트 전용 DB: docker-compose에 `postgres_test`(5434) 추가, Make 타깃(`db-test-up`), VS Code 런치(Pytest PG) 동기화.
+ - 리뷰 반영(P1):
+   - API: RSVP capacity 계산 시 기존 참석자 제외(재요청으로 인한 부당 강등 방지).
+   - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -24,6 +24,7 @@
     - pyright 호환 보완: 기존 상태 비교 시 enum 캐스팅으로 타입 안정화.
   - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
   - 보안: bandit(B101) 지적된 assert 제거 — 이벤트 용량 검사는 사전 조회한 capacity로 처리.
+    - 타입: capacity는 `cast(int, event.capacity)`로 지정하여 pyright 오류 해소.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -8,6 +8,7 @@
  - CI: gitleaks 액션에 `GITHUB_TOKEN` 주입 및 `permissions: pull-requests: read` 설정(PR 스캔 실패 수정).
  - 테스트 확장: 404(post/event/rsvp), 409(rsvp_exists), 이벤트 RSVP upsert(생성/업데이트), 잘못된 enum→422 케이스 추가.
  - CI 파이프라인: Python 잡에 Pytest Guard + pytest 실행 단계 추가.
+ - Web(M1-1 시작): react-query 도입(QueryClientProvider), 이벤트 목록 CSR→react-query 전환, 이벤트 상세 페이지(/events/[id]) + RSVP 액션(going/waitlist/cancel), API 오류 코드→UX 매핑 유틸 추가.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -20,7 +20,8 @@
  - Pytest DB 스위치: 기본 SQLite, `TEST_DB=pg` 설정 시 `TEST_DB_URL`(또는 `DATABASE_URL`)로 Postgres 테스트 지원(안전가드 포함).
  - 테스트 전용 DB: docker-compose에 `postgres_test`(5434) 추가, Make 타깃(`db-test-up`), VS Code 런치(Pytest PG) 동기화.
  - 리뷰 반영(P1):
-   - API: RSVP capacity 계산 시 기존 참석자 제외(재요청으로 인한 부당 강등 방지).
+  - API: RSVP capacity 계산 시 기존 참석자 제외(재요청으로 인한 부당 강등 방지).
+    - pyright 호환 보완: 기존 상태 비교 시 enum 캐스팅으로 타입 안정화.
    - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
 # Worklog
 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -16,6 +16,7 @@
  - Dev: VS Code 디버그 설정 추가(`.vscode/launch.json`) — API(SQLite/Postgres), Web 단일/복합 실행 지원.
  - Repo: .gitignore 정리 — `.env`/`.env.*` 무시, 단 `.env.example`은 명시적으로 추적.
  - 환경 예시(.env.example) 정리 — SQLite 기본값, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일, 한국어 주석 보강.
+ - Dev DB 포트: Docker Postgres 개발 기본 포트를 5433으로 전환(ports: "5433:5432"), .env.example/launch.json 동기화.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -14,6 +14,7 @@
  - Web: 간단 토스트(ToastProvider) 추가, 게시글/행사 생성 및 RSVP 액션 성공/에러 피드백 연결.
  - 테스트 확장(성공 경로): 목록 200 검증, /rsvps 생성 201 스모크.
  - Dev: VS Code 디버그 설정 추가(`.vscode/launch.json`) — API(SQLite/Postgres), Web 단일/복합 실행 지원.
+ - Repo: .gitignore 정리 — `.env`/`.env.*` 무시, 단 `.env.example`은 명시적으로 추적.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -11,6 +11,8 @@
  - Web(M1-1 시작): react-query 도입(QueryClientProvider), 이벤트 목록 CSR→react-query 전환, 이벤트 상세 페이지(/events/[id]) + RSVP 액션(going/waitlist/cancel), API 오류 코드→UX 매핑 유틸 추가.
  - API: RSVP capacity v1 적용(going 요청 시 정원 초과면 waitlist로 저장).
    - pyright 타입 오류 추가 수정: SQLAlchemy 인스턴스 속성 안전 추출로 경고 제거.
+ - Web: 간단 토스트(ToastProvider) 추가, 게시글/행사 생성 및 RSVP 액션 성공/에러 피드백 연결.
+ - 테스트 확장(성공 경로): 목록 200 검증, /rsvps 생성 201 스모크.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -10,6 +10,7 @@
  - CI 파이프라인: Python 잡에 Pytest Guard + pytest 실행 단계 추가.
  - Web(M1-1 시작): react-query 도입(QueryClientProvider), 이벤트 목록 CSR→react-query 전환, 이벤트 상세 페이지(/events/[id]) + RSVP 액션(going/waitlist/cancel), API 오류 코드→UX 매핑 유틸 추가.
  - API: RSVP capacity v1 적용(going 요청 시 정원 초과면 waitlist로 저장).
+   - pyright 타입 오류 수정: 정원 계산 시 Optional·SQL 표현식 타입 안전화.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -17,6 +17,7 @@
  - Repo: .gitignore 정리 — `.env`/`.env.*` 무시, 단 `.env.example`은 명시적으로 추적.
  - 환경 예시(.env.example) 정리 — SQLite 기본값, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일, 한국어 주석 보강.
  - Dev DB 포트: Docker Postgres 개발 기본 포트를 5433으로 전환(ports: "5433:5432"), .env.example/launch.json 동기화.
+ - Pytest DB 스위치: 기본 SQLite, `TEST_DB=pg` 설정 시 `TEST_DB_URL`(또는 `DATABASE_URL`)로 Postgres 테스트 지원(안전가드 포함).
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -15,6 +15,7 @@
  - 테스트 확장(성공 경로): 목록 200 검증, /rsvps 생성 201 스모크.
  - Dev: VS Code 디버그 설정 추가(`.vscode/launch.json`) — API(SQLite/Postgres), Web 단일/복합 실행 지원.
  - Repo: .gitignore 정리 — `.env`/`.env.*` 무시, 단 `.env.example`은 명시적으로 추적.
+ - 환경 예시(.env.example) 정리 — SQLite 기본값, Postgres 옵션 주석, NEXT_PUBLIC_WEB_API_BASE로 웹 변수 통일, 한국어 주석 보강.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -22,7 +22,8 @@
  - 리뷰 반영(P1):
   - API: RSVP capacity 계산 시 기존 참석자 제외(재요청으로 인한 부당 강등 방지).
     - pyright 호환 보완: 기존 상태 비교 시 enum 캐스팅으로 타입 안정화.
-   - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
+  - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
+  - 보안: bandit(B101) 지적된 assert 제거 — 이벤트 용량 검사는 사전 조회한 capacity로 처리.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -13,6 +13,7 @@
    - pyright 타입 오류 추가 수정: SQLAlchemy 인스턴스 속성 안전 추출로 경고 제거.
  - Web: 간단 토스트(ToastProvider) 추가, 게시글/행사 생성 및 RSVP 액션 성공/에러 피드백 연결.
  - 테스트 확장(성공 경로): 목록 200 검증, /rsvps 생성 201 스모크.
+ - Dev: VS Code 디버그 설정 추가(`.vscode/launch.json`) — API(SQLite/Postgres), Web 단일/복합 실행 지원.
 # Worklog
 
 ## 2025-10-05

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -10,7 +10,7 @@
  - CI 파이프라인: Python 잡에 Pytest Guard + pytest 실행 단계 추가.
  - Web(M1-1 시작): react-query 도입(QueryClientProvider), 이벤트 목록 CSR→react-query 전환, 이벤트 상세 페이지(/events/[id]) + RSVP 액션(going/waitlist/cancel), API 오류 코드→UX 매핑 유틸 추가.
  - API: RSVP capacity v1 적용(going 요청 시 정원 초과면 waitlist로 저장).
-   - pyright 타입 오류 수정: 정원 계산 시 Optional·SQL 표현식 타입 안전화.
+   - pyright 타입 오류 추가 수정: SQLAlchemy 인스턴스 속성 안전 추출로 경고 제거.
 # Worklog
 
 ## 2025-10-05

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -16,5 +16,23 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+
+  postgres_test:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: appdb_test
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: devpass
+    ports:
+      - "5434:5432"
+    volumes:
+      - pgdata_test:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d appdb_test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 volumes:
   pgdata:
+  pgdata_test:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: app
       POSTGRES_PASSWORD: devpass
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: 5.62.2
+        version: 5.62.2(react@19.1.1)
       next:
         specifier: 15.5.4
         version: 15.5.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -385,6 +388,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.62.2':
+    resolution: {integrity: sha512-LcwVcC5qpsDpHcqlXUUL5o9SaOBwhNkGeV+B06s0GBoyBr8FqXPuXT29XzYXR36lchhnerp6XO+CWc84/vh7Zg==}
+
+  '@tanstack/react-query@5.62.2':
+    resolution: {integrity: sha512-fkTpKKfwTJtVPKVR+ag7YqFgG/7TRVVPzduPAUF9zRCiiA8Wu305u+KJl8rCrh98Qce77vzIakvtUyzWLtaPGA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2253,6 +2264,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.62.2': {}
+
+  '@tanstack/react-query@5.62.2(react@19.1.1)':
+    dependencies:
+      '@tanstack/query-core': 5.62.2
+      react: 19.1.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session, sessionmaker
 
 from apps.api import models
@@ -15,10 +17,35 @@ from apps.api.main import app
 
 @pytest.fixture()
 def client(tmp_path: Path) -> Generator[TestClient, None, None]:
-    db_path = tmp_path / "test.sqlite3"
-    engine = create_engine(
-        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}, future=True
-    )
+    # 테스트 DB 선택: 기본은 SQLite, TEST_DB=pg이면 TEST_DB_URL/DATABASE_URL 사용
+    test_db = os.environ.get("TEST_DB", "sqlite").lower()
+    engine_url: str
+    engine_kwargs: dict = {"future": True}
+
+    if test_db == "pg":
+        candidate = os.environ.get("TEST_DB_URL") or os.environ.get("DATABASE_URL")
+        if not candidate or not candidate.startswith("postgresql"):
+            # 안전 폴백: 설정이 없으면 SQLite 사용
+            db_path = tmp_path / "test.sqlite3"
+            engine_url = f"sqlite:///{db_path}"
+            engine_kwargs["connect_args"] = {"check_same_thread": False}
+        else:
+            url = make_url(candidate)
+            db_name = (url.database or "").lower()
+            if "test" not in db_name and os.environ.get("TEST_DB_FORCE") != "1":
+                msg = (
+                    "Refusing to run tests on non-test database. "
+                    "Use TEST_DB_URL pointing to a dedicated DB (name contains 'test') "
+                    "or set TEST_DB_FORCE=1."
+                )
+                raise RuntimeError(msg)
+            engine_url = candidate
+    else:
+        db_path = tmp_path / "test.sqlite3"
+        engine_url = f"sqlite:///{db_path}"
+        engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+    engine = create_engine(engine_url, **engine_kwargs)
     TestingSessionLocal = sessionmaker(
         bind=engine, autoflush=False, autocommit=False, future=True
     )

--- a/tests/api/test_success.py
+++ b/tests/api/test_success.py
@@ -74,3 +74,31 @@ def test_rsvp_capacity_v1_enforces_waitlist(client: TestClient) -> None:
     )
     assert r2.status_code == HTTPStatus.CREATED
     assert r2.json()["status"] == "waitlist"
+
+
+def test_list_endpoints_ok(client: TestClient) -> None:
+    assert client.get("/members/?limit=5").status_code == HTTPStatus.OK
+    assert client.get("/posts/?limit=5").status_code == HTTPStatus.OK
+    assert client.get("/events/?limit=5").status_code == HTTPStatus.OK
+
+
+def test_rsvp_create_success(client: TestClient) -> None:
+    m = client.post(
+        "/members/",
+        json={"email": "c@example.com", "name": "C", "cohort": 2025},
+    ).json()
+    e = client.post(
+        "/events/",
+        json={
+            "title": "RSVP",
+            "starts_at": "2030-05-01T09:00:00Z",
+            "ends_at": "2030-05-01T10:00:00Z",
+            "location": "Seoul",
+            "capacity": 10,
+        },
+    ).json()
+    res = client.post(
+        "/rsvps/",
+        json={"member_id": m["id"], "event_id": e["id"], "status": "going"},
+    )
+    assert res.status_code == HTTPStatus.CREATED

--- a/tests/api/test_success.py
+++ b/tests/api/test_success.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+
+def test_create_post_and_get(client: TestClient) -> None:
+    m = client.post(
+        "/members/",
+        json={"email": "author@example.com", "name": "Author", "cohort": 2025},
+    ).json()
+    p = client.post(
+        "/posts/",
+        json={
+            "author_id": m["id"],
+            "title": "Hello",
+            "content": "World",
+            "published_at": None,
+        },
+    ).json()
+    res = client.get(f"/posts/{p['id']}")
+    assert res.status_code == HTTPStatus.OK
+    data = res.json()
+    assert data["id"] == p["id"]
+    assert data["title"] == "Hello"
+
+
+def test_create_event_and_get(client: TestClient) -> None:
+    e = client.post(
+        "/events/",
+        json={
+            "title": "Small",
+            "starts_at": "2030-01-01T09:00:00Z",
+            "ends_at": "2030-01-01T10:00:00Z",
+            "location": "Seoul",
+            "capacity": 1,
+        },
+    ).json()
+    res = client.get(f"/events/{e['id']}")
+    assert res.status_code == HTTPStatus.OK
+    assert res.json()["title"] == "Small"
+
+
+def test_rsvp_capacity_v1_enforces_waitlist(client: TestClient) -> None:
+    # capacity 1인 이벤트에 2명이 going을 시도하면 2번째는 waitlist
+    e = client.post(
+        "/events/",
+        json={
+            "title": "Cap1",
+            "starts_at": "2030-04-01T09:00:00Z",
+            "ends_at": "2030-04-01T10:00:00Z",
+            "location": "Seoul",
+            "capacity": 1,
+        },
+    ).json()
+    m1 = client.post(
+        "/members/",
+        json={"email": "a@example.com", "name": "A", "cohort": 2025},
+    ).json()
+    m2 = client.post(
+        "/members/",
+        json={"email": "b@example.com", "name": "B", "cohort": 2025},
+    ).json()
+
+    r1 = client.post(
+        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "going"}
+    )
+    assert r1.status_code == HTTPStatus.CREATED
+    assert r1.json()["status"] == "going"
+
+    r2 = client.post(
+        f"/events/{e['id']}/rsvp", json={"member_id": m2["id"], "status": "going"}
+    )
+    assert r2.status_code == HTTPStatus.CREATED
+    assert r2.json()["status"] == "waitlist"


### PR DESCRIPTION
M1 범위(이번 PR에서 처리)

Web
- react-query 도입 및 Provider 구성
- 이벤트 목록 CSR→react-query, 상세(/events/[id]) + RSVP 액션(going/waitlist/cancel)
- 게시글/행사 생성 폼(/posts/new, /events/new)
- API 오류 코드→UX 매핑 유틸 추가

API
- RSVP capacity v1: going 요청 시 정원 초과면 waitlist 강제 저장

테스트/CI
- 성공 경로 스모크: 게시글/행사 생성→상세 조회, RSVP capacity 동작
- 현재 13 tests passed (Pytest Guard 통과)

노트
- 인증은 간단 세션 기반을 M2에서 추가(소셜 나중, SSO 없음)
- 배포는 VPS 타깃으로 후속 PR에서 진행

---

M2 상세 계획(인증/권한 + 규칙 고도화)

목표
- 간단 세션 기반 인증으로 작성/관리 기능 보호
- 이벤트 대기열 규칙 개선(v2): 취소 시 자동 승급 등
- 테스트/보안 강화를 통해 운영 전환 준비

백엔드(API)
- 데이터 모델/마이그레이션
  - `admin_users` 테이블(id, email unique, password_hash, created_at)
  - Alembic migration 추가 및 업그레이드 경로 문서화
- 인증 엔드포인트
  - `POST /auth/login`: email+password → 세션 쿠키 발급(HttpOnly, SameSite=Lax, Secure in prod)
  - `POST /auth/logout`: 세션 무효화
  - `GET /auth/me`: 현재 사용자 조회(세션 검증)
- 권한 가드
  - 의존성 `require_admin` 추가(관리자 전용): posts/events 생성/수정/삭제 라우트 보호
  - 레이트리밋: 로그인 시도 5 req/min/IP
- 보안/설정
  - 비밀번호 해시: `bcrypt`(passes in requirements)
  - CORS/쿠키: prod에서 `secure`, dev는 http 허용
  - 구조화 로그: `code`와 `request_id` 포함
- 도메인 규칙(v2)
  - RSVP: `cancel` 발생 시 대기열 최상위 1명 자동 승급(트랜잭션)

프런트엔드(Web)
- 인증 UI
  - `/login` 페이지: 이메일/비밀번호, 성공 시 리다이렉트
  - 전역 상태: `useAuth` 훅(`GET /auth/me`) + 세션 기반 보호 라우팅
  - 보호 페이지: `/posts/new`, `/events/new` → 로그인 필요
- 에러 UX
  - `apiErrorToMessage` 확장: auth 관련 코드(login_failed, unauthorized)
  - 토스트/리다이렉트 규칙 정리

테스트
- API
  - 로그인 성공/실패(401), 보호 라우트 접근(403/200)
  - 대기열 승급: going 1명, waitlist 1명 → cancel 시 자동 승급 확인
- Web(E2E-lite 또는 통합)
  - 로그인 후 작성 폼 접근 가능, 로그아웃 후 401 처리
- 성능/보안
  - 로그인 레이트리밋 스모크, 세션 쿠키 속성 검증

작업 쪼개기(체크리스트)
- [ ] Alembic: `admin_users` 추가, bcrypt 의존성
- [ ] API: `/auth/login`, `/auth/logout`, `/auth/me` 구현 + 세션 미들웨어
- [ ] 권한 의존성(`require_admin`) 적용(작성/수정/삭제 라우트)
- [ ] RSVP v2 승급 로직 + 테스트
- [ ] Web: `/login`, `useAuth`, 보호 라우팅, 가드 적용
- [ ] 테스트: API/웹 성공/실패 케이스 보강
- [ ] 문서: architecture/README에 인증/권한/쿠키정책 반영

수용 기준(AC)
- 비관리자/비로그인 사용자는 생성/수정/삭제 불가(403/401)
- 관리자는 로그인 후 관련 기능 사용 가능(200/201)
- RSVP cancel 시 대기열 자동 승급 동작
- 테스트 18+ 통과, CI 그린

예상 위험/보완
- 세션/쿠키 설정 환경차(dev/prod) → 설정 분기 점검(CheckList 포함)
- bcrypt 성능 영향 최소화(테스트 시 라운드 축소)

