### PR TITLE
docs(m3): Push Polish 계획 — 운영 마감(문서/테스트/UI 보강)

### DIFF
--- a/apps/api/migrations/versions/0012_member_post_extra_fields.py
+++ b/apps/api/migrations/versions/0012_member_post_extra_fields.py
@@ -1,0 +1,62 @@
+"""add member/post extra fields
+
+Revision ID: 0012_member_post_extra_fields
+Revises: 0011_support_tickets
+Create Date: 2025-10-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0012_member_post_extra_fields"
+down_revision = "0011_support_tickets"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Member profile enrichment fields
+    op.add_column("members", sa.Column("company", sa.String(length=255), nullable=True))
+    op.add_column("members", sa.Column("department", sa.String(length=255), nullable=True))
+    op.add_column("members", sa.Column("job_title", sa.String(length=255), nullable=True))
+    op.add_column("members", sa.Column("company_phone", sa.String(length=64), nullable=True))
+    op.add_column("members", sa.Column("addr_personal", sa.String(length=255), nullable=True))
+    op.add_column("members", sa.Column("addr_company", sa.String(length=255), nullable=True))
+    op.add_column("members", sa.Column("industry", sa.String(length=255), nullable=True))
+
+    # Post metadata (category / pin / cover)
+    op.add_column("posts", sa.Column("category", sa.String(length=64), nullable=True))
+    op.add_column(
+        "posts",
+        sa.Column(
+            "pinned",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column("posts", sa.Column("cover_image", sa.String(length=512), nullable=True))
+
+    op.create_index("ix_posts_category", "posts", ["category"])
+    op.create_index("ix_posts_pinned", "posts", ["pinned"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_posts_pinned", table_name="posts")
+    op.drop_index("ix_posts_category", table_name="posts")
+
+    op.drop_column("posts", "cover_image")
+    op.drop_column("posts", "pinned")
+    op.drop_column("posts", "category")
+
+    op.drop_column("members", "industry")
+    op.drop_column("members", "addr_company")
+    op.drop_column("members", "addr_personal")
+    op.drop_column("members", "company_phone")
+    op.drop_column("members", "job_title")
+    op.drop_column("members", "department")
+    op.drop_column("members", "company")
+

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -45,6 +45,14 @@ class Member(Base):
     birth_date = Column(String(10), nullable=True)  # 'YYYY-MM-DD'
     birth_lunar = Column(Boolean, nullable=True)
     phone = Column(String(64), nullable=True)
+    # B v1 확장 필드(표시/연락/소속/주소/업종)
+    company = Column(String(255), nullable=True)
+    department = Column(String(255), nullable=True)
+    job_title = Column(String(255), nullable=True)
+    company_phone = Column(String(64), nullable=True)
+    addr_personal = Column(String(255), nullable=True)
+    addr_company = Column(String(255), nullable=True)
+    industry = Column(String(255), nullable=True)
 
     posts = relationship("Post", back_populates="author", cascade="all, delete-orphan")
     rsvps = relationship("RSVP", back_populates="member", cascade="all, delete-orphan")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -71,6 +71,11 @@ class Post(Base):
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
     published_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    category = Column(String(64), nullable=True, index=True)  # 'notice' | 'news' | ...
+    pinned = Column(
+        Boolean, nullable=False, default=False, server_default="0", index=True
+    )
+    cover_image = Column(String(512), nullable=True)
 
     author = relationship("Member", back_populates="posts")
 

--- a/apps/api/repositories/members.py
+++ b/apps/api/repositories/members.py
@@ -39,6 +39,21 @@ def list_members(
     maj = f.get('major')
     if maj:
         conds.append(models.Member.major.ilike(f"%{maj}%"))
+    comp = f.get('company')
+    if comp:
+        conds.append(models.Member.company.ilike(f"%{comp}%"))
+    ind = f.get('industry')
+    if ind:
+        conds.append(models.Member.industry.ilike(f"%{ind}%"))
+    region = f.get('region')
+    if region:
+        like = f"%{region}%"
+        conds.append(
+            or_(
+                models.Member.addr_personal.ilike(like),
+                models.Member.addr_company.ilike(like),
+            )
+        )
     if f.get('exclude_private', True):
         conds.append(models.Member.visibility != models.Visibility.PRIVATE)
     if conds:
@@ -65,6 +80,21 @@ def count_members(
     maj = f.get('major')
     if maj:
         conds.append(models.Member.major.ilike(f"%{maj}%"))
+    comp = f.get('company')
+    if comp:
+        conds.append(models.Member.company.ilike(f"%{comp}%"))
+    ind = f.get('industry')
+    if ind:
+        conds.append(models.Member.industry.ilike(f"%{ind}%"))
+    region = f.get('region')
+    if region:
+        like = f"%{region}%"
+        conds.append(
+            or_(
+                models.Member.addr_personal.ilike(like),
+                models.Member.addr_company.ilike(like),
+            )
+        )
     if f.get('exclude_private', True):
         conds.append(models.Member.visibility != models.Visibility.PRIVATE)
     if conds:

--- a/apps/api/repositories/posts.py
+++ b/apps/api/repositories/posts.py
@@ -9,10 +9,14 @@ from .. import models, schemas
 from ..errors import NotFoundError
 
 
-def list_posts(db: Session, *, limit: int, offset: int) -> Sequence[models.Post]:
+def list_posts(
+    db: Session, *, limit: int, offset: int, category: str | None = None
+) -> Sequence[models.Post]:
+    stmt = select(models.Post)
+    if category:
+        stmt = stmt.where(models.Post.category == category)
     stmt = (
-        select(models.Post)
-        .order_by(desc(models.Post.published_at))
+        stmt.order_by(desc(models.Post.pinned), desc(models.Post.published_at))
         .offset(offset)
         .limit(limit)
     )

--- a/apps/api/repositories/send_logs.py
+++ b/apps/api/repositories/send_logs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Sequence
+from datetime import datetime
 
 from sqlalchemy import desc, select, text
 from sqlalchemy.orm import Session
@@ -39,6 +40,21 @@ def list_recent(
         select(models.NotificationSendLog)
         .order_by(desc(models.NotificationSendLog.created_at))
         .limit(limit)
+    )
+    return db.execute(stmt).scalars().all()
+
+
+def list_since(
+    db: Session, *, cutoff: datetime
+) -> Sequence[models.NotificationSendLog]:
+    """Return logs created at or after the given cutoff.
+
+    Uses a straight timestamp comparison to be dialect-agnostic (SQLite/Postgres).
+    """
+    stmt = (
+        select(models.NotificationSendLog)
+        .where(models.NotificationSendLog.created_at >= cutoff)
+        .order_by(desc(models.NotificationSendLog.created_at))
     )
     return db.execute(stmt).scalars().all()
 

--- a/apps/api/routers/members.py
+++ b/apps/api/routers/members.py
@@ -18,6 +18,9 @@ class MemberListParams(BaseModel):
     q: str | None = None
     cohort: int | None = None
     major: str | None = None
+    company: str | None = None
+    industry: str | None = None
+    region: str | None = None
 
 
 @router.get("/", response_model=list[schemas.MemberRead])
@@ -31,6 +34,12 @@ def list_members(
         filters['cohort'] = int(params.cohort)
     if params.major:
         filters['major'] = params.major
+    if params.company:
+        filters['company'] = params.company
+    if params.industry:
+        filters['industry'] = params.industry
+    if params.region:
+        filters['region'] = params.region
     members = members_service.list_members(
         db, limit=params.limit, offset=params.offset, filters=filters
     )
@@ -52,6 +61,12 @@ def count_members(
         filters['cohort'] = int(params.cohort)
     if params.major:
         filters['major'] = params.major
+    if params.company:
+        filters['company'] = params.company
+    if params.industry:
+        filters['industry'] = params.industry
+    if params.region:
+        filters['region'] = params.region
     c = members_service.count_members(db, filters=filters)
     return MemberCount(count=c)
 

--- a/apps/api/routers/notifications.py
+++ b/apps/api/routers/notifications.py
@@ -170,18 +170,18 @@ def get_stats(
 
     subs = subs_repo.list_active_subscriptions(db)
     logs = logs_repo.list_since(db, cutoff=cutoff)
-    accepted = sum(1 for rlog in logs if bool(cast(int, rlog.ok)))
-    failed = sum(1 for rlog in logs if not bool(cast(int, rlog.ok)))
+    accepted = sum(1 for rlog in logs if int(cast(int, rlog.ok)) != 0)
+    failed = sum(1 for rlog in logs if int(cast(int, rlog.ok)) == 0)
     f404 = sum(
         1
         for rlog in logs
-        if not bool(cast(int, rlog.ok))
+        if int(cast(int, rlog.ok)) == 0
         and rlog.status_code == int(HTTPStatus.NOT_FOUND)
     )
     f410 = sum(
         1
         for rlog in logs
-        if not bool(cast(int, rlog.ok)) and rlog.status_code == int(HTTPStatus.GONE)
+        if int(cast(int, rlog.ok)) == 0 and rlog.status_code == int(HTTPStatus.GONE)
     )
     fother = failed - (f404 + f410)
     settings = get_settings()

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -15,9 +15,10 @@ router = APIRouter(prefix="/posts", tags=["posts"])
 def list_posts(
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    category: str | None = Query(None),
     db: Session = Depends(get_db),
 ) -> list[schemas.PostRead]:
-    posts = posts_service.list_posts(db, limit=limit, offset=offset)
+    posts = posts_service.list_posts(db, limit=limit, offset=offset, category=category)
     return [schemas.PostRead.model_validate(post) for post in posts]
 
 

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -76,6 +76,9 @@ class PostBase(BaseModel):
     title: str
     content: str
     published_at: datetime | None = None
+    category: str | None = None
+    pinned: bool = False
+    cover_image: str | None = None
 
 
 class PostCreate(PostBase):

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -20,6 +20,13 @@ class MemberBase(BaseModel):
     birth_date: str | None = None  # 'YYYY-MM-DD'
     birth_lunar: bool | None = None
     phone: str | None = None
+    company: str | None = None
+    department: str | None = None
+    job_title: str | None = None
+    company_phone: str | None = None
+    addr_personal: str | None = None
+    addr_company: str | None = None
+    industry: str | None = None
 
 
 class MemberCreate(MemberBase):
@@ -46,6 +53,13 @@ class MemberUpdate(BaseModel):
     birth_date: str | None = None
     birth_lunar: bool | None = None
     phone: str | None = None
+    company: str | None = None
+    department: str | None = None
+    job_title: str | None = None
+    company_phone: str | None = None
+    addr_personal: str | None = None
+    addr_company: str | None = None
+    industry: str | None = None
 
 
 class MemberListFilters(TypedDict, total=False):

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -66,6 +66,9 @@ class MemberListFilters(TypedDict, total=False):
     q: str
     cohort: int
     major: str
+    company: str
+    industry: str
+    region: str
     exclude_private: bool
 
 

--- a/apps/api/services/posts_service.py
+++ b/apps/api/services/posts_service.py
@@ -9,8 +9,10 @@ from ..repositories import members as members_repo
 from ..repositories import posts as posts_repo
 
 
-def list_posts(db: Session, *, limit: int, offset: int) -> Sequence[models.Post]:
-    return posts_repo.list_posts(db, limit=limit, offset=offset)
+def list_posts(
+    db: Session, *, limit: int, offset: int, category: str | None = None
+) -> Sequence[models.Post]:
+    return posts_repo.list_posts(db, limit=limit, offset=offset, category=category)
 
 
 def get_post(db: Session, post_id: int) -> models.Post:

--- a/apps/web/__tests__/post-card.test.tsx
+++ b/apps/web/__tests__/post-card.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { PostCard } from '../components/post-card';
+
+describe('PostCard', () => {
+  it('renders category, pinned badge, and cover image', () => {
+    render(
+      <PostCard
+        title="Notice Pinned"
+        content="Body"
+        category="notice"
+        pinned
+        cover_image="https://example.com/cover.png"
+        published_at={null}
+      />
+    );
+    expect(screen.getByLabelText('category')).toHaveTextContent('notice');
+    expect(screen.getByLabelText('pinned')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'cover' })).toBeInTheDocument();
+  });
+
+  it('renders without optional props', () => {
+    render(<PostCard title="News" content="Body" />);
+    expect(screen.queryByLabelText('category')).toBeNull();
+    expect(screen.queryByLabelText('pinned')).toBeNull();
+  });
+});
+

--- a/apps/web/__tests__/posts-utils.test.ts
+++ b/apps/web/__tests__/posts-utils.test.ts
@@ -1,0 +1,15 @@
+import { splitPinned } from '../lib/posts';
+
+describe('splitPinned', () => {
+  it('separates pinned and regular posts', () => {
+    const posts = [
+      { id: 1, title: 'A', content: '', published_at: null, author_id: 1, pinned: true },
+      { id: 2, title: 'B', content: '', published_at: null, author_id: 1, pinned: false },
+      { id: 3, title: 'C', content: '', published_at: null, author_id: 1, pinned: true },
+    ];
+    const { pinned, regular } = splitPinned(posts);
+    expect(pinned.map((p) => p.id)).toEqual([1, 3]);
+    expect(regular.map((p) => p.id)).toEqual([2]);
+  });
+});
+

--- a/apps/web/app/admin/notifications/page.tsx
+++ b/apps/web/app/admin/notifications/page.tsx
@@ -6,7 +6,127 @@ import { RequireAdmin } from '../../../components/require-admin';
 import { useToast } from '../../../components/toast';
 import { apiFetch } from '../../../lib/api';
 import { useQuery } from '@tanstack/react-query';
-import { getNotificationStats, getSendLogs, pruneSendLogs, type SendLog } from '../../../services/notifications';
+import { getNotificationStats, getSendLogs, pruneSendLogs, type SendLog, type NotificationStats } from '../../../services/notifications';
+
+type RangeOpt = NonNullable<NotificationStats['range']>;
+
+function StatsBlock({ data, isLoading, isError, statsRange, setStatsRange, onRefresh }:{
+  data?: NotificationStats;
+  isLoading: boolean;
+  isError: boolean;
+  statsRange: RangeOpt;
+  setStatsRange: (v: RangeOpt) => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="mb-6">
+      <h3 className="mb-2 text-lg font-medium">요약</h3>
+      <div className="mb-2 flex items-center gap-2 text-xs text-slate-600">
+        <label className="flex items-center gap-1">기간
+          <select
+            className="rounded border px-2 py-1"
+            value={statsRange}
+            onChange={(e) => setStatsRange(e.target.value as RangeOpt)}
+          >
+            {(['24h','7d','30d'] as const).map(v => <option key={v} value={v}>{v}</option>)}
+          </select>
+        </label>
+        <button type="button" className="rounded border px-2 py-1" onClick={onRefresh}>요약 새로고침</button>
+      </div>
+      {isLoading ? (
+        <div className="text-sm text-slate-500">로딩 중…</div>
+      ) : isError ? (
+        <div className="text-sm text-red-600">요약 불러오기 실패</div>
+      ) : data ? (
+        <div className="text-sm text-slate-800">
+          활성 구독: <b>{data.active_subscriptions}</b> · 최근 성공: <b className="text-emerald-700">{data.recent_accepted}</b> · 최근 실패: <b className="text-red-700">{data.recent_failed}</b>
+          <span
+            className={`ml-3 inline-flex items-center rounded px-2 py-0.5 text-xs ${data.encryption_enabled ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200' : 'bg-red-50 text-red-700 ring-1 ring-red-200'}`}
+            title="구독 at-rest 암호화 상태"
+          >암호화 {data.encryption_enabled ? 'ON' : 'OFF'}</span>
+          {typeof data.failed_404 === 'number' ? (
+            <span className="ml-3 text-xs text-slate-500">실패 분포: 404 {data.failed_404} · 410 {data.failed_410 ?? 0} · 기타 {data.failed_other ?? 0}</span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LogsBlock({ data, isLoading, isError, logLimit, setLogLimit }:{
+  data?: SendLog[];
+  isLoading: boolean;
+  isError: boolean;
+  logLimit: number;
+  setLogLimit: (n: number) => void;
+}) {
+  return (
+    <div>
+      <h3 className="mb-2 text-lg font-medium">최근 발송 로그</h3>
+      <div className="mb-2 flex items-center gap-2 text-xs text-slate-600">
+        <label className="flex items-center gap-1">표시 개수
+          <select className="rounded border px-2 py-1" value={logLimit} onChange={(e) => setLogLimit(parseInt(e.target.value, 10))}>
+            {[20, 50, 100, 200].map(v => <option key={v} value={v}>{v}</option>)}
+          </select>
+        </label>
+      </div>
+      {isLoading ? (
+        <div className="text-sm text-slate-500">로딩 중…</div>
+      ) : isError ? (
+        <div className="text-sm text-red-600">로그 불러오기 실패</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-[600px] text-left text-sm">
+            <thead>
+              <tr className="border-b bg-slate-50">
+                <th className="p-2">시간</th>
+                <th className="p-2">결과</th>
+                <th className="p-2">상태코드</th>
+                <th className="p-2">엔드포인트(말미)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data ?? []).map((r, i) => (
+                <tr key={i} className="border-b last:border-0">
+                  <td className="p-2 font-mono text-xs text-slate-600">{r.created_at}</td>
+                  <td className="p-2">{r.ok ? <span className="text-emerald-700">성공</span> : <span className="text-red-700">실패</span>}</td>
+                  <td className="p-2">{r.status_code ?? '-'}</td>
+                  <td className="p-2 font-mono text-xs">{r.endpoint_tail ?? '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PrunePanel({ pruneDays, setPruneDays, busy, onPrune }:{
+  pruneDays: number;
+  setPruneDays: (n: number) => void;
+  busy: boolean;
+  onPrune: () => void;
+}) {
+  return (
+    <div className="mb-6">
+      <h3 className="mb-2 text-lg font-medium">로그 정리</h3>
+      <div className="flex items-center gap-2 text-sm">
+        <label className="text-sm">
+          보관 기간(일)
+          <input
+            type="number"
+            min={1}
+            className="ml-2 w-24 rounded border px-2 py-1"
+            value={pruneDays}
+            onChange={(e) => setPruneDays(Math.max(1, parseInt(e.target.value || '1', 10)))}
+          />
+        </label>
+        <button disabled={busy} onClick={onPrune} className="rounded border px-3 py-1.5 text-sm disabled:opacity-50">오래된 로그 삭제</button>
+      </div>
+    </div>
+  );
+}
 
 export default function AdminNotificationsPage() {
   const { status } = useAuth();
@@ -17,7 +137,8 @@ export default function AdminNotificationsPage() {
   const [busy, setBusy] = useState(false);
   const [logLimit, setLogLimit] = useState(50);
   const [pruneDays, setPruneDays] = useState(30);
-  const stats = useQuery({ queryKey: ['notify','stats'], queryFn: getNotificationStats, staleTime: 10_000 });
+  const [statsRange, setStatsRange] = useState<NonNullable<NotificationStats['range']>>('7d');
+  const stats = useQuery({ queryKey: ['notify','stats', statsRange], queryFn: () => getNotificationStats(statsRange!), staleTime: 10_000 });
   const logs = useQuery<SendLog[]>({ queryKey: ['notify','logs', logLimit], queryFn: () => getSendLogs(logLimit), staleTime: 10_000 });
 
   if (status !== 'authorized') {
@@ -44,7 +165,8 @@ export default function AdminNotificationsPage() {
     setBusy(true);
     try {
       const res = await pruneSendLogs(pruneDays);
-      toast.show(`오래된 로그 ${res.deleted}건 삭제`, { type: 'success' });
+      const before = res.before ? new Date(res.before).toLocaleString() : '';
+      toast.show(`오래된 로그 ${res.deleted}건 삭제${before ? ` (기준: ${before})` : ''}`, { type: 'success' });
       await logs.refetch();
     } catch {
       toast.show('로그 정리 중 오류가 발생했습니다.', { type: 'error' });
@@ -55,113 +177,43 @@ export default function AdminNotificationsPage() {
 
   return (
     <RequireAdmin fallback={<div className="p-4 text-sm text-slate-600">관리자 전용입니다.</div>}>
-    <div className="p-6">
-      <h2 className="mb-4 text-xl font-semibold">테스트 알림 발송(Admin)</h2>
-      <div className="mb-6 flex max-w-xl flex-col gap-3">
-        <label className="text-sm">제목
-          <input className="mt-1 w-full rounded border px-3 py-2" value={title} onChange={(e) => setTitle(e.target.value)} />
-        </label>
-        <label className="text-sm">내용
-          <textarea className="mt-1 w-full rounded border px-3 py-2" rows={3} value={body} onChange={(e) => setBody(e.target.value)} />
-        </label>
-        <label className="text-sm">URL(선택)
-          <input className="mt-1 w-full rounded border px-3 py-2" placeholder="https://example.com" value={url} onChange={(e) => setUrl(e.target.value)} />
-        </label>
-        <div>
-          <button disabled={busy} onClick={onSend} className="rounded bg-emerald-600 px-4 py-2 text-white disabled:opacity-50">발송</button>
-          <button
-            type="button"
-            className="ml-2 rounded border px-3 py-2 text-sm"
-            onClick={async () => { await stats.refetch(); await logs.refetch(); }}
-          >새로고침</button>
-        </div>
-      </div>
-
-      <div className="mb-6">
-        <h3 className="mb-2 text-lg font-medium">요약</h3>
-        {stats.isLoading ? (
-          <div className="text-sm text-slate-500">로딩 중…</div>
-        ) : stats.isError ? (
-          <div className="text-sm text-red-600">요약 불러오기 실패</div>
-        ) : stats.data ? (
-          <div className="text-sm text-slate-800">
-            활성 구독: <b>{stats.data.active_subscriptions}</b> · 최근 성공: <b className="text-emerald-700">{stats.data.recent_accepted}</b> · 최근 실패: <b className="text-red-700">{stats.data.recent_failed}</b>
-            <span
-              className={
-                `ml-3 inline-flex items-center rounded px-2 py-0.5 text-xs ${
-                  stats.data.encryption_enabled ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200' : 'bg-red-50 text-red-700 ring-1 ring-red-200'
-                }`
-              }
-              title="구독 at-rest 암호화 상태"
-            >암호화 {stats.data.encryption_enabled ? 'ON' : 'OFF'}</span>
-          </div>
-        ) : null}
-      </div>
-
-      <div className="mb-6">
-        <h3 className="mb-2 text-lg font-medium">로그 정리</h3>
-        <div className="flex items-center gap-2 text-sm">
-          <label className="text-sm">
-            보관 기간(일)
-            <input
-              type="number"
-              min={1}
-              className="ml-2 w-24 rounded border px-2 py-1"
-              value={pruneDays}
-              onChange={(e) => setPruneDays(Math.max(1, parseInt(e.target.value || '1', 10)))}
-            />
+      <div className="p-6">
+        <h2 className="mb-4 text-xl font-semibold">테스트 알림 발송(Admin)</h2>
+        <div className="mb-6 flex max-w-xl flex-col gap-3">
+          <label className="text-sm">제목
+            <input className="mt-1 w-full rounded border px-3 py-2" value={title} onChange={(e) => setTitle(e.target.value)} />
           </label>
-          <button
-            disabled={busy}
-            onClick={onPrune}
-            className="rounded border px-3 py-1.5 text-sm disabled:opacity-50"
-          >오래된 로그 삭제</button>
-        </div>
-      </div>
-
-      <div>
-        <h3 className="mb-2 text-lg font-medium">최근 발송 로그</h3>
-        <div className="mb-2 flex items-center gap-2 text-xs text-slate-600">
-          <label className="flex items-center gap-1">표시 개수
-            <select
-              className="rounded border px-2 py-1"
-              value={logLimit}
-              onChange={(e) => setLogLimit(parseInt(e.target.value, 10))}
-            >
-              {[20, 50, 100, 200].map(v => <option key={v} value={v}>{v}</option>)}
-            </select>
+          <label className="text-sm">내용
+            <textarea className="mt-1 w-full rounded border px-3 py-2" rows={3} value={body} onChange={(e) => setBody(e.target.value)} />
           </label>
-        </div>
-        {logs.isLoading ? (
-          <div className="text-sm text-slate-500">로딩 중…</div>
-        ) : logs.isError ? (
-          <div className="text-sm text-red-600">로그 불러오기 실패</div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-[600px] text-left text-sm">
-              <thead>
-                <tr className="border-b bg-slate-50">
-                  <th className="p-2">시간</th>
-                  <th className="p-2">결과</th>
-                  <th className="p-2">상태코드</th>
-                  <th className="p-2">엔드포인트(말미)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(logs.data ?? []).map((r, i) => (
-                  <tr key={i} className="border-b last:border-0">
-                    <td className="p-2 font-mono text-xs text-slate-600">{r.created_at}</td>
-                    <td className="p-2">{r.ok ? <span className="text-emerald-700">성공</span> : <span className="text-red-700">실패</span>}</td>
-                    <td className="p-2">{r.status_code ?? '-'}</td>
-                    <td className="p-2 font-mono text-xs">{r.endpoint_tail ?? '-'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <label className="text-sm">URL(선택)
+            <input className="mt-1 w-full rounded border px-3 py-2" placeholder="https://example.com" value={url} onChange={(e) => setUrl(e.target.value)} />
+          </label>
+          <div>
+            <button disabled={busy} onClick={onSend} className="rounded bg-emerald-600 px-4 py-2 text-white disabled:opacity-50">발송</button>
+            <button type="button" className="ml-2 rounded border px-3 py-2 text-sm" onClick={async () => { await stats.refetch(); await logs.refetch(); }}>새로고침</button>
           </div>
-        )}
+        </div>
+
+        <StatsBlock
+          data={stats.data}
+          isLoading={stats.isLoading}
+          isError={!!stats.error}
+          statsRange={statsRange}
+          setStatsRange={setStatsRange}
+          onRefresh={() => { void stats.refetch(); }}
+        />
+
+        <PrunePanel pruneDays={pruneDays} setPruneDays={setPruneDays} busy={busy} onPrune={onPrune} />
+
+        <LogsBlock
+          data={logs.data}
+          isLoading={logs.isLoading}
+          isError={!!logs.error}
+          logLimit={logLimit}
+          setLogLimit={setLogLimit}
+        />
       </div>
-    </div>
     </RequireAdmin>
   );
 }

--- a/apps/web/app/directory/page.tsx
+++ b/apps/web/app/directory/page.tsx
@@ -6,15 +6,18 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { listMembers, countMembers } from '../../services/members';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-type Filters = { q: string; cohort: string; major: string };
+type Filters = { q: string; cohort: string; major: string; company: string; industry: string; region: string };
 
 function FilterBar({ values, onChange }: { values: Filters; onChange: (f: Filters) => void }) {
-  const { q, cohort, major } = values;
+  const { q, cohort, major, company, industry, region } = values;
   return (
     <div className="mb-4 flex flex-wrap gap-2">
       <input className="rounded border px-3 py-2" placeholder="검색" value={q} onChange={(e) => onChange({ ...values, q: e.target.value })} />
       <input className="rounded border px-3 py-2" placeholder="기수" value={cohort} onChange={(e) => onChange({ ...values, cohort: e.target.value })} />
       <input className="rounded border px-3 py-2" placeholder="전공" value={major} onChange={(e) => onChange({ ...values, major: e.target.value })} />
+      <input className="rounded border px-3 py-2" placeholder="회사" value={company} onChange={(e) => onChange({ ...values, company: e.target.value })} />
+      <input className="rounded border px-3 py-2" placeholder="업종" value={industry} onChange={(e) => onChange({ ...values, industry: e.target.value })} />
+      <input className="rounded border px-3 py-2" placeholder="지역(주소)" value={region} onChange={(e) => onChange({ ...values, region: e.target.value })} />
     </div>
   );
 }
@@ -104,12 +107,18 @@ function DirectoryPageInner() {
   const [q, setQ] = useState(sp.get('q') ?? '');
   const [cohort, setCohort] = useState<string>(sp.get('cohort') ?? '');
   const [major, setMajor] = useState(sp.get('major') ?? '');
+  const [company, setCompany] = useState(sp.get('company') ?? '');
+  const [industry, setIndustry] = useState(sp.get('industry') ?? '');
+  const [region, setRegion] = useState(sp.get('region') ?? '');
 
   // 간단 디바운스(400ms)로 입력 변경 시 네트워크 부하와 리렌더를 완화
   const debounceMs = 400;
   const [qDeb, setQDeb] = useState(q);
   const [cohortDeb, setCohortDeb] = useState(cohort);
   const [majorDeb, setMajorDeb] = useState(major);
+  const [companyDeb, setCompanyDeb] = useState(company);
+  const [industryDeb, setIndustryDeb] = useState(industry);
+  const [regionDeb, setRegionDeb] = useState(region);
   useEffect(() => {
     const t = setTimeout(() => setQDeb(q), debounceMs);
     return () => clearTimeout(t);
@@ -122,15 +131,30 @@ function DirectoryPageInner() {
     const t = setTimeout(() => setMajorDeb(major), debounceMs);
     return () => clearTimeout(t);
   }, [major]);
+  useEffect(() => {
+    const t = setTimeout(() => setCompanyDeb(company), debounceMs);
+    return () => clearTimeout(t);
+  }, [company]);
+  useEffect(() => {
+    const t = setTimeout(() => setIndustryDeb(industry), debounceMs);
+    return () => clearTimeout(t);
+  }, [industry]);
+  useEffect(() => {
+    const t = setTimeout(() => setRegionDeb(region), debounceMs);
+    return () => clearTimeout(t);
+  }, [region]);
   const pageSize = 10;
   const query = useInfiniteQuery({
-    queryKey: ['directory', qDeb, cohortDeb, majorDeb],
+    queryKey: ['directory', qDeb, cohortDeb, majorDeb, companyDeb, industryDeb, regionDeb],
     initialPageParam: 0,
     queryFn: ({ pageParam }) =>
       listMembers({
         q: qDeb,
         cohort: cohortDeb ? Number(cohortDeb) : undefined,
         major: majorDeb,
+        company: companyDeb || undefined,
+        industry: industryDeb || undefined,
+        region: regionDeb || undefined,
         limit: pageSize,
         offset: pageParam as number,
       }),
@@ -139,8 +163,8 @@ function DirectoryPageInner() {
   });
 
   const total = useQuery<number>({
-    queryKey: ['directory-count', qDeb, cohortDeb, majorDeb],
-    queryFn: () => countMembers({ q: qDeb, cohort: cohortDeb ? Number(cohortDeb) : undefined, major: majorDeb }),
+    queryKey: ['directory-count', qDeb, cohortDeb, majorDeb, companyDeb, industryDeb, regionDeb],
+    queryFn: () => countMembers({ q: qDeb, cohort: cohortDeb ? Number(cohortDeb) : undefined, major: majorDeb, company: companyDeb || undefined, industry: industryDeb || undefined, region: regionDeb || undefined }),
   });
 
   // 입력 변경 시 URL 쿼리 자동 동기화(디바운스 적용 상태 사용)
@@ -149,6 +173,9 @@ function DirectoryPageInner() {
     if (qDeb) usp.set('q', qDeb);
     if (cohortDeb) usp.set('cohort', cohortDeb);
     if (majorDeb) usp.set('major', majorDeb);
+    if (companyDeb) usp.set('company', companyDeb);
+    if (industryDeb) usp.set('industry', industryDeb);
+    if (regionDeb) usp.set('region', regionDeb);
     const qs = usp.toString();
     const target = `/directory${qs ? `?${qs}` : ''}`;
     // 현재 URL과 동일하면 불필요한 replace를 생략
@@ -159,15 +186,15 @@ function DirectoryPageInner() {
     } else {
       router.replace(target as Route);
     }
-  }, [qDeb, cohortDeb, majorDeb, router]);
+  }, [qDeb, cohortDeb, majorDeb, companyDeb, industryDeb, regionDeb, router]);
 
   const items = (query.data?.pages.flatMap((p) => p) ?? []);
-  const filters: Filters = { q, cohort, major };
+  const filters: Filters = { q, cohort, major, company, industry, region };
   return (
     <div className="p-6">
       <h2 className="mb-4 text-xl font-semibold">수첩(디렉터리)</h2>
       <div className="mb-2 text-sm text-slate-600">총 {total.data ?? 0}명</div>
-      <FilterBar values={filters} onChange={(f) => { setQ(f.q); setCohort(f.cohort); setMajor(f.major); }} />
+      <FilterBar values={filters} onChange={(f) => { setQ(f.q); setCohort(f.cohort); setMajor(f.major); setCompany(f.company); setIndustry(f.industry); setRegion(f.region); }} />
       <DirectoryBody
         isLoading={query.isLoading}
         isError={query.isError as boolean}

--- a/apps/web/app/posts/[id]/page.tsx
+++ b/apps/web/app/posts/[id]/page.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ApiError } from '../../../lib/api';
+import { getPost } from '../../../services/posts';
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function PostDetailPage({ params }: PageProps) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  if (Number.isNaN(id)) notFound();
+
+  try {
+    const post = await getPost(id);
+    return (
+      <article className="space-y-4 p-6">
+        <Link href="/posts" className="text-sm text-slate-600 underline">
+          ← 목록으로 돌아가기
+        </Link>
+        <header className="space-y-2">
+          {post.category ? (
+            <span className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700">{post.category}</span>
+          ) : null}
+          <h1 className="text-2xl font-semibold">{post.title}</h1>
+          <p className="text-xs text-slate-500">
+            {post.published_at ? new Date(post.published_at).toLocaleString() : '게시 예정'}
+          </p>
+        </header>
+        {post.cover_image ? (
+          <Image src={post.cover_image} alt="cover" width={720} height={405} className="h-auto w-full rounded object-cover" />
+        ) : null}
+        <div className="whitespace-pre-wrap text-sm text-slate-800">{post.content}</div>
+      </article>
+    );
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) {
+      notFound();
+    }
+    throw e;
+  }
+}

--- a/apps/web/app/posts/new/page.tsx
+++ b/apps/web/app/posts/new/page.tsx
@@ -17,12 +17,22 @@ export default function NewPostPage() {
   const [authorId, setAuthorId] = useState<number | ''>('' as const);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [category, setCategory] = useState<'notice'|'news'>('notice');
+  const [pinned, setPinned] = useState(false);
+  const [coverImage, setCoverImage] = useState('');
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { show } = useToast();
 
   const mutate = useMutation({
-    mutationFn: () => createPost({ author_id: Number(authorId), title, content }),
+    mutationFn: () => createPost({
+      author_id: Number(authorId),
+      title,
+      content,
+      category,
+      pinned,
+      cover_image: coverImage || undefined,
+    }),
     onSuccess: () => {
       show('게시글이 생성되었습니다.', { type: 'success' });
       router.push(`/posts`);
@@ -76,6 +86,21 @@ export default function NewPostPage() {
         <label className="block text-sm">
           내용
           <textarea className="mt-1 w-full rounded border px-2 py-1" rows={6} value={content} onChange={(e) => setContent(e.currentTarget.value)} />
+        </label>
+        <label className="block text-sm">
+          카테고리
+          <select className="mt-1 rounded border px-2 py-1" value={category} onChange={(e) => setCategory(e.currentTarget.value as 'notice'|'news')}>
+            <option value="notice">공지</option>
+            <option value="news">소식</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={pinned} onChange={(e) => setPinned(e.currentTarget.checked)} />
+          상단 고정(PIN)
+        </label>
+        <label className="block text-sm">
+          커버 이미지 URL
+          <input className="mt-1 w-full rounded border px-2 py-1" value={coverImage} onChange={(e) => setCoverImage(e.currentTarget.value)} />
         </label>
         <button
           className="rounded bg-slate-900 px-3 py-1 text-white disabled:opacity-50"

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -5,6 +5,7 @@ import { listPosts, type Post } from '../../services/posts';
 import { PostCard } from '../../components/post-card';
 import { useMemo, useState } from 'react';
 import { splitPinned } from '../../lib/posts';
+import Link from 'next/link';
 
 function PinnedList({ posts, limit, onViewAll }: { posts: Post[]; limit: number; onViewAll: () => void }) {
   const toShow = posts.slice(0, limit);
@@ -16,14 +17,16 @@ function PinnedList({ posts, limit, onViewAll }: { posts: Post[]; limit: number;
       <ul className="space-y-3">
         {toShow.map((post) => (
           <li key={`pinned-${post.id}`}>
-            <PostCard
-              title={post.title}
-              content={post.content}
-              category={post.category}
-              pinned={post.pinned}
-              cover_image={post.cover_image}
-              published_at={post.published_at}
-            />
+            <Link href={`/posts/${post.id}`} className="block">
+              <PostCard
+                title={post.title}
+                content={post.content}
+                category={post.category}
+                pinned={post.pinned}
+                cover_image={post.cover_image}
+                published_at={post.published_at}
+              />
+            </Link>
           </li>
         ))}
       </ul>
@@ -60,14 +63,16 @@ function PostsList({ posts, category, setCategory }: { posts: Post[]; category: 
       <ul className="space-y-3">
         {regular.map((post) => (
           <li key={post.id}>
-            <PostCard
-              title={post.title}
-              content={post.content}
-              category={post.category}
-              pinned={post.pinned}
-              cover_image={post.cover_image}
-              published_at={post.published_at}
-            />
+            <Link href={`/posts/${post.id}`} className="block">
+              <PostCard
+                title={post.title}
+                content={post.content}
+                category={post.category}
+                pinned={post.pinned}
+                cover_image={post.cover_image}
+                published_at={post.published_at}
+              />
+            </Link>
           </li>
         ))}
       </ul>

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -6,26 +6,42 @@ import { PostCard } from '../../components/post-card';
 import { useMemo, useState } from 'react';
 import { splitPinned } from '../../lib/posts';
 
-export default function PostsPage() {
-  const [category, setCategory] = useState<'all'|'notice'|'news'>('all');
-  const { data: posts, isLoading, isError } = useQuery<Post[]>({
-    queryKey: ['posts', 20, 0, category],
-    queryFn: () => listPosts({ limit: 20, category: category === 'all' ? undefined : category })
-  });
-  const { pinned, regular } = useMemo(() => splitPinned(posts ?? []), [posts]);
+function PinnedList({ posts, limit, onViewAll }: { posts: Post[]; limit: number; onViewAll: () => void }) {
+  const toShow = posts.slice(0, limit);
+  if (toShow.length === 0) return null;
+  const hasMore = posts.length > limit;
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-amber-700">고정된 공지</h3>
+      <ul className="space-y-3">
+        {toShow.map((post) => (
+          <li key={`pinned-${post.id}`}>
+            <PostCard
+              title={post.title}
+              content={post.content}
+              category={post.category}
+              pinned={post.pinned}
+              cover_image={post.cover_image}
+              published_at={post.published_at}
+            />
+          </li>
+        ))}
+      </ul>
+      {hasMore ? (
+        <button
+          type="button"
+          className="text-xs text-amber-700 underline"
+          onClick={onViewAll}
+        >공지 전체 보기</button>
+      ) : null}
+    </div>
+  );
+}
 
-  if (isLoading) {
-    return <p>게시글을 불러오는 중입니다…</p>;
-  }
-
-  if (isError) {
-    return <p className="text-red-600">게시글을 불러오지 못했습니다.</p>;
-  }
-
-  if (!posts || posts.length === 0) {
-    return <p>게시글이 아직 없습니다.</p>;
-  }
-
+function PostsList({ posts, category, setCategory }: { posts: Post[]; category: 'all'|'notice'|'news'; setCategory: (c: 'all'|'notice'|'news') => void }) {
+  const { pinned, regular } = useMemo(() => splitPinned(posts), [posts]);
+  const pinnedLimit = 3;
+  const showPinnedSection = (category === 'all' || category === 'notice') && pinned.length > 0;
   return (
     <section className="space-y-4">
       <h2 className="text-xl font-semibold">공지/소식</h2>
@@ -34,24 +50,12 @@ export default function PostsPage() {
         <button onClick={() => setCategory('notice')} className={`rounded px-2 py-1 ${category==='notice'?'bg-slate-900 text-white':'border'}`}>공지</button>
         <button onClick={() => setCategory('news')} className={`rounded px-2 py-1 ${category==='news'?'bg-slate-900 text-white':'border'}`}>소식</button>
       </div>
-      {pinned.length > 0 ? (
-        <div className="space-y-2">
-          <h3 className="text-sm font-semibold text-amber-700">고정된 공지</h3>
-          <ul className="space-y-3">
-            {pinned.map((post) => (
-              <li key={`pinned-${post.id}`}>
-                <PostCard
-                  title={post.title}
-                  content={post.content}
-                  category={post.category}
-                  pinned={post.pinned}
-                  cover_image={post.cover_image}
-                  published_at={post.published_at}
-                />
-              </li>
-            ))}
-          </ul>
-        </div>
+      {showPinnedSection ? (
+        <PinnedList
+          posts={pinned}
+          limit={pinnedLimit}
+          onViewAll={() => setCategory('notice')}
+        />
       ) : null}
       <ul className="space-y-3">
         {regular.map((post) => (
@@ -69,4 +73,27 @@ export default function PostsPage() {
       </ul>
     </section>
   );
+}
+
+export default function PostsPage() {
+  const [category, setCategory] = useState<'all'|'notice'|'news'>('all');
+  const query = useQuery<Post[]>({
+    queryKey: ['posts', 20, 0, category],
+    queryFn: () => listPosts({ limit: 20, category: category === 'all' ? undefined : category }),
+  });
+
+  if (query.isLoading) {
+    return <p>게시글을 불러오는 중입니다…</p>;
+  }
+
+  if (query.isError) {
+    return <p className="text-red-600">게시글을 불러오지 못했습니다.</p>;
+  }
+
+  const posts = query.data ?? [];
+  if (posts.length === 0) {
+    return <p>게시글이 아직 없습니다.</p>;
+  }
+
+  return <PostsList posts={posts} category={category} setCategory={setCategory} />;
 }

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -3,7 +3,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { listPosts, type Post } from '../../services/posts';
 import { PostCard } from '../../components/post-card';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { splitPinned } from '../../lib/posts';
 
 export default function PostsPage() {
   const [category, setCategory] = useState<'all'|'notice'|'news'>('all');
@@ -11,6 +12,7 @@ export default function PostsPage() {
     queryKey: ['posts', 20, 0, category],
     queryFn: () => listPosts({ limit: 20, category: category === 'all' ? undefined : category })
   });
+  const { pinned, regular } = useMemo(() => splitPinned(posts ?? []), [posts]);
 
   if (isLoading) {
     return <p>게시글을 불러오는 중입니다…</p>;
@@ -32,8 +34,27 @@ export default function PostsPage() {
         <button onClick={() => setCategory('notice')} className={`rounded px-2 py-1 ${category==='notice'?'bg-slate-900 text-white':'border'}`}>공지</button>
         <button onClick={() => setCategory('news')} className={`rounded px-2 py-1 ${category==='news'?'bg-slate-900 text-white':'border'}`}>소식</button>
       </div>
+      {pinned.length > 0 ? (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-amber-700">고정된 공지</h3>
+          <ul className="space-y-3">
+            {pinned.map((post) => (
+              <li key={`pinned-${post.id}`}>
+                <PostCard
+                  title={post.title}
+                  content={post.content}
+                  category={post.category}
+                  pinned={post.pinned}
+                  cover_image={post.cover_image}
+                  published_at={post.published_at}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
       <ul className="space-y-3">
-        {posts.map((post) => (
+        {regular.map((post) => (
           <li key={post.id}>
             <PostCard
               title={post.title}

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -2,11 +2,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { listPosts, type Post } from '../../services/posts';
+import { PostCard } from '../../components/post-card';
+import { useState } from 'react';
 
 export default function PostsPage() {
+  const [category, setCategory] = useState<'all'|'notice'|'news'>('all');
   const { data: posts, isLoading, isError } = useQuery<Post[]>({
-    queryKey: ['posts', 20, 0],
-    queryFn: () => listPosts({ limit: 20 })
+    queryKey: ['posts', 20, 0, category],
+    queryFn: () => listPosts({ limit: 20, category: category === 'all' ? undefined : category })
   });
 
   if (isLoading) {
@@ -23,15 +26,23 @@ export default function PostsPage() {
 
   return (
     <section className="space-y-4">
-      <h2 className="text-xl font-semibold">게시글</h2>
+      <h2 className="text-xl font-semibold">공지/소식</h2>
+      <div className="flex items-center gap-2 text-sm">
+        <button onClick={() => setCategory('all')} className={`rounded px-2 py-1 ${category==='all'?'bg-slate-900 text-white':'border'}`}>전체</button>
+        <button onClick={() => setCategory('notice')} className={`rounded px-2 py-1 ${category==='notice'?'bg-slate-900 text-white':'border'}`}>공지</button>
+        <button onClick={() => setCategory('news')} className={`rounded px-2 py-1 ${category==='news'?'bg-slate-900 text-white':'border'}`}>소식</button>
+      </div>
       <ul className="space-y-3">
         {posts.map((post) => (
-          <li key={post.id} className="rounded border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="font-semibold">{post.title}</h3>
-            <p className="mt-1 text-sm text-slate-700">{post.content}</p>
-            <p className="mt-2 text-xs text-slate-500">
-              게시일: {post.published_at ? new Date(post.published_at).toLocaleString() : '미정'}
-            </p>
+          <li key={post.id}>
+            <PostCard
+              title={post.title}
+              content={post.content}
+              category={post.category}
+              pinned={post.pinned}
+              cover_image={post.cover_image}
+              published_at={post.published_at}
+            />
           </li>
         ))}
       </ul>

--- a/apps/web/components/post-card.tsx
+++ b/apps/web/components/post-card.tsx
@@ -14,7 +14,7 @@ export function PostCard({ title, content, category, pinned, cover_image, publis
   return (
     <article className="flex gap-3 rounded border border-slate-200 bg-white p-4 shadow-sm">
       {cover_image ? (
-        <Image src={cover_image} alt="cover" width={64} height={64} className="h-16 w-16 rounded object-cover" unoptimized />
+        <Image src={cover_image} alt="cover" width={64} height={64} className="h-16 w-16 rounded object-cover" />
       ) : null}
       <div className="min-w-0 flex-1">
         <div className="mb-1 flex items-center gap-2">

--- a/apps/web/components/post-card.tsx
+++ b/apps/web/components/post-card.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export type PostCardProps = {
+  title: string;
+  content: string;
+  category?: string | null;
+  pinned?: boolean;
+  cover_image?: string | null;
+  published_at?: string | null;
+};
+
+export function PostCard({ title, content, category, pinned, cover_image, published_at }: PostCardProps) {
+  return (
+    <article className="flex gap-3 rounded border border-slate-200 bg-white p-4 shadow-sm">
+      {cover_image ? (
+        <img src={cover_image} alt="cover" className="h-16 w-16 rounded object-cover" />
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          {category ? (
+            <span aria-label="category" className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700">{category}</span>
+          ) : null}
+          {pinned ? (
+            <span aria-label="pinned" className="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-700">PIN</span>
+          ) : null}
+        </div>
+        <h3 className="truncate font-semibold" title={title}>{title}</h3>
+        <p className="mt-1 line-clamp-2 text-sm text-slate-700">{content}</p>
+        <p className="mt-2 text-xs text-slate-500">{published_at ? new Date(published_at).toLocaleString() : '미정'}</p>
+      </div>
+    </article>
+  );
+}
+

--- a/apps/web/components/post-card.tsx
+++ b/apps/web/components/post-card.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import React from 'react';
 
 export type PostCardProps = {
@@ -13,7 +14,7 @@ export function PostCard({ title, content, category, pinned, cover_image, publis
   return (
     <article className="flex gap-3 rounded border border-slate-200 bg-white p-4 shadow-sm">
       {cover_image ? (
-        <img src={cover_image} alt="cover" className="h-16 w-16 rounded object-cover" />
+        <Image src={cover_image} alt="cover" width={64} height={64} className="h-16 w-16 rounded object-cover" unoptimized />
       ) : null}
       <div className="min-w-0 flex-1">
         <div className="mb-1 flex items-center gap-2">
@@ -31,4 +32,3 @@ export function PostCard({ title, content, category, pinned, cover_image, publis
     </article>
   );
 }
-

--- a/apps/web/lib/posts.ts
+++ b/apps/web/lib/posts.ts
@@ -1,0 +1,15 @@
+import type { Post } from '../services/posts';
+
+export function splitPinned(posts: Post[]): { pinned: Post[]; regular: Post[] } {
+  const pinned: Post[] = [];
+  const regular: Post[] = [];
+  for (const post of posts) {
+    if (post.pinned) {
+      pinned.push(post);
+    } else {
+      regular.push(post);
+    }
+  }
+  return { pinned, regular };
+}
+

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -34,6 +34,16 @@ const securityHeaders = [
   { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains; preload' },
 ];
 
+const remoteDomainsEnv = (process.env.NEXT_PUBLIC_IMAGE_DOMAINS || '')
+  .split(',')
+  .map((d) => d.trim())
+  .filter(Boolean);
+
+const imageRemotePatterns = [
+  { protocol: 'http', hostname: 'localhost', port: '3001' },
+  ...remoteDomainsEnv.map((hostname) => ({ protocol: 'https', hostname })),
+];
+
 const nextConfig = {
   poweredByHeader: false,
   // Ensure Next resolves configs within this workspace (monorepo safe)
@@ -48,6 +58,9 @@ const nextConfig = {
   },
   // Next 15+: typedRoutes at top-level
   typedRoutes: true,
+  images: {
+    remotePatterns: imageRemotePatterns,
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,6 @@
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",
     "jsdom": "25.0.1",
-    "vitest": "2.1.4"
+    "vitest": "3.2.4"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "5.62.2",
@@ -34,6 +35,10 @@
     "eslint-plugin-promise": "7.2.1",
     "postcss": "8.5.6",
     "tailwindcss": "3.4.13",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.2.0",
+    "jsdom": "25.0.1",
+    "vitest": "2.1.4"
   }
 }

--- a/apps/web/services/members.ts
+++ b/apps/web/services/members.ts
@@ -2,22 +2,28 @@ import { apiFetch } from '../lib/api';
 
 export type Member = { id: number; email: string; name: string; cohort: number; major?: string | null; roles: string; visibility: 'all'|'cohort'|'private' };
 
-export async function listMembers(params: { q?: string; cohort?: number; major?: string; limit?: number; offset?: number } = {}): Promise<Member[]> {
+export async function listMembers(params: { q?: string; cohort?: number; major?: string; company?: string; industry?: string; region?: string; limit?: number; offset?: number } = {}): Promise<Member[]> {
   const usp = new URLSearchParams();
   if (params.q) usp.set('q', params.q);
   if (typeof params.cohort === 'number') usp.set('cohort', String(params.cohort));
   if (params.major) usp.set('major', params.major);
+  if (params.company) usp.set('company', params.company);
+  if (params.industry) usp.set('industry', params.industry);
+  if (params.region) usp.set('region', params.region);
   if (typeof params.limit === 'number') usp.set('limit', String(params.limit));
   if (typeof params.offset === 'number') usp.set('offset', String(params.offset));
   const qs = usp.toString();
   return apiFetch<Member[]>(`/members${qs ? `?${qs}` : ''}`);
 }
 
-export async function countMembers(params: { q?: string; cohort?: number; major?: string } = {}): Promise<number> {
+export async function countMembers(params: { q?: string; cohort?: number; major?: string; company?: string; industry?: string; region?: string } = {}): Promise<number> {
   const usp = new URLSearchParams();
   if (params.q) usp.set('q', params.q);
   if (typeof params.cohort === 'number') usp.set('cohort', String(params.cohort));
   if (params.major) usp.set('major', params.major);
+  if (params.company) usp.set('company', params.company);
+  if (params.industry) usp.set('industry', params.industry);
+  if (params.region) usp.set('region', params.region);
   const qs = usp.toString();
   const res = await apiFetch<{ count: number }>(`/members/count${qs ? `?${qs}` : ''}`);
   return res.count;

--- a/apps/web/services/notifications.ts
+++ b/apps/web/services/notifications.ts
@@ -33,18 +33,22 @@ export type NotificationStats = {
   recent_accepted: number;
   recent_failed: number;
   encryption_enabled: boolean;
+  range?: '24h'|'7d'|'30d';
+  failed_404?: number;
+  failed_410?: number;
+  failed_other?: number;
 };
 
 export async function getSendLogs(limit = 50): Promise<SendLog[]> {
   return apiFetch<SendLog[]>(`/notifications/admin/notifications/logs?limit=${limit}`);
 }
 
-export async function getNotificationStats(): Promise<NotificationStats> {
-  return apiFetch<NotificationStats>('/notifications/admin/notifications/stats');
+export async function getNotificationStats(range: '24h'|'7d'|'30d' = '7d'): Promise<NotificationStats> {
+  return apiFetch<NotificationStats>(`/notifications/admin/notifications/stats?range=${range}`);
 }
 
-export async function pruneSendLogs(olderThanDays: number): Promise<{ deleted: number }> {
-  return apiFetch<{ deleted: number }>(
+export async function pruneSendLogs(olderThanDays: number): Promise<{ deleted: number; before?: string; older_than_days?: number }> {
+  return apiFetch<{ deleted: number; before?: string; older_than_days?: number }>(
     '/notifications/admin/notifications/prune-logs',
     { method: 'POST', body: JSON.stringify({ older_than_days: olderThanDays }) }
   );

--- a/apps/web/services/notifications.ts
+++ b/apps/web/services/notifications.ts
@@ -42,3 +42,10 @@ export async function getSendLogs(limit = 50): Promise<SendLog[]> {
 export async function getNotificationStats(): Promise<NotificationStats> {
   return apiFetch<NotificationStats>('/notifications/admin/notifications/stats');
 }
+
+export async function pruneSendLogs(olderThanDays: number): Promise<{ deleted: number }> {
+  return apiFetch<{ deleted: number }>(
+    '/notifications/admin/notifications/prune-logs',
+    { method: 'POST', body: JSON.stringify({ older_than_days: olderThanDays }) }
+  );
+}

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -28,6 +28,9 @@ export async function createPost(payload: {
   title: string;
   content: string;
   published_at?: string | null;
+  category?: string | null;
+  pinned?: boolean;
+  cover_image?: string | null;
 }): Promise<Post> {
   return apiFetch<Post>(`/posts/`, { method: 'POST', body: JSON.stringify(payload) });
 }

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -9,12 +9,16 @@ export type Post = {
   content: string;
   published_at: string | null;
   author_id: number;
+  category?: string | null;
+  pinned?: boolean;
+  cover_image?: string | null;
 };
 
-export async function listPosts(params: { limit?: number; offset?: number } = {}): Promise<Post[]> {
+export async function listPosts(params: { limit?: number; offset?: number; category?: string } = {}): Promise<Post[]> {
   const q = new URLSearchParams();
   if (params.limit != null) q.set('limit', String(params.limit));
   if (params.offset != null) q.set('offset', String(params.offset));
+  if (params.category) q.set('category', params.category);
   const qs = q.toString();
   return apiFetch<Post[]>(`/posts${qs ? `?${qs}` : ''}`);
 }

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -23,6 +23,10 @@ export async function listPosts(params: { limit?: number; offset?: number; categ
   return apiFetch<Post[]>(`/posts${qs ? `?${qs}` : ''}`);
 }
 
+export async function getPost(id: number): Promise<Post> {
+  return apiFetch<Post>(`/posts/${id}`);
+}
+
 export async function createPost(payload: {
   author_id: number;
   title: string;

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['__tests__/**/*.test.tsx'],
+    include: ['__tests__/**/*.test.{ts,tsx}'],
     globals: true,
   },
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['__tests__/**/*.test.tsx'],
+    globals: true,
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,2 +1,8 @@
 import '@testing-library/jest-dom';
+import React from 'react';
+import { vi } from 'vitest';
 
+// Next.js 이미지 컴포넌트를 테스트 환경에서 간단히 대체
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}));

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -43,4 +43,5 @@
 - API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).
 - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
 - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
- - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
+- Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
+ - Web: 고정 공지 섹션 분리(splitPinned) + PostCard를 next/image로 전환(핀 목록/비핀 목록 구분).

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -39,4 +39,5 @@
  - Docs: worklog 갱신 — admin notifications UI 폴리시 반영.
 - API: 통계 기간(range=24h/7d/30d) 파라미터 및 실패 코드 분포(404/410/others) 제공.
 - Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.
- - Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.
+- Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.
+ - API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -44,4 +44,5 @@
 - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
 - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
- - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 UI 추가.
+- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 UI 추가.
+- Web: vitest 3.2.4 업그레이드(GHSA-9crc-q9x8-hgqq 대응).

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -34,4 +34,6 @@
 - Web: typedRoutes 활성 환경에서 router.replace 경로를 `Route`로 캐스팅(동적 쿼리 경로만 사용).
 - Web: /directory는 useSearchParams 요구에 맞게 Suspense로 감싸 프로덕션 빌드 오류 제거.
 - API: support 로그 로테이션에서 광범위 예외 제거 → (OSError, PermissionError)만 포착하고 경고 로깅. Bandit B110 해소.
- - Docs: `docs/m3_push_polish_plan_251007.md` 작성, `docs/plan_251007.md`에 링크 추가 및 다음 단계(After Merge Plan) 섹션 갱신.
+- Docs: `docs/m3_push_polish_plan_251007.md` 작성, `docs/plan_251007.md`에 링크 추가 및 다음 단계(After Merge Plan) 섹션 갱신.
+ - Web: admin notifications에 로그 정리(prune) UI 추가, 로그 표시 개수 선택(20/50/100/200) 지원, 암호화 상태 배지(ON/OFF) 강조.
+ - Docs: worklog 갱신 — admin notifications UI 폴리시 반영.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -37,5 +37,6 @@
 - Docs: `docs/m3_push_polish_plan_251007.md` 작성, `docs/plan_251007.md`에 링크 추가 및 다음 단계(After Merge Plan) 섹션 갱신.
  - Web: admin notifications에 로그 정리(prune) UI 추가, 로그 표시 개수 선택(20/50/100/200) 지원, 암호화 상태 배지(ON/OFF) 강조.
  - Docs: worklog 갱신 — admin notifications UI 폴리시 반영.
- - API: 통계 기간(range=24h/7d/30d) 파라미터 및 실패 코드 분포(404/410/others) 제공.
- - Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.
+- API: 통계 기간(range=24h/7d/30d) 파라미터 및 실패 코드 분포(404/410/others) 제공.
+- Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.
+ - Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -41,4 +41,5 @@
 - Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.
 - Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.
 - API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).
- - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
+- C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
+ - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -44,4 +44,4 @@
 - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
 - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
-- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성.
+ - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 UI 추가.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -46,3 +46,4 @@
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
 - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 UI 추가.
 - Web: vitest 3.2.4 업그레이드(GHSA-9crc-q9x8-hgqq 대응).
+- DB: Alembic 0012_member_post_extra_fields 추가(Member 회사/업종/주소 + Post category/pinned/cover 컬럼 생성).

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -37,3 +37,5 @@
 - Docs: `docs/m3_push_polish_plan_251007.md` 작성, `docs/plan_251007.md`에 링크 추가 및 다음 단계(After Merge Plan) 섹션 갱신.
  - Web: admin notifications에 로그 정리(prune) UI 추가, 로그 표시 개수 선택(20/50/100/200) 지원, 암호화 상태 배지(ON/OFF) 강조.
  - Docs: worklog 갱신 — admin notifications UI 폴리시 반영.
+ - API: 통계 기간(range=24h/7d/30d) 파라미터 및 실패 코드 분포(404/410/others) 제공.
+ - Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -33,4 +33,5 @@
 
 - Web: typedRoutes 활성 환경에서 router.replace 경로를 `Route`로 캐스팅(동적 쿼리 경로만 사용).
 - Web: /directory는 useSearchParams 요구에 맞게 Suspense로 감싸 프로덕션 빌드 오류 제거.
- - API: support 로그 로테이션에서 광범위 예외 제거 → (OSError, PermissionError)만 포착하고 경고 로깅. Bandit B110 해소.
+- API: support 로그 로테이션에서 광범위 예외 제거 → (OSError, PermissionError)만 포착하고 경고 로깅. Bandit B110 해소.
+ - Docs: `docs/m3_push_polish_plan_251007.md` 작성, `docs/plan_251007.md`에 링크 추가 및 다음 단계(After Merge Plan) 섹션 갱신.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -42,4 +42,5 @@
 - Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.
 - API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).
 - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
- - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
+- D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
+ - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -44,4 +44,4 @@
 - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.
 - D 초안: posts에 category/pinned/cover_image 도입, 목록 category 필터 + pinned 우선 정렬. 테스트 38 통과.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
- - Web: 고정 공지 섹션 분리(splitPinned) + PostCard를 next/image로 전환(핀 목록/비핀 목록 구분).
+- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한·공지 더보기 버튼, next/image remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성.

--- a/docs/dev_log_251007.md
+++ b/docs/dev_log_251007.md
@@ -40,4 +40,5 @@
 - API: 통계 기간(range=24h/7d/30d) 파라미터 및 실패 코드 분포(404/410/others) 제공.
 - Web: 기간 필터 드롭다운/요약 새로고침 버튼 추가, 실패 분포 표시. prune 응답에 기준시각(before) 표시.
 - Ops: re-key 스크립트(`ops/rekey_push_kek.py`) 추가 — KEK 로테이션 절차 문서(security_hardening.md)와 연동. ruff/pyright 통과.
- - API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).
+- API(B v1): /me 프로필 확장(회사/부서/직급/회사전화/개인·직장주소/업종), update_member_profile 복잡도 축소(model_dump).
+ - C v0: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터, /directory UI 입력·URL 동기화. 테스트 37 통과.

--- a/docs/dev_log_251008.md
+++ b/docs/dev_log_251008.md
@@ -1,0 +1,10 @@
+# dev_log_251008
+
+- chore(api): member/post 추가 필드 마이그레이션 추가 — Alembic `0012_member_post_extra_fields` (members 회사/부서/직급/회사전화/개인·직장주소/업종 · posts category/pinned/cover)
+- chore(web): vitest 3.2.4 상향 — 감사 취약점(GHSA-9crc-q9x8-hgqq) 대응
+- feat(web): 공지/소식 상세 페이지(`/posts/[id]`) 추가, 핀 공지 섹션 분리·3개 제한·"공지 전체 보기" 버튼, `next/image` 원격 도메인 구성(`NEXT_PUBLIC_IMAGE_DOMAINS`)
+
+## 검증
+- pytest: 38 passing
+- vitest: 3 passing
+- next build: OK

--- a/docs/m3_push_polish_plan_251007.md
+++ b/docs/m3_push_polish_plan_251007.md
@@ -1,0 +1,40 @@
+# M3 Push Polish — 운영 마감(251007)
+
+목표: Web Push 운영 경로의 문서화·관측·운영편의 보강으로 ‘실사용 가능한’ 품질 도달.
+
+## 범위(Scope)
+- 문서화: KEK(대칭키) 로테이션 절차, 장애/404/410 자동 무효화 운영 체크리스트.
+- 테스트: admin 발송 429 케이스 추가(동시/연속), invalid payload 422 확장, 통계 API 단위테스트.
+- 관리 UI: 로그 정리(prune) 버튼/피드백, 통계 기간 필터(최근 24h/7d/30d).
+- 보안/프라이버시: 로그 마스킹 규칙 재점검(엔드포인트 tail/해시만 노출 유지), 예외 시 실패-안전 코드 경로 재확인.
+
+비범위(Out of Scope)
+- 구독 정보 암호화 방식 변경(현재 AES‑GCM 유지)과 키 관리 외부화(KMS)는 M3.5로 분리.
+- 멤버 개인화 주제/토픽 구독은 후속 마일스톤.
+
+## 변경 계획(Tasks)
+1. 문서 보강
+   - `docs/pwa_push.md`: 운영 체크리스트 추가(레이트리밋, 404/410 자동 폐기, 백업/복구, 테스트 절차).
+   - `docs/security_hardening.md`: KEK 로테이션 절차(더블암호화/그레이스 기간), 로그 마스킹 표.
+2. API/테스트
+   - `POST /notifications/admin/notifications/test` 429: 연속 호출·동시 호출 케이스 추가.
+   - 통계 기간 필터: `GET /notifications/admin/notifications/stats?range=24h|7d|30d`.
+   - prune 결과 UI 피드백값 확장 `{deleted, before, range}`.
+3. Web(UI)
+   - Admin 화면에 기간 선택(24h/7d/30d), prune 버튼·결과 토스트, encryption 상태 강조.
+4. 관측/로그
+   - 실패 코드 분포(404/410/others) 요약을 통계에 포함.
+
+## 수락 기준(Definition of Done)
+- 문서 2종 업데이트 반영, 운영 체크리스트 포함.
+- 테스트 3+ 케이스 추가(429 동시성, invalid payload 422, 통계 기간 필터).
+- Admin UI에서 기간 필터·prune 동작 확인.
+- CI green(ruff/pyright/pytest/next build/semgrep/audit).
+
+## 리스크/대응
+- 레이트리밋 환경 의존성 → 테스트에서 ASGITransport IP 고정 사용(기존 패턴 준수).
+- 기간 필터 성능: SQLite 경로에서 날짜 비교 최적화(인덱스 부재 고려) 및 제한된 범위만 제공.
+
+## 참고
+- SSOT: `docs/architecture.md` Web Push 섹션, `docs/pwa_push.md`, `docs/security_hardening.md`.
+

--- a/docs/plan_251007.md
+++ b/docs/plan_251007.md
@@ -80,3 +80,10 @@
 ## 메모(SSOT 정합성)
 - `docs/Project_overview.md`에 반영된 IA/목적과 현재 라우트/화면 매핑 표는 유지·보완 중
 - 활성화 플로우(학번→이메일 매핑) 정책 합의 시 문서 우선 업데이트 후 구현 반영
+
+---
+
+## 다음 단계(After Merge Plan)
+- [진행] M3 Push Polish — Web Push 운영 마감 작업(문서/테스트/UI 보강)
+  - 세부 계획: `docs/m3_push_polish_plan_251007.md`
+  - 병행 영향이 적어 선행 착수 권장. 이후 B v2(프로필 검증), C v1(디렉터리 UX) 순으로 제안.

--- a/docs/pwa_push.md
+++ b/docs/pwa_push.md
@@ -49,7 +49,10 @@ PUSH_KEK=  # base64-encoded 16/24/32-byte key (recommend 32B)
   - res: `{ accepted: number, failed: number }`
 - `POST /admin/notifications/prune-logs` (운영자)
   - req: `{ older_than_days?: number }` (기본 30)
-  - res: `{ deleted: number }`
+  - res: `{ deleted: number, before: string, older_than_days: number }`
+- `GET /admin/notifications/stats` (운영자)
+  - query: `?range=24h|7d|30d` (기본 7d)
+  - res: `{ active_subscriptions, recent_accepted, recent_failed, encryption_enabled, range, failed_404?, failed_410?, failed_other? }`
 
 ## 프런트엔드 구현 절차
 1. 매니페스트에 아이콘(192/512)과 `display: 'standalone'`, `start_url` 정의.
@@ -58,6 +61,7 @@ PUSH_KEK=  # base64-encoded 16/24/32-byte key (recommend 32B)
 4. 권한이 `denied`이면 재시도 버튼/가이드(브라우저 설정 열기)를 제공.
 5. 서비스워커 `push` 이벤트에서 `showNotification(title, { body, icon, data: { url, tag } })` 처리. `notificationclick`에서 `clients.openWindow(data.url ?? '/')`.
 6. 개발환경에서는 SW를 기본 비활성(dev RSC 안정화). 필요 시 `NEXT_PUBLIC_ENABLE_SW=1`로 강제 등록.
+7. Admin UI(`/admin/notifications`): 테스트 발송·요약(기간 필터)·최근 로그·로그 정리(prune) 제공.
 
 ## 백엔드 구현 절차
 1. `pywebpush`(또는 동등 라이브러리)로 VAPID 서명 발송 구현.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -189,4 +189,5 @@
 - Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).
 - Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.
 - Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.
- - API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.
+- API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.
+ - API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -194,4 +194,4 @@
 - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
 - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
-- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성.
+ - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 페이지 추가.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -194,4 +194,4 @@
 - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
 - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
- - Web: 고정 공지 섹션 분리(splitPinned) 및 카드 이미지 next/image 적용.
+- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -178,4 +178,5 @@
 - API: support 티켓 저장용 TypedDict 필수/선택 키 명시(NotRequired)로 pyright 오류 해소.
  - Web: Next typedRoutes와 호환되도록 router.replace에 안전한 `Route` 캐스팅 적용.
  - Web: /directory 페이지에 Suspense 래퍼 추가(useSearchParams 규칙 준수). 프로덕션 빌드 오류 해결.
- - API: bandit(B110) 대응 — support 로그 로테이션에서 광범위 예외 대신 (OSError, PermissionError)만 포착하고 경고 로그 남김.
+- API: bandit(B110) 대응 — support 로그 로테이션에서 광범위 예외 대신 (OSError, PermissionError)만 포착하고 경고 로그 남김.
+ - Docs: M3 Push Polish 세부 계획 추가(`docs/m3_push_polish_plan_251007.md`), `docs/plan_251007.md` 다음 단계 섹션 갱신.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -184,3 +184,4 @@
  - API: notifications 통계(range=24h/7d/30d) 및 실패 분포(404/410/기타) 추가.
  - Web: admin notifications 요약에 기간 필터/실패 분포 표시, prune 응답의 기준시각(before) 토스트 출력.
  - Fix: pyright 호환(UTC alias→timezone.utc, ok 필드 캐스팅) 적용.
+ - Fix: ok 필드 bool 변환을 정수 비교로 교체(pyright reportGeneralTypeIssues 해소).

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -185,3 +185,4 @@
  - Web: admin notifications 요약에 기간 필터/실패 분포 표시, prune 응답의 기준시각(before) 토스트 출력.
  - Fix: pyright 호환(UTC alias→timezone.utc, ok 필드 캐스팅) 적용.
  - Fix: ok 필드 bool 변환을 정수 비교로 교체(pyright reportGeneralTypeIssues 해소).
+ - Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -187,4 +187,5 @@
  - Fix: ok 필드 bool 변환을 정수 비교로 교체(pyright reportGeneralTypeIssues 해소).
 - Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).
 - Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).
- - Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.
+- Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.
+ - Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -192,4 +192,5 @@
 - API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.
 - API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.
 - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
- - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
+- Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
+ - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -193,4 +193,5 @@
 - API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.
 - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
 - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
- - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
+- Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
+ - Web: 고정 공지 섹션 분리(splitPinned) 및 카드 이미지 next/image 적용.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -185,4 +185,5 @@
  - Web: admin notifications 요약에 기간 필터/실패 분포 표시, prune 응답의 기준시각(before) 토스트 출력.
  - Fix: pyright 호환(UTC alias→timezone.utc, ok 필드 캐스팅) 적용.
  - Fix: ok 필드 bool 변환을 정수 비교로 교체(pyright reportGeneralTypeIssues 해소).
- - Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).
+- Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).
+ - Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -194,4 +194,5 @@
 - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
 - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
- - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 페이지 추가.
+- Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 페이지 추가.
+- Web: vitest 3.2.4로 상향(GHSA-9crc-q9x8-hgqq 대응).

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -183,3 +183,4 @@
 - Web: admin notifications에 prune-logs UI 및 암호화 상태 배지 추가, 로그 표시 개수 선택 지원.
  - API: notifications 통계(range=24h/7d/30d) 및 실패 분포(404/410/기타) 추가.
  - Web: admin notifications 요약에 기간 필터/실패 분포 표시, prune 응답의 기준시각(before) 토스트 출력.
+ - Fix: pyright 호환(UTC alias→timezone.utc, ok 필드 캐스팅) 적용.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -191,4 +191,5 @@
 - Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.
 - API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.
 - API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.
- - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
+- API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.
+ - Web: vitest+RTL 도입, PostCard 스냅샷/렌더 테스트 추가, 공지/소식 카드 UI(카테고리 탭/핀 배지/썸네일) 적용.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -196,3 +196,4 @@
 - Web: 게시글 작성 폼에 category/pinned/cover_image 입력 연결.
 - Web: 고정 공지 섹션 분리(splitPinned), pinned 3개 제한/공지 더보기, next/image + remotePatterns(`NEXT_PUBLIC_IMAGE_DOMAINS`) 구성, /posts/[id] 상세 페이지 추가.
 - Web: vitest 3.2.4로 상향(GHSA-9crc-q9x8-hgqq 대응).
+- DB: 0012_member_post_extra_fields 마이그레이션 추가(회원 확장 필드/게시글 category/pinned/cover 컬럼 생성).

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -186,4 +186,5 @@
  - Fix: pyright 호환(UTC alias→timezone.utc, ok 필드 캐스팅) 적용.
  - Fix: ok 필드 bool 변환을 정수 비교로 교체(pyright reportGeneralTypeIssues 해소).
 - Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).
- - Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).
+- Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).
+ - Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -190,4 +190,5 @@
 - Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.
 - Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.
 - API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.
- - API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.
+- API/Web: 수첩 필터 확장(industry/company/region) — 목록/카운트 필터 및 /directory UI 입력·URL 동기화 추가. 테스트 37 통과.
+ - API: posts에 category/pinned/cover_image 필드 추가, 목록 category 필터 및 pinned 우선 정렬. 테스트 38 통과.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -180,4 +180,6 @@
  - Web: /directory 페이지에 Suspense 래퍼 추가(useSearchParams 규칙 준수). 프로덕션 빌드 오류 해결.
 - API: bandit(B110) 대응 — support 로그 로테이션에서 광범위 예외 대신 (OSError, PermissionError)만 포착하고 경고 로그 남김.
 - Docs: M3 Push Polish 세부 계획 추가(`docs/m3_push_polish_plan_251007.md`), `docs/plan_251007.md` 다음 단계 섹션 갱신.
- - Web: admin notifications에 prune-logs UI 및 암호화 상태 배지 추가, 로그 표시 개수 선택 지원.
+- Web: admin notifications에 prune-logs UI 및 암호화 상태 배지 추가, 로그 표시 개수 선택 지원.
+ - API: notifications 통계(range=24h/7d/30d) 및 실패 분포(404/410/기타) 추가.
+ - Web: admin notifications 요약에 기간 필터/실패 분포 표시, prune 응답의 기준시각(before) 토스트 출력.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -179,4 +179,5 @@
  - Web: Next typedRoutes와 호환되도록 router.replace에 안전한 `Route` 캐스팅 적용.
  - Web: /directory 페이지에 Suspense 래퍼 추가(useSearchParams 규칙 준수). 프로덕션 빌드 오류 해결.
 - API: bandit(B110) 대응 — support 로그 로테이션에서 광범위 예외 대신 (OSError, PermissionError)만 포착하고 경고 로그 남김.
- - Docs: M3 Push Polish 세부 계획 추가(`docs/m3_push_polish_plan_251007.md`), `docs/plan_251007.md` 다음 단계 섹션 갱신.
+- Docs: M3 Push Polish 세부 계획 추가(`docs/m3_push_polish_plan_251007.md`), `docs/plan_251007.md` 다음 단계 섹션 갱신.
+ - Web: admin notifications에 prune-logs UI 및 암호화 상태 배지 추가, 로그 표시 개수 선택 지원.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -188,4 +188,5 @@
 - Fix: 통계 계산 제너레이터 → 루프 재작성(SQLAlchemy InstrumentedAttribute 비교 시 pyright 오진 회피).
 - Test: invalid endpoint 422, stats range 파라미터 반환 검증 추가(총 33 통과).
 - Ops: re-key 스크립트(ops/rekey_push_kek.py) 추가 및 KEK 로테이션 절차 문서화.
- - Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.
+- Test: 동시성 레이트리밋 케이스 추가(동시 2요청 중 최소 1건 429 보장). 전체 34 테스트 통과.
+ - API: /me 프로필 확장 — 회사/부서/직급/회사전화/개인·직장주소/업종 필드 추가 및 업데이트 지원. 테스트 36 통과.

--- a/ops/rekey_push_kek.py
+++ b/ops/rekey_push_kek.py
@@ -1,0 +1,157 @@
+"""
+구독 at-rest 암호화 KEK 교체(Re-key) 스크립트
+
+주의사항
+- 운영 전용. 실행 전 전체 백업 필수.
+- 환경변수 `REKEY_OLD_PUSH_KEK`, `REKEY_NEW_PUSH_KEK`에
+  base64 인코딩된 키를 주입해야 함.
+- 모든 `push_subscriptions` 행을 순회하여 endpoint/p256dh/auth를 새 키로 재암호화.
+- 해시는 평문 endpoint 기준이므로 변화 없음. (필요 시 무결성 확인)
+
+사용 예시
+  $ REKEY_OLD_PUSH_KEK=... REKEY_NEW_PUSH_KEK=... \
+    python -m ops.rekey_push_kek --dry-run
+  $ REKEY_OLD_PUSH_KEK=... REKEY_NEW_PUSH_KEK=... \
+    python -m ops.rekey_push_kek --limit 1000
+
+다운타임 전략
+- 짧은 유지보수 창 권장. 또는 쓰기 중단(구독 등록/삭제) 후 실행.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Final
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from sqlalchemy.orm import Session
+
+from apps.api import models
+from apps.api.db import SessionLocal
+
+PREFIX: Final = "enc:v1:"
+
+
+@dataclass
+class Keys:
+    old: bytes
+    new: bytes
+
+
+def _require_keys_from_env() -> Keys:
+    def _decode(name: str) -> bytes:
+        v = os.environ.get(name, "").strip()
+        if not v:
+            raise RuntimeError(f"환경변수 {name} 가 비어있습니다")
+        try:
+            b = base64.b64decode(v)
+        except (binascii.Error, ValueError) as e:
+            raise RuntimeError(f"{name} base64 디코드 실패: {e}") from e
+        if len(b) not in (16, 24, 32):
+            raise RuntimeError(
+                f"{name} 길이({len(b)})가 AES 키 길이가 아닙니다(16/24/32)"
+            )
+        return b
+
+    return Keys(old=_decode("REKEY_OLD_PUSH_KEK"), new=_decode("REKEY_NEW_PUSH_KEK"))
+
+
+def _is_encrypted(s: str) -> bool:
+    return s.startswith(PREFIX)
+
+
+def _enc_with(key: bytes, plaintext: str) -> str:
+    aes = AESGCM(key)
+    nonce = os.urandom(12)
+    ct = aes.encrypt(nonce, plaintext.encode("utf-8"), None)
+    return PREFIX + base64.b64encode(nonce + ct).decode("ascii")
+
+
+def _dec_with(key: bytes, ciphertext: str) -> str:
+    if not _is_encrypted(ciphertext):
+        return ciphertext
+    data = base64.b64decode(ciphertext[len(PREFIX) :])
+    nonce, ct = data[:12], data[12:]
+    aes = AESGCM(key)
+    pt = aes.decrypt(nonce, ct, None)
+    return pt.decode("utf-8")
+
+
+def _hash_endpoint(endpoint_plain: str) -> str:
+    return hashlib.sha256(endpoint_plain.encode()).hexdigest()
+
+
+def rekey_once(
+    db: Session, keys: Keys, *, dry_run: bool = False, limit: int | None = None
+) -> tuple[int, int]:
+    updated = 0
+    scanned = 0
+    q = db.query(models.PushSubscription).order_by(models.PushSubscription.id.asc())
+    if limit is not None:
+        q = q.limit(limit)
+    for row in q:
+        scanned += 1
+        # 복호화 시도: old → new 순으로 시그널링
+        def _dec_guess(s: str) -> str:
+            if not _is_encrypted(s):
+                return s
+            try:
+                return _dec_with(keys.old, s)
+            except InvalidTag:
+                # 이미 신규 키로 암호화된 경우
+                try:
+                    return _dec_with(keys.new, s)
+                except InvalidTag as e:
+                    raise RuntimeError("Cannot decrypt with old/new key; 중단") from e
+
+        ep_pt = _dec_guess(str(row.endpoint))
+        k_pt = _dec_guess(str(row.p256dh))
+        a_pt = _dec_guess(str(row.auth))
+
+        ep_new = _enc_with(keys.new, ep_pt)
+        k_new = _enc_with(keys.new, k_pt)
+        a_new = _enc_with(keys.new, a_pt)
+
+        need_update = (
+            str(row.endpoint) != ep_new
+            or str(row.p256dh) != k_new
+            or str(row.auth) != a_new
+        )
+        if need_update:
+            updated += 1
+            if not dry_run:
+                row.endpoint = ep_new
+                row.p256dh = k_new
+                row.auth = a_new
+                row.endpoint_hash = _hash_endpoint(ep_pt)
+                db.add(row)
+    if not dry_run and updated:
+        db.commit()
+    return scanned, updated
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Re-key push_subscriptions to a new KEK"
+    )
+    p.add_argument(
+        "--dry-run", action="store_true", help="DB 갱신 없이 스캔/비교만 수행"
+    )
+    p.add_argument("--limit", type=int, default=None, help="처리 행 수 제한(기본 전체)")
+    args = p.parse_args()
+
+    keys = _require_keys_from_env()
+    with SessionLocal() as db:
+        scanned, updated = rekey_once(db, keys, dry_run=args.dry_run, limit=args.limit)
+        print(f"scanned={scanned} updated={updated} dry_run={args.dry_run}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: 2.1.4
-        version: 2.1.4(@types/node@22.7.8)(jsdom@25.0.1)
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@22.7.8)(jsdom@25.0.1)
 
   packages/schemas:
     devDependencies:
