### PR TITLE
feat(api): SESSION_MAX_AGE 환경변수 추가

### DIFF
--- a/.env.api.example
+++ b/.env.api.example
@@ -61,3 +61,5 @@ COOKIE_SAMESITE=lax
 COOKIE_SECURE=true
 # 필요 시 쿠키 도메인 고정(미설정 권장): 예) api.example.com 또는 .example.com
 COOKIE_DOMAIN=
+# 세션 만료 시간(초). 기본 7일(604800). 0이면 브라우저 종료 시 만료.
+SESSION_MAX_AGE=604800

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -78,6 +78,8 @@ class Settings(BaseSettings):
     cookie_same_site: str = Field(default="lax", alias="COOKIE_SAMESITE")
     cookie_secure: bool | None = Field(default=None, alias="COOKIE_SECURE")
     cookie_domain: str | None = Field(default=None, alias="COOKIE_DOMAIN")
+    # 세션 만료 시간 (초). 기본 7일. 0이면 브라우저 세션 쿠키.
+    session_max_age: int = Field(default=604800, alias="SESSION_MAX_AGE")
 
     # --- Validators ---
     @field_validator("cookie_same_site")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -84,6 +84,7 @@ app.add_middleware(
     same_site=_same_site,
     https_only=_https_only,
     domain=settings.cookie_domain or None,
+    max_age=settings.session_max_age or None,  # 0이면 세션 쿠키
 )
 
 media_root = Path(settings.media_root)

--- a/docs/dev_log_251203.md
+++ b/docs/dev_log_251203.md
@@ -2,3 +2,4 @@
 
 - Fixed: FastAPI 0.120.1 → 0.123.5 업그레이드, Starlette 0.48.0 → 0.50.0 (GHSA-7f5h-v6xp-fcq8 해결)
 - Changed: check_versions.py FastAPI 버전 동기화
+- Added: SESSION_MAX_AGE 환경변수로 세션 만료 시간 설정 가능 (기본 7일)

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -2,6 +2,7 @@
 
 - sec(api): FastAPI 0.123.5로 상향, Starlette GHSA-7f5h-v6xp-fcq8 취약점 해결 — #72
 - ci: check_versions.py FastAPI 버전 동기화
+- feat(api): SESSION_MAX_AGE 환경변수 추가 (기본 7일) — #74
 
 ## 2025-12-02
 


### PR DESCRIPTION
## Summary
- 세션 쿠키 만료 시간을 환경변수로 설정 가능
- 기본값: 7일 (604800초)
- 0 설정 시 브라우저 종료와 함께 만료되는 세션 쿠키로 동작

## Changes
- `apps/api/config.py`: `session_max_age` 설정 추가
- `apps/api/main.py`: SessionMiddleware에 `max_age` 파라미터 적용
- `.env.api.example`: 새 환경변수 문서화

## Test plan
- [x] 로컬 테스트 통과
- [ ] CI 통과 확인

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)