### PR TITLE
feat(api,web,docs): M3 Web Push 스캐폴드 착수 (Draft)

### DIFF
--- a/docs/dev_log_251006.md
+++ b/docs/dev_log_251006.md
@@ -26,3 +26,8 @@
 - 문서: 실행 계획(로드맵) 문서 추가(docs/execution_plan_251006.md).
 - 마무리: /auth 로그인 레이트리밋(5/min) 추가, RSVP v2 승급 회귀 테스트, import 정리.
  - 웹 빌드: /login에서 useSearchParams를 Suspense로 감싸 Next 빌드 에러 해결.
+
+## M3 시작
+- 브랜치 `feat/m3-webpush` 생성.
+- `docs/m3_plan.md` 초안 추가(스코프/DoD/체크리스트/보안 노트).
+- 실행 계획(docs/execution_plan_251006.md)에 M3 진행 상태 표기.

--- a/docs/execution_plan_251006.md
+++ b/docs/execution_plan_251006.md
@@ -46,7 +46,7 @@
   - [x] bandit B101 제거(unsafe assert 미사용)
 - 완료 기준: 관리자 로그인 후에만 생성 가능, 대기열 승급 동작, 20+ 테스트, CI 그린
 
-### M3: PWA/Web Push 채널
+### M3: PWA/Web Push 채널 — 진행 시작(`feat/m3-webpush` 브랜치, docs/m3_plan.md)
 - API: 구독 저장/삭제/테스트 발송(pywebpush+VAPID), 404/410 자동 폐기
 - DB: push_subscription/notification_preference 테이블
 - Web: 권한 온보딩 CTA, subscribe/unsubscribe, SW push/notificationclick