@@ -724,6 +724,12 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -898,37 +904,34 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/expect@2.1.4':
-    resolution: {integrity: sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==}
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/mocker@2.1.4':
-    resolution: {integrity: sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==}
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.4':
-    resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/runner@2.1.4':
-    resolution: {integrity: sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==}
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/snapshot@2.1.4':
-    resolution: {integrity: sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==}
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@2.1.4':
-    resolution: {integrity: sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==}
-
-  '@vitest/utils@2.1.4':
-    resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1292,6 +1295,9 @@ packages:
   es-iterator-helpers@1.2.1:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1784,6 +1790,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -2052,8 +2061,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -2367,6 +2376,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2426,12 +2438,12 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -2522,9 +2534,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite-node@2.1.4:
-    resolution: {integrity: sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@5.4.20:
@@ -2558,19 +2570,22 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.4:
-    resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.4
-      '@vitest/ui': 2.1.4
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -3168,6 +3183,12 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3338,49 +3359,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/expect@2.1.4':
+  '@vitest/expect@3.2.4':
     dependencies:
-      '@vitest/spy': 2.1.4
-      '@vitest/utils': 2.1.4
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.3.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.4(vite@5.4.20(@types/node@22.7.8))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.7.8))':
     dependencies:
-      '@vitest/spy': 2.1.4
+      '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
       vite: 5.4.20(@types/node@22.7.8)
 
