### PR TITLE
perf(api): 데이터베이스 복합 인덱스 최적화

### DIFF
--- a/apps/api/migrations/versions/a1b2c3d4e5f6_add_composite_indexes.py
+++ b/apps/api/migrations/versions/a1b2c3d4e5f6_add_composite_indexes.py
@@ -23,13 +23,6 @@ def upgrade() -> None:
         ['event_id', 'status'],
     )
 
-    # NotificationPreference: member_id + channel 조회 최적화
-    op.create_index(
-        'ix_notif_pref_member_channel',
-        'notification_preferences',
-        ['member_id', 'channel'],
-    )
-
     # PushSubscription: 활성 구독 조회용 partial index
     # list_active_subscriptions()가 revoked_at IS NULL만 필터하므로
     # id 컬럼에 partial index를 걸어 활성 구독만 인덱싱
@@ -43,5 +36,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index('ix_push_subs_active', table_name='push_subscriptions')
-    op.drop_index('ix_notif_pref_member_channel', table_name='notification_preferences')
     op.drop_index('ix_rsvps_event_status', table_name='rsvps')

--- a/docs/dev_log_251129.md
+++ b/docs/dev_log_251129.md
@@ -20,6 +20,6 @@
 - Fixed: GzipMiddleware LIFO 순서 수정, get_comment_counts_batch 테스트 추가 (Copilot 리뷰)
 - Notes: PR #61, refs #56, 비동기 전환은 별도 PR로 분리
 
-- Added: 데이터베이스 복합 인덱스 최적화 (RSVP, 알림 설정, 활성 구독)
-- Fixed: ix_push_subs_active 인덱스 컬럼 수정 (member_id → id, 실제 쿼리 패턴 반영)
+- Added: 데이터베이스 복합 인덱스 최적화 (RSVP, 활성 구독)
+- Fixed: ix_push_subs_active 인덱스 컬럼 수정, ix_notif_pref_member_channel 제거 (Copilot 리뷰)
 - Notes: PR #62, refs #57

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,9 +1,8 @@
 ## 2025-11-29
 
 - perf(db): 데이터베이스 인덱스 최적화 — PR #62, refs #57
-  - migrations/versions/a1b2c3d4e5f6 — 복합 인덱스 3개 추가
+  - migrations/versions/a1b2c3d4e5f6 — 복합 인덱스 2개 추가
   - ix_rsvps_event_status: (event_id, status) RSVP 상태 조회 최적화
-  - ix_notif_pref_member_channel: (member_id, channel) 알림 설정 조회
   - ix_push_subs_active: 활성 구독 partial index (id WHERE revoked_at IS NULL)
 
 - perf(api): 백엔드 퍼포먼스 최적화 (P0) — PR #61, refs #56


### PR DESCRIPTION
## Summary
- 복합 인덱스 3개 추가로 쿼리 성능 최적화
- `ix_rsvps_event_status`: (event_id, status) — RSVP 상태별 조회 최적화
- `ix_notif_pref_member_channel`: (member_id, channel) — 알림 설정 조회 최적화
- `ix_push_subs_active`: 활성 구독 partial index (revoked_at IS NULL)

## Changes
- `apps/api/migrations/versions/a1b2c3d4e5f6_add_composite_indexes.py` 추가

## Notes
- N+1 쿼리 방지 (Members joinedload): 현재 MemberRead에 posts/rsvps가 포함되지 않아 불필요하므로 생략
- P1/P2 항목 (Full-text search, cursor pagination 등)은 별도 PR로 분리

## Test plan
- [ ] 마이그레이션 적용 확인 (`alembic upgrade head`)
- [ ] RSVP 상태 조회 쿼리 성능 확인
- [ ] 알림 설정 조회 쿼리 성능 확인

refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)