### PR TITLE
docs(env): 프로덕션 이미지 URL 설정 예시 추가

### DIFF
--- a/.env.api.example
+++ b/.env.api.example
@@ -43,6 +43,8 @@ PUSH_KEK=
 
 # 7) 업로드/미디어
 MEDIA_ROOT=uploads
+# 이미지 URL 베이스. 로컬은 상대경로(/media), 프로덕션은 API 절대 URL 권장.
+# 예) 프로덕션: MEDIA_URL_BASE=https://api.sogecon.wastelite.kr/media
 MEDIA_URL_BASE=/media
 AVATAR_MAX_BYTES=100000
 AVATAR_MAX_UPLOAD_BYTES=2000000

--- a/.env.web.example
+++ b/.env.web.example
@@ -23,5 +23,7 @@ NEXT_PUBLIC_ENABLE_SW=1
 # 프리뷰에서 DevTools/HMR 등을 위해 CSP 완화가 필요할 때만 1
 NEXT_PUBLIC_RELAX_CSP=
 
-# 5) 이미지 외부 도메인(쉼표 구분). 예: img.cdn.example.com,static.example.com
+# 5) 이미지 외부 도메인(쉼표 구분, 빌드타임 적용)
+# 프로덕션에서 API 서버가 이미지를 서빙하면 해당 도메인 추가 필수.
+# 예) NEXT_PUBLIC_IMAGE_DOMAINS=api.sogecon.wastelite.kr
 NEXT_PUBLIC_IMAGE_DOMAINS=

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,3 +1,7 @@
+## 2025-12-10
+
+- docs(env): 프로덕션 이미지 URL 설정 예시 추가 — MEDIA_URL_BASE, IMAGE_DOMAINS (#88)
+
 ## 2025-12-09
 
 - feat(api,web): 게시물 관리 기능 추가 — 수정/삭제 API, 관리자 목록 페이지 (이슈 #87)


### PR DESCRIPTION
## Summary

- `.env.api.example`: `MEDIA_URL_BASE` 프로덕션 절대 URL 예시 주석 추가
- `.env.web.example`: `NEXT_PUBLIC_IMAGE_DOMAINS` 설명 보강

## 관련 이슈

Refs #88 — 프로덕션에서 이미지 404 발생 문제 해결을 위한 환경변수 가이드

## 배포 후 작업

VPS에서 아래 환경변수 설정 필요:

**API** (`.env.api`):
```
MEDIA_URL_BASE=https://api.sogecon.wastelite.kr/media
```

**Web** (빌드 시):
```
NEXT_PUBLIC_IMAGE_DOMAINS=api.sogecon.wastelite.kr
```

상세 체크리스트는 이슈 #88 코멘트 참조.

## Test plan

- [ ] 예시 파일 주석 확인
- [ ] VPS 배포 후 이미지 업로드/표시 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)