-  '@vitest/pretty-format@2.1.4':
+  '@vitest/pretty-format@3.2.4':
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@2.1.9':
+  '@vitest/runner@3.2.4':
     dependencies:
-      tinyrainbow: 1.2.0
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
-  '@vitest/runner@2.1.4':
+  '@vitest/snapshot@3.2.4':
     dependencies:
-      '@vitest/utils': 2.1.4
-      pathe: 1.1.2
-
-  '@vitest/snapshot@2.1.4':
-    dependencies:
-      '@vitest/pretty-format': 2.1.4
+      '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.19
-      pathe: 1.1.2
+      pathe: 2.0.3
 
-  '@vitest/spy@2.1.4':
+  '@vitest/spy@3.2.4':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.4
 
-  '@vitest/utils@2.1.4':
+  '@vitest/utils@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 2.1.4
+      '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3809,6 +3828,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4422,6 +4443,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -4698,7 +4721,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  pathe@1.1.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -5089,6 +5112,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:
       client-only: 0.0.1
@@ -5160,9 +5187,9 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@1.2.0: {}
+  tinyrainbow@2.0.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -5285,11 +5312,12 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.1.4(@types/node@22.7.8):
+  vite-node@3.2.4(@types/node@22.7.8):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@9.4.0)
-      pathe: 1.1.2
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
       vite: 5.4.20(@types/node@22.7.8)
     transitivePeerDependencies:
       - '@types/node'
