### PR TITLE
fix(web): React 19.2.3 — CVE-2025-55182 보안 패치

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@tanstack/react-query": "5.62.2",
     "next": "15.5.9",
-    "react": "19.2.1",
-    "react-dom": "19.2.1",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "web-vitals": "4.2.3"
   },
   "devDependencies": {

--- a/docs/dev_log_251217.md
+++ b/docs/dev_log_251217.md
@@ -1,5 +1,6 @@
 # 2025-12-17
 
+- Security: React 19.2.1 → 19.2.3 업데이트 (CVE-2025-55182 CVSS 10.0 RCE)
 - Changed: 전체 페이지(22개) 디자인 토큰 치환 — slate/emerald/red → semantic 토큰
 - Changed: 전체 컴포넌트(15개) 디자인 토큰 치환 — 하드코딩 0건 달성
 - Fixed: neutral.subtle 토큰 누락 수정 + 스냅샷 테스트 업데이트

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -23,9 +23,9 @@
 - pytest==8.4.2
 
 ## Frontend (apps/web)
-- next: 15.5.8
-- react: 19.2.1
-- react-dom: 19.2.1
+- next: 15.5.9
+- react: 19.2.3
+- react-dom: 19.2.3
 
 ### Dev tools
 - typescript: 5.8.3

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,5 +1,6 @@
 ## 2025-12-17
 
+- fix(web): React 19.2.3 업데이트 — CVE-2025-55182 (React2Shell RCE) 수정 + CI 버전락 갱신
 - refactor(web): 디자인 토큰 일관성 정리 — 기반 작업 (#99)
 - refactor(web): 전체 페이지 디자인 토큰 치환 — slate/red/emerald→semantic (#99, PR #100)
 - refactor(web): 전체 컴포넌트 디자인 토큰 치환 — 하드코딩 0건 달성 (#99, PR #100)

--- a/ops/ci/check_versions.py
+++ b/ops/ci/check_versions.py
@@ -22,8 +22,8 @@ def check_package_json() -> None:
     expected_deps = {
         "dependencies": {
             "next": "15.5.9",
-            "react": "19.2.1",
-            "react-dom": "19.2.1",
+            "react": "19.2.3",
+            "react-dom": "19.2.3",
         },
         "devDependencies": {
             "eslint": "9.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,16 +18,16 @@ importers:
     dependencies:
       '@tanstack/react-query':
         specifier: 5.62.2
-        version: 5.62.2(react@19.2.1)
+        version: 5.62.2(react@19.2.3)
       next:
         specifier: 15.5.9
-        version: 15.5.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
-        specifier: 19.2.1
-        version: 19.2.1
+        specifier: 19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: 19.2.1
-        version: 19.2.1(react@19.2.1)
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
       web-vitals:
         specifier: 4.2.3
         version: 4.2.3
@@ -46,7 +46,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: 16.2.0
-        version: 16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: 22.7.8
         version: 22.7.8
@@ -2456,10 +2456,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@19.2.1:
-    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
-      react: ^19.2.1
+      react: ^19.2.3
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2467,8 +2467,8 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react@19.2.1:
-    resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -3559,10 +3559,10 @@ snapshots:
 
   '@tanstack/query-core@5.62.2': {}
 
-  '@tanstack/react-query@5.62.2(react@19.2.1)':
+  '@tanstack/react-query@5.62.2(react@19.2.3)':
     dependencies:
       '@tanstack/query-core': 5.62.2
-      react: 19.2.1
+      react: 19.2.3
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3585,12 +3585,12 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.0(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.0(@types/react@19.2.7)
@@ -5188,15 +5188,15 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.5.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001745
       postcss: 8.4.31
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-      styled-jsx: 5.1.6(react@19.2.1)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -5488,16 +5488,16 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.2.1(react@19.2.1):
+  react-dom@19.2.3(react@19.2.3):
     dependencies:
-      react: 19.2.1
+      react: 19.2.3
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
-  react@19.2.1: {}
+  react@19.2.3: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -5838,10 +5838,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(react@19.2.1):
+  styled-jsx@5.1.6(react@19.2.3):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.1
+      react: 19.2.3
 
   sucrase@3.35.0:
     dependencies:


### PR DESCRIPTION
## Summary

**CVE-2025-55182 (React2Shell)** 긴급 보안 패치

- CVSS 10.0 최대 심각도
- React Server Components RCE 취약점
- 중국 국가급 해커 그룹 활성 익스플로잇 확인됨 (12/3 공개 직후)

### 변경사항
- react: 19.2.1 → 19.2.3
- react-dom: 19.2.1 → 19.2.3

### 참고
- https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
- https://www.wiz.io/blog/critical-vulnerability-in-react-cve-2025-55182

## Test plan

- [x] `pnpm -C apps/web build` 성공
- [x] `pnpm -C apps/web test` 65건 전체 통과
- [ ] CI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)