### PR TITLE
fix(api): MEDIA_URL_BASE 절대 URL mount 보정 (#88)

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Literal, cast
+from urllib.parse import urlsplit
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -94,8 +95,11 @@ app.add_middleware(
 
 media_root = Path(settings.media_root)
 media_root.mkdir(parents=True, exist_ok=True)
+media_mount_path = urlsplit(settings.media_url_base).path or "/"
+if not media_mount_path.startswith("/"):
+    media_mount_path = f"/{media_mount_path}"
 app.mount(
-    settings.media_url_base,
+    media_mount_path,
     StaticFiles(directory=str(media_root)),
     name="media",
 )

--- a/docs/dev_log_251210.md
+++ b/docs/dev_log_251210.md
@@ -1,0 +1,5 @@
+# 2025-12-10
+
+- Fixed: MEDIA_URL_BASE 절대 URL일 때 StaticFiles mount 경로 보정 (api)
+- Ops/Docs: prod api/media 설정 검증 및 웹 재배포 (sogecon.wastelite.kr)
+

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,7 @@
 ## 2025-12-10
 
 - docs(env): 프로덕션 이미지 URL 설정 예시 추가 — MEDIA_URL_BASE, IMAGE_DOMAINS (#88)
+- fix(api): MEDIA_URL_BASE 절대 URL mount 경로 보정 — StaticFiles AssertionError 해결 (#88)
 
 ## 2025-12-09
 

--- a/tests/api/test_media_mount.py
+++ b/tests/api/test_media_mount.py
@@ -1,0 +1,29 @@
+from importlib import import_module, reload
+import os
+
+from apps.api import config
+
+
+def test_media_url_base_absolute_mounts_media_path(monkeypatch) -> None:
+    """MEDIA_URL_BASE가 절대 URL이어도 /media 경로로 정상 mount되는지 확인."""
+
+    main_module = import_module("apps.api.main")
+    original_media_url = os.environ.get("MEDIA_URL_BASE")
+
+    try:
+        monkeypatch.setenv("MEDIA_URL_BASE", "https://api.example.com/media")
+        config.reset_settings_cache()
+        main_module = reload(main_module)
+
+        mounted_paths = {
+            getattr(route, "path", None) for route in main_module.app.router.routes
+        }
+        assert "/media" in mounted_paths
+    finally:
+        # 환경 복원
+        if original_media_url is None:
+            monkeypatch.delenv("MEDIA_URL_BASE", raising=False)
+        else:
+            monkeypatch.setenv("MEDIA_URL_BASE", original_media_url)
+        config.reset_settings_cache()
+        reload(main_module)


### PR DESCRIPTION
## 개요
- MEDIA_URL_BASE가 절대 URL일 때 StaticFiles가 루트 경로로 인식해 AssertionError가 발생하던 문제를 수정했습니다.
- 절대 URL이어도 path 부분만 추출해 항상 /media로 mount하도록 변경했습니다.
- 회귀 방지를 위해 MEDIA_URL_BASE 절대 URL 케이스를 재로드 테스트에 추가했습니다.

## 재현 방법
1) .env.api 에서 MEDIA_URL_BASE=https://api.sogecon.wastelite.kr/media 처럼 절대 URL 설정
2) uvicorn apps.api.main:app 실행 → startup 단계에서 "Routed paths must start with '/'" AssertionError로 프로세스 종료

## 변경 내용
- apps/api/main.py: media_url_base를 urlsplit 후 path만 mount, leading slash 보장
- tests/api/test_media_mount.py: MEDIA_URL_BASE 절대 URL 설정 시 /media가 router에 존재하는지 검증
- docs/worklog.md, docs/dev_log_251210.md: 작업 기록 추가

## 테스트
- (로컬) 미실행 — 필요 시 `pytest tests/api/test_media_mount.py`

## 참고
- 서버에 이미 반영되어 /healthz 정상 확인 및 웹 재배포 완료 (a7410ae)

Refs #88