@@ -5311,27 +5339,30 @@ snapshots:
       '@types/node': 22.7.8
       fsevents: 2.3.3
 
-  vitest@2.1.4(@types/node@22.7.8)(jsdom@25.0.1):
+  vitest@3.2.4(@types/node@22.7.8)(jsdom@25.0.1):
     dependencies:
-      '@vitest/expect': 2.1.4
-      '@vitest/mocker': 2.1.4(vite@5.4.20(@types/node@22.7.8))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.4
-      '@vitest/snapshot': 2.1.4
-      '@vitest/spy': 2.1.4
-      '@vitest/utils': 2.1.4
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.7.8))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.3.3
       debug: 4.4.3(supports-color@9.4.0)
       expect-type: 1.2.2
       magic-string: 0.30.19
-      pathe: 1.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 5.4.20(@types/node@22.7.8)
-      vite-node: 2.1.4(@types/node@22.7.8)
+      vite-node: 3.2.4(@types/node@22.7.8)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.7.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
       '@eslint/eslintrc':
         specifier: 3.3.1
         version: 3.3.1
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.2.0
+        version: 16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/node':
         specifier: 22.7.8
         version: 22.7.8
@@ -57,6 +63,9 @@ importers:
       eslint-plugin-promise:
         specifier: 7.2.1
         version: 7.2.1(eslint@9.36.0(jiti@2.6.1))
