### PR TITLE
refactor(web): DrawerMenu 동적 임포트 공통 모듈로 분리

### DIFF
--- a/apps/web/components/figma-header.tsx
+++ b/apps/web/components/figma-header.tsx
@@ -3,14 +3,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import React, { useState } from 'react';
-import dynamic from 'next/dynamic';
 import Drawer from './ui/drawer';
 import { useAuth } from '../hooks/useAuth';
-
-const DrawerMenu = dynamic(
-  () => import('./drawer-menu').then((mod) => ({ default: mod.DrawerMenu })),
-  { ssr: false }
-);
+import { LazyDrawerMenu } from './lazy';
 
 export default function FigmaHeader() {
   const [open, setOpen] = useState(false);
@@ -44,7 +39,7 @@ export default function FigmaHeader() {
       </div>
       <Drawer open={open} onClose={() => setOpen(false)} title="메뉴" side="right">
         {/* 메뉴는 단일 출처로 유지(dup 제거) */}
-        <DrawerMenu status={status} onClose={() => setOpen(false)} />
+        <LazyDrawerMenu status={status} onClose={() => setOpen(false)} />
       </Drawer>
     </header>
   );

--- a/apps/web/components/lazy.tsx
+++ b/apps/web/components/lazy.tsx
@@ -1,0 +1,15 @@
+/**
+ * 동적 임포트 컴포넌트 모음
+ * - SSR 비활성화가 필요한 컴포넌트들을 한 곳에서 관리
+ * - 중복 dynamic() 호출 방지
+ */
+import dynamic from 'next/dynamic';
+
+/**
+ * DrawerMenu — SSR 비활성화 (클라이언트 전용)
+ * useRouter, useState 등 클라이언트 훅 사용으로 SSR 불가
+ */
+export const LazyDrawerMenu = dynamic(
+  () => import('./drawer-menu').then((mod) => ({ default: mod.DrawerMenu })),
+  { ssr: false }
+);

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -4,7 +4,6 @@ import React, { useRef, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import type { Route } from 'next';
-import dynamic from 'next/dynamic';
 
 import { HeaderAuth } from './header-auth';
 import { NotifyCTA } from './notify-cta';
@@ -12,11 +11,7 @@ import { RequireAdmin } from './require-admin';
 import { useAuth } from '../hooks/useAuth';
 import Drawer from './ui/drawer';
 import { NavDropdown } from './ui/nav-dropdown';
-
-const DrawerMenu = dynamic(
-  () => import('./drawer-menu').then((mod) => ({ default: mod.DrawerMenu })),
-  { ssr: false }
-);
+import { LazyDrawerMenu } from './lazy';
 
 type LinkItem = {
   href: Route;
@@ -125,7 +120,7 @@ export function SiteHeader() {
       </div>
       {/* Drawer 메뉴 */}
       <Drawer open={open} onClose={closeMenu} side="right" className="w-[285px]">
-        <DrawerMenu status={status} onClose={closeMenu} />
+        <LazyDrawerMenu status={status} onClose={closeMenu} />
       </Drawer>
     </header>
   );

--- a/docs/dev_log_251201.md
+++ b/docs/dev_log_251201.md
@@ -1,0 +1,4 @@
+# 2025-12-01
+
+- Changed: Issue #55 프론트엔드 퍼포먼스 최적화 PR 머지 진행
+- Changed: DrawerMenu 동적 임포트 공통 모듈(lazy.tsx)로 분리 — PR #65

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -865,3 +865,6 @@
 
 2025-11-30 perf(web): OTF → WOFF2 전환으로 브랜드 폰트 1.79MB 절감 — refs #55
 - KoPubWorld Dotum Bold 3.5MB → 2.0MB (43%), 서강체 548KB → 263KB (52%)
+
+2025-11-30 refactor(web): DrawerMenu 동적 임포트 공통 모듈로 분리 — refs #55
+- components/lazy.tsx 생성, figma-header/site-header에서 중복 제거


### PR DESCRIPTION
## Summary
- `components/lazy.tsx` 생성하여 `LazyDrawerMenu` export
- `figma-header.tsx`, `site-header.tsx`에서 중복 `dynamic()` 호출 제거
- 동적 임포트 설정을 한 곳에서 관리

## 변경 사항
| 파일 | 변경 |
|------|------|
| `components/lazy.tsx` | 신규 생성 — 동적 임포트 모음 |
| `figma-header.tsx` | `dynamic()` 제거, `LazyDrawerMenu` 사용 |
| `site-header.tsx` | `dynamic()` 제거, `LazyDrawerMenu` 사용 |

## Test plan
- [x] `pnpm -C apps/web build` 성공
- [ ] 로컬에서 Drawer 메뉴 동작 확인

refs #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)