### PR TITLE
ci: add LHCI debug workflow and repro script (NO_FCP tracking)

### DIFF
--- a/.github/workflows/lighthouse-debug.yml
+++ b/.github/workflows/lighthouse-debug.yml
@@ -1,0 +1,112 @@
+name: lighthouse-debug
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lhci-debug:
+    name: Lighthouse Debug (traces/screenshots)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.17.1
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install deps (web)
+        run: pnpm -C apps/web install --frozen-lockfile
+
+      - name: Build (web)
+        run: pnpm -C apps/web build
+
+      - name: Start server
+        env:
+          NEXT_PUBLIC_RELAX_CSP: "1"
+          NEXT_PUBLIC_ENABLE_SW: "0"
+        run: pnpm -C apps/web start &
+
+      - name: Wait for server
+        run: |
+          for i in {1..60}; do
+            if curl -sSf http://localhost:3000 >/dev/null; then echo ready; exit 0; fi
+            sleep 2
+          done
+          echo "server did not start" && exit 1
+
+      - name: Prewarm pages
+        run: |
+          for u in \
+            http://localhost:3000/ \
+            http://localhost:3000/about/greeting \
+            http://localhost:3000/about/org \
+            http://localhost:3000/about/history \
+            http://localhost:3000/directory \
+            http://localhost:3000/board; do
+            echo "prewarm $u"; curl -sS "$u" >/dev/null || true
+          done
+
+      - name: Lighthouse CI (debug mobile)
+        id: lhci_mobile
+        uses: treosh/lighthouse-ci-action@v12
+        continue-on-error: true
+        with:
+          configPath: './lighthouserc.mobile.json'
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          LHCI_COLLECT__SETTINGS__CHROME_FLAGS: "--no-sandbox --disable-dev-shm-usage --headless=new --disable-gpu --window-size=412,823"
+          LHCI_COLLECT__SETTINGS__THROTTLING_METHOD: devtools
+          LHCI_COLLECT__SETTINGS__DISABLE_STORAGE_RESET: false
+          LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_FCP: 120000
+          LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_LOAD: 120000
+          NEXT_PUBLIC_RELAX_CSP: "1"
+          NEXT_PUBLIC_ENABLE_SW: "0"
+          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+
+      - name: Lighthouse CI (debug desktop)
+        id: lhci_desktop
+        uses: treosh/lighthouse-ci-action@v12
+        continue-on-error: true
+        with:
+          configPath: './lighthouserc.desktop.json'
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          LHCI_COLLECT__SETTINGS__CHROME_FLAGS: "--no-sandbox --disable-dev-shm-usage --headless=new --disable-gpu --window-size=1365,1200"
+          LHCI_COLLECT__SETTINGS__THROTTLING_METHOD: devtools
+          LHCI_COLLECT__SETTINGS__DISABLE_STORAGE_RESET: false
+          LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_FCP: 120000
+          LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_LOAD: 120000
+          NEXT_PUBLIC_RELAX_CSP: "1"
+          NEXT_PUBLIC_ENABLE_SW: "0"
+          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+
+      - name: Attach debug note
+        if: ${{ always() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              'LHCI debug run completed.',
+              '- Traces/screenshots are available in workflow artifacts.',
+              `- Mobile links: ${process.env.LHCI_LINKS_MOBILE || ''}`,
+              `- Desktop links: ${process.env.LHCI_LINKS_DESKTOP || ''}`,
+            ].join('\n');
+            if (context.payload.pull_request) {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            } else {
+              core.info(body);
+            }

--- a/docs/dev_log_251027.md
+++ b/docs/dev_log_251027.md
@@ -68,3 +68,7 @@
 - 게시판 초기 탭 판별 시 카테고리 키를 `BOARD_CATEGORIES`에서 파생해 단일 SSOT 유지.
 - CSS 일관성: body 배경을 CSS 변수 `--surface-background` 사용으로 통일.
 - 워크플로 주석: `continue-on-error` 위치에 TODO(#33) 주석 추가(복원 계획 명시).
+### LHCI NO_FCP 디버그 워크플로 추가(2025-10-27 밤)
+- 수동 실행용 `lighthouse-debug` 워크플로 추가(workflow_dispatch). devtools throttling, traces/screenshots 아티팩트 업로드.
+- 로컬 재현 스크립트 `scripts/lhci-debug.sh` 추가(서버 기동/프리웜/collect 1회 저장).
+- 이슈 #33 트랙에서 원인 규명 후 게이트/차단 복원 계획에 따라 단계적 되돌림.

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -469,5 +469,9 @@
 - web(css): body 배경을 CSS 변수로 통일.
 - ci(lighthouse): continue-on-error 위치에 TODO(#33) 주석 추가(복원 가이드).
 
+## 2025-10-27 (CI-debug)
+- ci(lighthouse): 수동 실행 디버그 워크플로 추가(`lighthouse-debug`, traces/screenshots 업로드, devtools throttling).
+- ops: 로컬 재현 스크립트 `scripts/lhci-debug.sh` 추가(서버 기동/프리웜/collect 1회 저장). 이슈 #33 추적.
+
 ## 2025-10-27 (CI)
 - ci(lighthouse): GH Actions를 @v12로 업그레이드하고 코멘트 파서(links/assertionResults) 분리 파싱 적용, 실패해도 항상 코멘트 남김. 게이트(Perf/A11y ≥ 0.90)는 유지. (PR #30)

--- a/scripts/lhci-debug.sh
+++ b/scripts/lhci-debug.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# LHCI NO_FCP reproduction helper
+# Usage: scripts/lhci-debug.sh [mobile|desktop] [url]
+# Requires: node, pnpm (workspace), lhci (installed by action or npx)
+
+ROOT_DIR=/home/ginis
+FORM_FACTOR=mobile
+URL=http://localhost:3000/
+
+export NEXT_PUBLIC_RELAX_CSP=1
+export NEXT_PUBLIC_ENABLE_SW=0
+export NEXT_PUBLIC_WEB_API_BASE=http://localhost:3000
+
+# Start server if not running
+if ! curl -sSf http://localhost:3000 >/dev/null 2>&1; then
+  echo Starting


### PR DESCRIPTION
## 목적
- Issue #33 (LHCI NO_FCP 플래키) 원인 규명을 위한 **디버그 워크플로/로컬 재현 스크립트** 추가 PR입니다.
- 운영 워크플로는 비차단 상태를 유지하고, 이 PR은 분석 편의성(트레이스/스크린샷 수집)을 높입니다.

## 변경사항
- ci: `.github/workflows/lighthouse-debug.yml` 추가 — `workflow_dispatch` 수동 실행, devtools throttling, traces/screenshots 아티팩트 업로드
- scripts: `scripts/lhci-debug.sh` 추가 — 로컬에서 서버 기동/프리웜 후 `lhci collect` 1회 실행, 아티팩트 저장
- docs: `docs/dev_log_251027.md`/`docs/worklog.md` 업데이트

## 사용법
- GitHub Actions → `lighthouse-debug` 워크플로 → Run workflow 버튼으로 실행 (브랜치 선택 가능)
- 로컬: `scripts/lhci-debug.sh mobile http://localhost:3000/` (또는 `desktop`)

## 관계 이슈
- Relates to #33 (비차단 → 원인 분석 → 게이트/차단 복원 단계적 진행)

## 체크리스트
- [x] 워크플로 수동 실행에서 아티팩트 정상 생성
- [x] 로컬 스크립트 실행 시 아티팩트 경로 출력
- [x] 문서 업데이트 (dev_log/worklog)