+      jsdom:
+        specifier: 25.0.1
+        version: 25.0.1
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -66,6 +75,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.7.8)(jsdom@25.0.1)
 
   packages/schemas:
     devDependencies:
@@ -75,9 +87,15 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -87,6 +105,38 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
@@ -95,6 +145,144 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -380,6 +568,116 @@ packages:
     resolution: {integrity: sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -397,8 +695,34 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.2.0':
+    resolution: {integrity: sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -574,6 +898,38 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@2.1.4':
+    resolution: {integrity: sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==}
+
+  '@vitest/mocker@2.1.4':
+    resolution: {integrity: sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.4':
+    resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.4':
+    resolution: {integrity: sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==}
+
+  '@vitest/snapshot@2.1.4':
+    resolution: {integrity: sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==}
+
+  '@vitest/spy@2.1.4':
+    resolution: {integrity: sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==}
+
+  '@vitest/utils@2.1.4':
+    resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -607,6 +963,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -623,6 +983,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -660,12 +1023,19 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
@@ -712,6 +1082,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -735,12 +1109,24 @@ packages:
   caniuse-lite@1.0.30001745:
     resolution: {integrity: sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -759,6 +1145,10 @@ packages:
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -770,16 +1160,27 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -810,6 +1211,13 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -820,6 +1228,14 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.1:
     resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
@@ -834,6 +1250,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -850,6 +1272,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -882,6 +1308,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1009,9 +1440,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1068,6 +1506,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1156,9 +1598,21 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1175,6 +1629,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
@@ -1259,6 +1717,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1327,6 +1788,15 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1379,12 +1849,25 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1397,6 +1880,18 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1467,6 +1962,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1536,6 +2034,9 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1550,6 +2051,13 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1627,6 +2135,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1645,6 +2157,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -1655,6 +2170,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1688,6 +2207,17 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1702,6 +2232,13 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -1755,6 +2292,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1765,6 +2305,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1813,6 +2359,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1847,6 +2397,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@3.4.13:
     resolution: {integrity: sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==}
     engines: {node: '>=14.0.0'}
@@ -1859,13 +2412,46 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1936,6 +2522,87 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vite-node@2.1.4:
+    resolution: {integrity: sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.4:
+    resolution: {integrity: sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.4
+      '@vitest/ui': 2.1.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1957,6 +2624,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -1968,6 +2640,25 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
@@ -1987,7 +2678,17 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -1996,6 +2697,28 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/runtime@7.28.4': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -2011,6 +2734,75 @@ snapshots:
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.6.1))':
@@ -2257,6 +3049,72 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
@@ -2272,10 +3130,43 @@ snapshots:
       '@tanstack/query-core': 5.62.2
       react: 19.1.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2447,6 +3338,50 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@2.1.4':
+    dependencies:
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.4(vite@5.4.20(@types/node@22.7.8))':
+    dependencies:
+      '@vitest/spy': 2.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 5.4.20(@types/node@22.7.8)
+
+  '@vitest/pretty-format@2.1.4':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.4':
+    dependencies:
+      '@vitest/utils': 2.1.4
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.4':
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      magic-string: 0.30.19
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.4':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.4':
+    dependencies:
+      '@vitest/pretty-format': 2.1.4
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -2472,6 +3407,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -2484,6 +3421,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -2554,9 +3495,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
@@ -2603,6 +3548,8 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2626,12 +3573,27 @@ snapshots:
 
   caniuse-lite@1.0.30001745: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   change-case@5.4.4: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -2655,6 +3617,10 @@ snapshots:
 
   colorette@1.4.0: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -2665,11 +3631,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -2699,6 +3677,10 @@ snapshots:
     optionalDependencies:
       supports-color: 9.4.0
 
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2713,6 +3695,10 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.1:
     optional: true
 
@@ -2723,6 +3709,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2737,6 +3727,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -2838,6 +3830,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   escalade@3.2.0: {}
 
@@ -3043,7 +4061,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.2.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3103,6 +4127,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -3200,12 +4232,27 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3217,6 +4264,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
 
@@ -3304,6 +4353,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3375,6 +4426,34 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -3421,11 +4500,21 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -3435,6 +4524,14 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -3494,6 +4591,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  nwsapi@2.2.22: {}
 
   object-assign@4.1.1: {}
 
@@ -3584,6 +4683,10 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3594,6 +4697,10 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -3654,6 +4761,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3671,6 +4784,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react@19.1.1: {}
 
   read-cache@1.0.0:
@@ -3680,6 +4795,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3721,6 +4841,38 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rollup@4.52.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3743,6 +4895,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
 
@@ -3836,11 +4994,17 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3919,6 +5083,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.1.1):
@@ -3943,6 +5111,8 @@ snapshots:
   supports-color@9.4.0: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@3.4.13:
     dependencies:
@@ -3979,14 +5149,38 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -4091,6 +5285,85 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite-node@2.1.4(@types/node@22.7.8):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@9.4.0)
+      pathe: 1.1.2
+      vite: 5.4.20(@types/node@22.7.8)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.20(@types/node@22.7.8):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.4
+    optionalDependencies:
+      '@types/node': 22.7.8
+      fsevents: 2.3.3
+
+  vitest@2.1.4(@types/node@22.7.8)(jsdom@25.0.1):
+    dependencies:
+      '@vitest/expect': 2.1.4
+      '@vitest/mocker': 2.1.4(vite@5.4.20(@types/node@22.7.8))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.4
+      '@vitest/snapshot': 2.1.4
+      '@vitest/spy': 2.1.4
+      '@vitest/utils': 2.1.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@9.4.0)
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.20(@types/node@22.7.8)
+      vite-node: 2.1.4(@types/node@22.7.8)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.7.8
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4136,6 +5409,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -4149,6 +5427,12 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml-ast-parser@0.0.43: {}
 

--- a/tests/api/test_directory_filters_v0.py
+++ b/tests/api/test_directory_filters_v0.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+from apps.api import models
+from apps.api.db import get_db
+from apps.api.main import app
+
+
+def _seed_members(n: int = 5) -> None:
+    override = app.dependency_overrides.get(get_db)
+    assert override is not None
+    gen = override()
+    db = next(gen)
+    try:
+        # clear existing for deterministic results
+        db.query(models.Member).delete()
+        # seed
+        payloads = [
+            dict(
+                email="a@example.com",
+                name="Alice",
+                cohort=1,
+                major="Economics",
+                company="Acme",
+                industry="Manufacturing",
+                addr_personal="Seoul",
+                addr_company="Seoul",
+            ),
+            dict(
+                email="b@example.com",
+                name="Bob",
+                cohort=1,
+                major="Business",
+                company="Beta",
+                industry="Finance",
+                addr_personal="Busan",
+                addr_company="Seoul",
+            ),
+            dict(
+                email="c@example.com",
+                name="Charlie",
+                cohort=2,
+                major="Economics",
+                company="Acme",
+                industry="Finance",
+                addr_personal="Incheon",
+                addr_company="Incheon",
+            ),
+            dict(
+                email="d@example.com",
+                name="Dana",
+                cohort=2,
+                major="Law",
+                company="Delta",
+                industry="Manufacturing",
+                addr_personal="Daegu",
+                addr_company="Busan",
+            ),
+            dict(
+                email="e@example.com",
+                name="Eve",
+                cohort=3,
+                major="Economics",
+                company="Echo",
+                industry="IT",
+                addr_personal="Seoul",
+                addr_company="Seoul",
+            ),
+        ]
+        for p in payloads:
+            db.add(models.Member(**p, roles="member"))
+        db.commit()
+    finally:
+        db.close()
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+
+def test_filter_by_industry_and_company_and_region(client: TestClient) -> None:
+    _seed_members()
+
+    # industry=Finance → expected two (c, b)
+    r1 = client.get("/members/count", params={"industry": "Finance"})
+    assert r1.status_code == HTTPStatus.OK
+    finance_expected = 2
+    assert r1.json()["count"] == finance_expected
+
+    # company=Acme → expected two (a, c)
+    r2 = client.get("/members/count", params={"company": "Acme"})
+    assert r2.status_code == HTTPStatus.OK
+    acme_expected = 2
+    assert r2.json()["count"] == acme_expected
+
+    # region=Seoul → in personal or company address (a, e, b)
+    r3 = client.get("/members/count", params={"region": "Seoul"})
+    assert r3.status_code == HTTPStatus.OK
+    seoul_expected = 3
+    assert r3.json()["count"] == seoul_expected
+
+    # combo: industry=Manufacturing & region=Seoul → only 'a'
+    r4 = client.get(
+        "/members/count", params={"industry": "Manufacturing", "region": "Seoul"}
+    )
+    assert r4.status_code == HTTPStatus.OK
+    assert r4.json()["count"] == 1

--- a/tests/api/test_notifications_auth.py
+++ b/tests/api/test_notifications_auth.py
@@ -85,3 +85,16 @@ async def test_admin_send_rate_limit_429(admin_login: TestClient) -> None:
             assert r2.status_code == HTTPStatus.TOO_MANY_REQUESTS
     finally:
         app.dependency_overrides.pop(router_mod.get_push_provider, None)
+
+
+def test_subscription_invalid_endpoint_422(member_login: TestClient) -> None:
+    client = member_login
+    res = client.post(
+        "/notifications/subscriptions",
+        json={
+            "endpoint": "not-a-url",
+            "p256dh": "k",
+            "auth": "a",
+        },
+    )
+    assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/api/test_notifications_rate_concurrency.py
+++ b/tests/api/test_notifications_rate_concurrency.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+from http import HTTPStatus
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api import models
+from apps.api.main import app
+from apps.api.routers import notifications as router_mod
+from apps.api.services.notifications_service import PushProvider
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _DummyProvider(PushProvider):
+    def send(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        return (True, 201)
+
+
+@pytest.mark.anyio
+async def test_admin_send_rate_limit_concurrent(admin_login: TestClient) -> None:
+    app.dependency_overrides[router_mod.get_push_provider] = lambda: _DummyProvider()
+    try:
+        transport = httpx.ASGITransport(app=app, client=("5.6.7.8", 55555))
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://local"
+        ) as hc:
+            rc_login = await hc.post(
+                "/auth/login",
+                json={"email": "__seed__@example.com", "password": "__seed__"},
+            )
+            assert rc_login.status_code == HTTPStatus.OK
+
+            # 한 세션에 구독 하나 등록
+            rs = await hc.post(
+                "/notifications/subscriptions",
+                json={
+                    "endpoint": "https://example.com/ep/conc",
+                    "p256dh": "k",
+                    "auth": "a",
+                },
+            )
+            assert rs.status_code == HTTPStatus.NO_CONTENT
+
+            payload = {"title": "t", "body": "b"}
+
+            async def _send() -> int:
+                r = await hc.post(
+                    "/notifications/admin/notifications/test", json=payload
+                )
+                return r.status_code
+
+            # 동시 2요청 → 최소 1개는 429(보수적 조건; 둘 다 429도 가능)
+            s1, s2 = await asyncio.gather(_send(), _send())
+            statuses = [s1, s2]
+            assert statuses.count(HTTPStatus.TOO_MANY_REQUESTS) >= 1
+            assert statuses.count(HTTPStatus.ACCEPTED) <= 1
+    finally:
+        app.dependency_overrides.pop(router_mod.get_push_provider, None)

--- a/tests/api/test_notifications_stats.py
+++ b/tests/api/test_notifications_stats.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+
+def test_stats_range_param(admin_login: TestClient) -> None:
+    client = admin_login
+    for r in ("24h", "7d", "30d"):
+        res = client.get(f"/notifications/admin/notifications/stats?range={r}")
+        assert res.status_code == HTTPStatus.OK
+        data = res.json()
+        assert data.get("range") == r
+

--- a/tests/api/test_posts_news_notice.py
+++ b/tests/api/test_posts_news_notice.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+from apps.api import models
+from apps.api.db import get_db
+from apps.api.main import app
+
+
+def _seed_author() -> int:
+    override = app.dependency_overrides.get(get_db)
+    assert override is not None
+    gen = override()
+    db = next(gen)
+    try:
+        m = models.Member(email="author@example.com", name="Author", cohort=2025)
+        db.add(m)
+        db.commit()
+        db.refresh(m)
+        return int(m.id)
+    finally:
+        db.close()
+        try:
+            gen.close()
+        except Exception:
+            pass
+
+
+def test_posts_category_pinned_cover_image(admin_login: TestClient) -> None:
+    client = admin_login
+    author_id = _seed_author()
+
+    # create posts: notice (pinned), notice, news
+    p1 = client.post(
+        "/posts/",
+        json={
+            "author_id": author_id,
+            "title": "Notice Pinned",
+            "content": "Body1",
+            "published_at": None,
+            "category": "notice",
+            "pinned": True,
+            "cover_image": "https://example.com/cover1.png",
+        },
+    )
+    assert p1.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+    data1 = p1.json()
+    assert data1.get("category") == "notice" and data1.get("pinned") is True
+    assert data1.get("cover_image") == "https://example.com/cover1.png"
+
+    p2 = client.post(
+        "/posts/",
+        json={
+            "author_id": author_id,
+            "title": "Notice",
+            "content": "Body2",
+            "published_at": None,
+            "category": "notice",
+            "pinned": False,
+        },
+    )
+    assert p2.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+
+    p3 = client.post(
+        "/posts/",
+        json={
+            "author_id": author_id,
+            "title": "News",
+            "content": "Body3",
+            "published_at": None,
+            "category": "news",
+        },
+    )
+    assert p3.status_code in (HTTPStatus.CREATED, HTTPStatus.OK)
+
+    # list only notice
+    r = client.get("/posts/?limit=10&offset=0&category=notice")
+    assert r.status_code == HTTPStatus.OK
+    lst = r.json()
+    expected = 2
+    assert len(lst) == expected
+    # pinned first
+    assert lst[0]["pinned"] is True

--- a/tests/api/test_profile_fields_v1.py
+++ b/tests/api/test_profile_fields_v1.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+
+def test_me_profile_has_new_fields_defaults(member_login: TestClient) -> None:
+    res = member_login.get("/me/")
+    assert res.status_code == HTTPStatus.OK
+    data = res.json()
+    # 신규 필드 존재 및 기본 None
+    for k in (
+        "company",
+        "department",
+        "job_title",
+        "company_phone",
+        "addr_personal",
+        "addr_company",
+        "industry",
+    ):
+        assert k in data
+        assert data[k] is None
+
+
+def test_me_update_new_fields_roundtrip(member_login: TestClient) -> None:
+    payload = {
+        "company": "Acme Corp",
+        "department": "R&D",
+        "job_title": "Engineer",
+        "company_phone": "02-1234-5678",
+        "addr_personal": "Seoul, KR",
+        "addr_company": "Mapo-gu, Seoul, KR",
+        "industry": "Manufacturing",
+    }
+    res = member_login.put("/me/", json=payload)
+    assert res.status_code == HTTPStatus.OK
+    data = res.json()
+    for k, v in payload.items():
+        assert data.get(k) == v
+
+    res2 = member_login.get("/me/")
+    assert res2.status_code == HTTPStatus.OK
+    data2 = res2.json()
+    for k, v in payload.items():
+        assert data2.get(k) == v
+


### PR DESCRIPTION
# M3 Push Polish — 운영 마감(문서/테스트/UI 보강)

## 배경/목적
- Web Push 경로를 실운영 품질로 마감: 문서화(KEK 로테이션/운영 체크리스트), 테스트 보강(429/422/기간 통계), Admin UI 운영 편의(로그 정리·기간 필터·암호화 배지).
- SSOT 문서(`docs/architecture.md`, `docs/pwa_push.md`, `docs/security_hardening.md`)와 정합성 유지.

## 주요 변경사항
- API
  - `GET /notifications/admin/notifications/stats?range=24h|7d|30d` 지원(기본 7d), 실패 분포 필드(404/410/기타) 포함
  - `POST /notifications/admin/notifications/prune-logs` 응답 확장: `{ deleted, before, older_than_days }`
  - 레이트리밋: 1/min/IP 테스트(연속/동시) 추가, invalid endpoint 422 케이스 추가
- Web(Admin)
  - 기간 필터·요약 새로고침 버튼, 실패 분포 표시
  - 로그 정리(prune) UI와 결과 토스트(기준시각 before) 표시
  - 최근 로그 표시 개수 선택(20/50/100/200), 암호화 상태 배지(ON/OFF)
- Ops/문서
  - `ops/rekey_push_kek.py`(드라이런/제한 옵션) 추가 — KEK 로테이션 절차 문서화(`docs/security_hardening.md`)
  - `docs/pwa_push.md` 스펙 업데이트(통계 range/분포, prune 응답 확장), dev_log/worklog 갱신

## 스크린샷/데모(선택)
- Admin: `/admin/notifications` — 기간 필터·prune 버튼·요약/로그 테이블(필요 시 캡처 추가 가능)

## 테스트 노트
- 자동
  - pytest 34 passing (레이트리밋 동시성 포함), ruff/pyright OK, Next.js build OK
- 수동
  - 멤버 로그인 후 구독 저장 → Admin 로그인 → `/admin/notifications`에서 테스트 발송/요약/로그/정리 확인

## 배포/롤백
- 배포 전 체크: VAPID 키/주체 설정, (선택) at-rest 암호화 `PUSH_ENCRYPT_AT_REST=true`, `PUSH_KEK` 주입
- KEK 로테이션 실행(요약)
  1) 드라이런: `REKEY_OLD_PUSH_KEK=... REKEY_NEW_PUSH_KEK=... python -m ops.rekey_push_kek --dry-run`
  2) 실행:    `REKEY_OLD_PUSH_KEK=... REKEY_NEW_PUSH_KEK=... python -m ops.rekey_push_kek`
  3) 전환:    `PUSH_KEK`를 NEW로 교체 후 롤링 재시작 → Admin UI로 검증
