### PR TITLE
feat(web): DS v1 — 디렉터리 모바일 카드 뷰/필터 (Phase 2)


### DIFF
--- a/docs/dev_log_251010.md
+++ b/docs/dev_log_251010.md
@@ -13,3 +13,7 @@
 
 - Build
   - apps/web에 puppeteer(dev) 추가 후 루트에서 `pnpm install --lockfile-only`로 pnpm-lock.yaml 동기화.
+
+- DS v1 Phase 2 킥오프
+  - 브랜치 생성: `feat/ds-v1-phase2-directory-mobile`
+  - 계획서 보강: `docs/plan_ds_v1_phase2_directory_mobile.md` — DoD/체크리스트/E2E 항목 추가(2025-10-10)

--- a/docs/plan_ds_v1_phase2_directory_mobile.md
+++ b/docs/plan_ds_v1_phase2_directory_mobile.md
@@ -1,4 +1,4 @@
-# DS v1 Phase 2 — 디렉터리 모바일 카드 뷰/필터(초안)
+# DS v1 Phase 2 — 디렉터리 모바일 카드 뷰/필터 (Kickoff 2025-10-10)
 
 ## 목적
 - 모바일에서 가독성과 상호작용성을 높이기 위해 카드 뷰를 도입하고, 필터 UI를 아코디언/풀폭으로 개선한다.
@@ -13,14 +13,21 @@
    - 카드 내부 이미지/아이콘 없으면 텍스트만, 무한스크롤 버튼 영역 재배치
 
 ## DoD
-- [ ] md 미만 카드, md 이상 테이블 유지
-- [ ] vitest: 카드 렌더/펼치기/아코디언/공유 링크 토글
-- [ ] Lighthouse(/directory): 모바일 Perf/A11y ≥ 0.90
+- [ ] 반응형: md 미만 카드 뷰, md 이상 테이블 유지(접근성 보존)
+- [ ] 상호작용: 카드 펼치기(aria-expanded/키보드 토글), 아코디언 필터, 공유 링크 토글 버튼화
+- [ ] 테스트(vitest): 카드 렌더/펼치기/아코디언/공유 링크 토글
+- [ ] E2E(CDP): URL 동기화·카드 펼치기 스모크 추가(`/directory`)
+- [ ] 성능/접근성: Lighthouse(모바일) Perf/A11y ≥ 0.90 유지, 예산 준수(lighthouse-budget.json)
 
 ## 브랜치/PR
 - branch: `feat/ds-v1-phase2-directory-mobile`
 - PR Title: `feat(web): DS v1 — 디렉터리 모바일 카드 뷰/필터`
 - 정책: Draft 시작 → 카드/테스트/LH 그린 후 Ready
+- 체크리스트(머지 전):
+  - [ ] vitest 그린, `pnpm -C apps/web build` 그린
+  - [ ] E2E(CDP) `/directory` 스모크 통과
+  - [ ] Lighthouse 리포트 링크 PR 코멘트 확인(Perf/A11y ≥ 0.90)
 
 ## 리스크/메모
 - 데이터 행 수↑에서 스크롤 성능 주의(가상화는 후속 검토)
+- 아코디언/카드 토글 상태가 URL과 엮이지 않도록(뒤로가기 UX 저하 방지)

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -238,3 +238,4 @@
  - Web/Tabs: `defaultIndex`가 비활성 탭을 가리키는 경우 첫 활성 탭으로 보정, Home/End 키 입력 시 선택 변경과 함께 포커스 이동 처리(접근성 보완).
 - Build: puppeteer(dev) 추가에 따른 pnpm-lock.yaml 갱신(워크스페이스 루트에서 lockfile-only).
  - Web/Tabs: 키 핸들러 복잡도(ESLint complexity) ↓ — 키→핸들러 매핑/공통 util로 분기 단순화.
+ - DS v1 Phase 2 킥오프: 브랜치 생성(`feat/ds-v1-phase2-directory-mobile`), 계획서 보강(DoD/체크리스트/E2E 추가).


### PR DESCRIPTION
DS v1 Phase 2 — 디렉터리 모바일 카드 뷰/필터 (Kickoff 2025-10-10)

목표
- 모바일 가독성·상호작용 개선: 카드 뷰 도입, 필터 UI 아코디언/풀폭, URL 동기화 유지
- 성능·접근성: Lighthouse(모바일) Perf/A11y ≥ 0.90 유지, 예산 준수

범위
- 카드 뷰(모바일): 이름/이메일/기수/회사 요약 + 상세(전공/업종/공개범위) 토글
- 필터/정렬: 아코디언, inputMode/autoComplete 지정, 공유 링크 토글 버튼화
- 무한스크롤 버튼 영역/레이아웃 보정

DoD / 체크리스트
- [ ] 반응형: md 미만 카드·md 이상 테이블 유지
- [ ] vitest: 카드 렌더/펼치기/아코디언/공유 링크 토글
- [ ] E2E(CDP): `/directory` URL 동기화·카드 펼치기 스모크
- [ ] Lighthouse(모바일) Perf/A11y ≥ 0.90

문서
- docs/plan_ds_v1_phase2_directory_mobile.md (Kickoff 보강)

비고
- 가상화는 Phase 2 범위 밖(후속 검토). 토글 상태는 URL과 분리해 뒤로가기 UX 보존.