@@ -72,4 +72,3 @@
 - SSOT: `docs/architecture.md`, `docs/agents_base.md`
 - 계획서: `docs/m1_plan.md`, `docs/m2_plan.md`
 - 관련 PR: M1(#2), M2(#3)
-

--- a/docs/m3_plan.md
+++ b/docs/m3_plan.md
@@ -1,0 +1,40 @@
+# M3 계획(Web Push)
+
+## 목표
+- Web Push 구독 저장/해지 API와 테스트 발송(Admin 전용) 구현
+- 프런트에서 구독/해지 흐름 및 SW 푸시 핸들링 추가
+- 민감정보/레이트리밋 최소 가드 적용
+
+## 범위(스코프)
+- API
+  - `POST /notifications/subscriptions` 구독 저장(중복 엔드포인트 idempotent)
+  - `DELETE /notifications/subscriptions` 구독 삭제(또는 revoke)
+  - `POST /admin/notifications/test` 관리자 전용 테스트 발송
+- DB
+  - `push_subscription` 테이블(엔드포인트 unique, p256dh, auth, ua, created_at, last_seen_at, revoked_at)
+  - (선택) `notification_preference` 초안
+- Web
+  - `public/sw.js` push/notificationclick 핸들러
+  - `app/sw-register.tsx` 구독/해지 + API 연동
+  - 로그인 후 CTA로 노출
+- 보안/운영
+  - 404/410 시 구독 자동 폐기
+  - Admin 테스트 발송 레이트리밋(예: 1/min/IP)
+
+## 완료 기준(DoD)
+- 개발환경에서 구독/해지/테스트 발송이 동작
+- 죽은 구독(404/410) 자동 정리
+- 테스트 6+ 추가(API 구독/해지/중복/어드민 발송 경로)
+- CI 그린
+
+## 작업 순서(체크리스트)
+- [ ] DB 마이그레이션 2건 추가(0004, 0005)
+- [ ] API 라우터 `notifications.py` 추가 및 권한 가드
+- [ ] pywebpush 연동(개발키; prod는 Secret Manager 상정)
+- [ ] Web SW/구독 모듈 추가 및 연결
+- [ ] 테스트: `tests/api/test_notifications.py`
+- [ ] 문서: `docs/architecture.md`, `docs/execution_plan_251006.md` 갱신
+
+## 참고
+- VAPID 공개키는 `NEXT_PUBLIC_VAPID_PUBLIC_KEY` 사용(.env.example에 추가)
+

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -42,12 +42,14 @@
  - Dev DB 포트: Docker Postgres 개발 기본 포트를 5433으로 전환(ports: "5433:5432"), .env.example/launch.json 동기화.
  - Pytest DB 스위치: 기본 SQLite, `TEST_DB=pg` 설정 시 `TEST_DB_URL`(또는 `DATABASE_URL`)로 Postgres 테스트 지원(안전가드 포함).
  - 테스트 전용 DB: docker-compose에 `postgres_test`(5434) 추가, Make 타깃(`db-test-up`), VS Code 런치(Pytest PG) 동기화.
- - 리뷰 반영(P1):
+- 리뷰 반영(P1):
   - API: RSVP capacity 계산 시 기존 참석자 제외(재요청으로 인한 부당 강등 방지).
     - pyright 호환 보완: 기존 상태 비교 시 enum 캐스팅으로 타입 안정화.
   - Web: apiFetch에서 Problem Details code를 보존(에러 코드→UX 매핑 동작 보장).
   - 보안: bandit(B101) 지적된 assert 제거 — 이벤트 용량 검사는 사전 조회한 capacity로 처리.
     - 타입: capacity는 `cast(int, event.capacity)`로 지정하여 pyright 오류 해소.
+
+- M3 착수: 브랜치 `feat/m3-webpush` 생성, `docs/m3_plan.md` 추가, 실행 계획 문서에 진행상태 반영.
 # Worklog
 
 ## 2025-10-05


### PR DESCRIPTION
## Summary
- M3(Web Push) 작업을 시작합니다. 스캐폴드와 계획서를 포함한 드래프트 PR 입니다.

## Scope (현재)
- docs: `docs/m3_plan.md` 추가, `docs/execution_plan_251006.md`에 M3 진행 상태 반영, dev_log/worklog 갱신.
- api(models/migrations): `push_subscriptions`, `notification_preferences` 모델 및 Alembic 마이그레이션(0004/0005) 추가.
- api(router): `apps/api/routers/notifications.py` 초안(구독 저장/삭제, 관리자 테스트 발송 stub) + `apps/api/main.py` include.
- 품질: ruff/pyright/pytest 훅 통과 (로컬 17 tests ok).

## Next (to complete in this PR)
- [ ] pywebpush 연동 + VAPID 키 처리(.env.example 가이드 포함)
- [ ] 404/410 응답 시 구독 자동 폐기
- [ ] API 테스트 추가: `tests/api/test_notifications.py` (구독/중복/삭제/idempotent/관리자 발송)
- [ ] Web: `public/sw.js` push/notificationclick, `app/sw-register.tsx` 구독/해지 + API 연동, 로그인 후 CTA
- [ ] Docs: `docs/architecture.md` Web Push 섹션 보강

## How to run (local)
1) `make venv && make api-install`
2) 마이그레이션: `alembic -c apps/api/alembic.ini upgrade head`
3) API: `make api-dev` (기본 포트 3001)
4) Web: `make web-dev` (기본 포트 3000)
5) 환경: `.env.example` 참고 (VAPID_PUBLIC_KEY/PRIVATE_KEY, SUBJECT 추가)

## Notes
- 현재 발송 엔드포인트(`/admin/notifications/test`)는 202 + {accepted:0} stub입니다. 후속 커밋에서 실제 발송/에러 핸들링/레이트리밋을 추가합니다.
- SQLAlchemy 클래식 매핑과 pyright 호환을 위해 라우터 갱신 시 `setattr` 사용.

참고 문서: `docs/m3_plan.md`, `docs/execution_plan_251006.md`