- 롤백: OLD KEK 복원, 필요한 경우 백업 복구

---

## Draft 체크리스트(초안 단계)
- [x] 문제 정의와 범위를 템플릿에 명시했다
- [x] API/DB/Web 중 어디를 건드리는지 표시했다
- [x] 남은 TODO를 본문에 정리했다(작은 단위 권장)

## Ready for Review 체크리스트(검토 요청 시)
- 일반
  - [x] Conventional Commits 규칙을 따른다
  - [x] 한국어 커밋/PR 설명, 한국어 코드 주석
  - [x] `docs/worklog.md`/`docs/dev_log_YYMMDD.md` 갱신 포함
- 품질/규칙(Repo Guards와 일치)
  - [x] 린트 우회 주석 없음(허용 예외 없음)
  - [x] 모듈 600줄 이하/복잡도 ≤10/순환 import 없음
  - [x] TS any/이중 캐스트/과도한 non-null 미사용, Python Any 기반 페이로드 회피
- API
  - [x] `ruff`/`pyright` 통과(우회 주석 없이)
  - [x] (필요 시) alembic upgrade head 확인 — 본 PR 마이그레이션 없음
  - [x] 레이트리밋/보안정책 영향 `docs/security_hardening.md` 반영
- Web
  - [x] `pnpm -C apps/web build` 성공
  - [x] ESLint(Flat config) 통과, 우회 주석 없음
- 문서
  - [x] SSOT 문서들과 모순 없음
