### PR TITLE
feat(api): #116 가입신청 및 관리자 승인·반려 API 구현

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -30,6 +30,7 @@ from .routers import (
     admin_events,
     admin_hero,
     admin_posts,
+    admin_signup_requests,
     auth,
     comments,
     events,
@@ -304,3 +305,4 @@ app.include_router(uploads.router)
 app.include_router(admin_posts.router)
 app.include_router(admin_events.router)
 app.include_router(admin_hero.router)
+app.include_router(admin_signup_requests.router)

--- a/apps/api/migrations/versions/b6d2e8f1c4a7_add_phone_note_to_signup_requests.py
+++ b/apps/api/migrations/versions/b6d2e8f1c4a7_add_phone_note_to_signup_requests.py
@@ -1,0 +1,32 @@
+"""add phone note to signup requests
+
+Revision ID: b6d2e8f1c4a7
+Revises: 9ab3c7d4e1f2
+Create Date: 2026-02-18 10:25:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6d2e8f1c4a7"
+down_revision: str | None = "9ab3c7d4e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "signup_requests",
+        sa.Column("phone", sa.String(length=64), nullable=True),
+    )
+    op.add_column("signup_requests", sa.Column("note", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("signup_requests", "note")
+    op.drop_column("signup_requests", "phone")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -300,6 +300,8 @@ class SignupRequest(Base):
     name = Column(String(255), nullable=False)
     cohort = Column(Integer, nullable=False)
     major = Column(String(255), nullable=True)
+    phone = Column(String(64), nullable=True)
+    note = Column(Text, nullable=True)
     status = Column(
         String(16),
         nullable=False,

--- a/apps/api/repositories/signup_requests.py
+++ b/apps/api/repositories/signup_requests.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from .. import models, schemas
+
+
+def _build_conditions(
+    filters: schemas.SignupRequestListFilters,
+) -> list[ColumnElement[bool]]:
+    conditions: list[ColumnElement[bool]] = []
+
+    q = filters.get("q")
+    if q:
+        like = f"%{q.strip()}%"
+        conditions.append(
+            or_(
+                models.SignupRequest.student_id.ilike(like),
+                models.SignupRequest.name.ilike(like),
+                models.SignupRequest.email.ilike(like),
+            )
+        )
+
+    status = filters.get("status")
+    if status is not None:
+        conditions.append(models.SignupRequest.status == status)
+
+    return conditions
+
+
+async def create_signup_request(
+    db: AsyncSession,
+    payload: schemas.SignupRequestCreate,
+) -> models.SignupRequest:
+    row = models.SignupRequest(**payload.model_dump())
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def get_pending_by_student_id(
+    db: AsyncSession,
+    student_id: str,
+) -> models.SignupRequest | None:
+    stmt = select(models.SignupRequest).where(
+        and_(
+            models.SignupRequest.student_id == student_id,
+            models.SignupRequest.status == "pending",
+        )
+    )
+    result = await db.execute(stmt)
+    return result.scalars().first()
+
+
+async def get_signup_request_by_id(
+    db: AsyncSession,
+    signup_request_id: int,
+) -> models.SignupRequest | None:
+    stmt = select(models.SignupRequest).where(
+        models.SignupRequest.id == signup_request_id
+    )
+    result = await db.execute(stmt)
+    return result.scalars().first()
+
+
+async def list_signup_requests_with_total(
+    db: AsyncSession,
+    *,
+    limit: int,
+    offset: int,
+    filters: schemas.SignupRequestListFilters | None = None,
+) -> tuple[Sequence[models.SignupRequest], int]:
+    f = filters or {}
+    conditions = _build_conditions(f)
+
+    stmt = (
+        select(models.SignupRequest)
+        .order_by(
+            desc(models.SignupRequest.requested_at),
+            desc(models.SignupRequest.id),
+        )
+        .offset(offset)
+        .limit(limit)
+    )
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    rows = (await db.execute(stmt)).scalars().all()
+
+    count_stmt = select(func.count(models.SignupRequest.id))
+    if conditions:
+        count_stmt = count_stmt.where(and_(*conditions))
+    total = int((await db.execute(count_stmt)).scalar_one())
+
+    return rows, total
+
+
+async def save_signup_request(
+    db: AsyncSession,
+    row: models.SignupRequest,
+) -> models.SignupRequest:
+    await db.commit()
+    await db.refresh(row)
+    return row

--- a/apps/api/routers/admin_signup_requests.py
+++ b/apps/api/routers/admin_signup_requests.py
@@ -1,0 +1,106 @@
+"""관리자 가입신청 심사 API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas
+from ..db import get_db
+from ..services import signup_service
+from ..services.auth_service import CurrentUser, require_permission
+
+router = APIRouter(prefix="/admin/signup-requests", tags=["admin-signup-requests"])
+
+
+class SignupRequestListParams(BaseModel):
+    limit: int = Query(20, ge=1, le=100)
+    offset: int = Query(0, ge=0)
+    q: str | None = Query(default=None, min_length=1, max_length=100)
+    status: schemas.SignupRequestStatusLiteral | None = Query(default=None)
+
+
+class SignupRequestListResponse(BaseModel):
+    items: list[schemas.SignupRequestRead]
+    total: int
+
+
+class SignupActivationContextResponse(BaseModel):
+    signup_request_id: int
+    student_id: str
+    email: str
+    name: str
+    cohort: int
+
+
+class SignupApproveResponse(BaseModel):
+    request: schemas.SignupRequestRead
+    activation_context: SignupActivationContextResponse
+
+
+class SignupRejectPayload(BaseModel):
+    reason: str = Field(min_length=1, max_length=500)
+
+
+@router.get("/", response_model=SignupRequestListResponse)
+async def list_signup_requests(
+    params: SignupRequestListParams = Depends(),
+    db: AsyncSession = Depends(get_db),
+    _user: CurrentUser = Depends(require_permission("admin_signup")),
+) -> SignupRequestListResponse:
+    filters: schemas.SignupRequestListFilters = {}
+    if params.q is not None:
+        filters["q"] = params.q
+    if params.status is not None:
+        filters["status"] = params.status
+
+    rows, total = await signup_service.list_signup_requests_with_total(
+        db,
+        limit=params.limit,
+        offset=params.offset,
+        filters=filters or None,
+    )
+    return SignupRequestListResponse(
+        items=[schemas.SignupRequestRead.model_validate(row) for row in rows],
+        total=total,
+    )
+
+
+@router.post("/{signup_request_id}/approve", response_model=SignupApproveResponse)
+async def approve_signup_request(
+    signup_request_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: CurrentUser = Depends(require_permission("admin_signup")),
+) -> SignupApproveResponse:
+    row, context = await signup_service.approve_signup_request(
+        db,
+        signup_request_id=signup_request_id,
+        decided_by_student_id=user.student_id,
+    )
+    return SignupApproveResponse(
+        request=schemas.SignupRequestRead.model_validate(row),
+        activation_context=SignupActivationContextResponse(
+            signup_request_id=context.signup_request_id,
+            student_id=context.student_id,
+            email=context.email,
+            name=context.name,
+            cohort=context.cohort,
+        ),
+    )
+
+
+@router.post("/{signup_request_id}/reject", response_model=schemas.SignupRequestRead)
+async def reject_signup_request(
+    signup_request_id: int,
+    payload: SignupRejectPayload,
+    db: AsyncSession = Depends(get_db),
+    user: CurrentUser = Depends(require_permission("admin_signup")),
+) -> schemas.SignupRequestRead:
+    row = await signup_service.reject_signup_request(
+        db,
+        signup_request_id=signup_request_id,
+        decided_by_student_id=user.student_id,
+        reject_reason=payload.reason,
+    )
+    return schemas.SignupRequestRead.model_validate(row)

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -12,9 +12,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .. import schemas
 from ..config import get_settings
 from ..db import get_db
 from ..ratelimit import consume_limit
+from ..services import signup_service
 from ..services.auth_service import (
     CurrentAdmin,
     CurrentMember,
@@ -114,6 +116,20 @@ async def member_login(
 ) -> dict[str, str]:
     """멤버 로그인."""
     return await login_member(db, request, payload.student_id, payload.password)
+
+
+@router.post(
+    "/member/signup",
+    response_model=schemas.SignupRequestRead,
+    status_code=201,
+)
+async def member_signup(
+    payload: schemas.SignupRequestCreate,
+    db: AsyncSession = Depends(get_db),
+) -> schemas.SignupRequestRead:
+    """신규 가입신청 생성."""
+    row = await signup_service.create_signup_request(db, payload)
+    return schemas.SignupRequestRead.model_validate(row)
 
 
 @router.post("/member/logout", status_code=204)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -159,6 +159,8 @@ class SignupRequestBase(BaseModel):
     name: str
     cohort: int
     major: str | None = None
+    phone: str | None = None
+    note: str | None = None
     status: SignupRequestStatusLiteral = "pending"
     requested_at: datetime | None = None
     decided_at: datetime | None = None
@@ -173,12 +175,29 @@ class SignupRequestCreate(BaseModel):
     name: str
     cohort: int
     major: str | None = None
+    phone: str | None = None
+    note: str | None = None
+
+    @field_validator("phone")
+    @classmethod
+    def _validate_phone(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        trimmed = value.strip()
+        if not _PHONE_PATTERN.fullmatch(trimmed):
+            raise ValueError("전화번호는 숫자, +, -, 공백으로만 7~20자 입력해주세요.")
+        return trimmed
 
 
 class SignupRequestRead(SignupRequestBase):
     id: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SignupRequestListFilters(TypedDict, total=False):
+    q: str
+    status: SignupRequestStatusLiteral
 
 
 class AdminEventListFilters(TypedDict, total=False):

--- a/apps/api/services/roles_service.py
+++ b/apps/api/services/roles_service.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+
+@dataclass(frozen=True)
+class RoleProfile:
+    grade: str
+    permissions: set[str]
+
+
+def normalize_roles(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        roles: list[str] = []
+        for item in cast(Sequence[object], value):
+            if isinstance(item, str) and item.strip():
+                roles.append(item.strip())
+        return roles
+
+    return []
+
+
+def ensure_member_role(roles: list[str]) -> list[str]:
+    if "member" in roles:
+        return roles
+    return ["member", *roles]
+
+
+def parse_roles(raw_roles: object) -> RoleProfile:
+    roles = normalize_roles(raw_roles)
+    tokens = set(roles)
+
+    if "super_admin" in tokens:
+        grade = "super_admin"
+    elif "admin" in tokens:
+        grade = "admin"
+    else:
+        grade = "member"
+
+    permissions = {token for token in tokens if token.startswith("admin_")}
+    return RoleProfile(grade=grade, permissions=permissions)
+
+
+def has_permission(
+    raw_roles: object,
+    permission: str,
+    *,
+    allow_admin_fallback: bool = True,
+) -> bool:
+    profile = parse_roles(raw_roles)
+
+    if profile.grade == "super_admin":
+        return True
+
+    if permission in profile.permissions:
+        return True
+
+    if allow_admin_fallback and profile.grade == "admin":
+        return True
+
+    return False

--- a/apps/api/services/signup_service.py
+++ b/apps/api/services/signup_service.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models, schemas
+from ..errors import ConflictError, NotFoundError
+from ..repositories import signup_requests as signup_requests_repo
+
+
+@dataclass(frozen=True)
+class SignupActivationContext:
+    signup_request_id: int
+    student_id: str
+    email: str
+    name: str
+    cohort: int
+
+
+async def create_signup_request(
+    db: AsyncSession,
+    payload: schemas.SignupRequestCreate,
+) -> models.SignupRequest:
+    member_stmt = select(models.Member).where(
+        models.Member.student_id == payload.student_id
+    )
+    existing_member = (await db.execute(member_stmt)).scalars().first()
+    if existing_member is not None and cast(str, existing_member.status) == "active":
+        raise ConflictError(
+            code="member_already_active",
+            detail="이미 활성화된 회원입니다.",
+        )
+
+    pending_row = await signup_requests_repo.get_pending_by_student_id(
+        db, payload.student_id
+    )
+    if pending_row is not None:
+        raise ConflictError(
+            code="signup_already_pending",
+            detail="이미 심사 대기 중인 신청이 있습니다.",
+        )
+
+    try:
+        return await signup_requests_repo.create_signup_request(db, payload)
+    except IntegrityError as exc:
+        await db.rollback()
+        if "uq_signup_requests_student_id_pending" in str(exc.orig):
+            raise ConflictError(
+                code="signup_already_pending",
+                detail="이미 심사 대기 중인 신청이 있습니다.",
+            ) from exc
+        raise
+
+
+async def list_signup_requests_with_total(
+    db: AsyncSession,
+    *,
+    limit: int,
+    offset: int,
+    filters: schemas.SignupRequestListFilters | None = None,
+) -> tuple[Sequence[models.SignupRequest], int]:
+    return await signup_requests_repo.list_signup_requests_with_total(
+        db,
+        limit=limit,
+        offset=offset,
+        filters=filters,
+    )
+
+
+async def approve_signup_request(
+    db: AsyncSession,
+    *,
+    signup_request_id: int,
+    decided_by_student_id: str,
+) -> tuple[models.SignupRequest, SignupActivationContext]:
+    row = await signup_requests_repo.get_signup_request_by_id(db, signup_request_id)
+    if row is None:
+        raise NotFoundError(
+            code="signup_request_not_found",
+            detail="가입신청을 찾을 수 없습니다.",
+        )
+
+    if cast(str, row.status) != "pending":
+        raise ConflictError(
+            code="signup_request_not_pending",
+            detail="대기 중인 신청만 승인할 수 있습니다.",
+        )
+
+    member_stmt = select(models.Member).where(
+        models.Member.student_id == row.student_id
+    )
+    member = (await db.execute(member_stmt)).scalars().first()
+    if member is None:
+        member = models.Member(
+            student_id=row.student_id,
+            email=row.email,
+            name=row.name,
+            cohort=row.cohort,
+            major=row.major,
+            roles="member",
+            status="active",
+            visibility=models.Visibility.ALL,
+        )
+        db.add(member)
+    else:
+        if cast(str, member.status) == "active":
+            raise ConflictError(
+                code="member_already_active",
+                detail="이미 활성화된 회원입니다.",
+            )
+        setattr(member, "email", cast(str, row.email))
+        setattr(member, "name", cast(str, row.name))
+        setattr(member, "cohort", cast(int, row.cohort))
+        setattr(member, "major", cast(str | None, row.major))
+        setattr(member, "status", "active")
+
+    setattr(row, "status", "approved")
+    setattr(row, "decided_at", datetime.now(tz=UTC))
+    setattr(row, "decided_by_student_id", decided_by_student_id)
+    setattr(row, "reject_reason", None)
+
+    row = await signup_requests_repo.save_signup_request(db, row)
+    context = SignupActivationContext(
+        signup_request_id=cast(int, row.id),
+        student_id=cast(str, row.student_id),
+        email=cast(str, row.email),
+        name=cast(str, row.name),
+        cohort=cast(int, row.cohort),
+    )
+    return row, context
+
+
+async def reject_signup_request(
+    db: AsyncSession,
+    *,
+    signup_request_id: int,
+    decided_by_student_id: str,
+    reject_reason: str,
+) -> models.SignupRequest:
+    row = await signup_requests_repo.get_signup_request_by_id(db, signup_request_id)
+    if row is None:
+        raise NotFoundError(
+            code="signup_request_not_found",
+            detail="가입신청을 찾을 수 없습니다.",
+        )
+
+    if cast(str, row.status) != "pending":
+        raise ConflictError(
+            code="signup_request_not_pending",
+            detail="대기 중인 신청만 반려할 수 있습니다.",
+        )
+
+    setattr(row, "status", "rejected")
+    setattr(row, "decided_at", datetime.now(tz=UTC))
+    setattr(row, "decided_by_student_id", decided_by_student_id)
+    setattr(row, "reject_reason", reject_reason)
+    return await signup_requests_repo.save_signup_request(db, row)

--- a/docs/dev_log_260218.md
+++ b/docs/dev_log_260218.md
@@ -12,4 +12,7 @@
 - Feat: #115 착수 — `members.status`/`signup_requests` 모델·마이그레이션 추가, 시드를 관리자 bootstrap 전용으로 재구성
 - Fixed: PR #121 리뷰 반영 — `MemberCreate`에 `status` 노출 제거, `seed-admin` alias 중복 정의 정리
 - Chore: PR #121 CI(verify-dto) 대응으로 `packages/schemas/openapi.json`, `packages/schemas/index.d.ts` 재생성 반영
+- Feat: #116 착수 — `POST /auth/member/signup`, 관리자 심사 API(`GET/approve/reject /admin/signup-requests`) 및 `admin_signup` 권한 가드 추가
+- Feat: `roles_service` 단일 파서 도입 및 `signup_requests`에 `phone`/`note` 컬럼 확장(+ Alembic `b6d2e8f1c4a7`)
+- Test: `tests/api/test_signup_requests_api.py` 추가(신청/중복/활성충돌/권한403/승인·반려 플로우 검증)
 - Notes: 이슈 #114 작업 착수, Epic #113 하위 이슈 순서에 맞춰 진행

--- a/packages/schemas/index.d.ts
+++ b/packages/schemas/index.d.ts
@@ -329,6 +329,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/member/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Member Signup
+         * @description 신규 가입신청 생성.
+         */
+        post: operations["member_signup_auth_member_signup_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/member/logout": {
         parameters: {
             query?: never;
@@ -802,6 +822,57 @@ export interface paths {
         head?: never;
         /** Update Admin Hero Item */
         patch: operations["update_admin_hero_item_admin_hero__hero_item_id__patch"];
+        trace?: never;
+    };
+    "/admin/signup-requests/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Signup Requests */
+        get: operations["list_signup_requests_admin_signup_requests__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/signup-requests/{signup_request_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Approve Signup Request */
+        post: operations["approve_signup_request_admin_signup_requests__signup_request_id__approve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/signup-requests/{signup_request_id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject Signup Request */
+        post: operations["reject_signup_request_admin_signup_requests__signup_request_id__reject_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
 }
@@ -1506,6 +1577,94 @@ export interface components {
             status_code: number | null;
             /** Endpoint Tail */
             endpoint_tail: string | null;
+        };
+        /** SignupActivationContextResponse */
+        SignupActivationContextResponse: {
+            /** Signup Request Id */
+            signup_request_id: number;
+            /** Student Id */
+            student_id: string;
+            /** Email */
+            email: string;
+            /** Name */
+            name: string;
+            /** Cohort */
+            cohort: number;
+        };
+        /** SignupApproveResponse */
+        SignupApproveResponse: {
+            request: components["schemas"]["SignupRequestRead"];
+            activation_context: components["schemas"]["SignupActivationContextResponse"];
+        };
+        /** SignupRejectPayload */
+        SignupRejectPayload: {
+            /** Reason */
+            reason: string;
+        };
+        /** SignupRequestCreate */
+        SignupRequestCreate: {
+            /** Student Id */
+            student_id: string;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Name */
+            name: string;
+            /** Cohort */
+            cohort: number;
+            /** Major */
+            major?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Note */
+            note?: string | null;
+        };
+        /** SignupRequestListResponse */
+        SignupRequestListResponse: {
+            /** Items */
+            items: components["schemas"]["SignupRequestRead"][];
+            /** Total */
+            total: number;
+        };
+        /** SignupRequestRead */
+        SignupRequestRead: {
+            /** Student Id */
+            student_id: string;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /** Name */
+            name: string;
+            /** Cohort */
+            cohort: number;
+            /** Major */
+            major?: string | null;
+            /** Phone */
+            phone?: string | null;
+            /** Note */
+            note?: string | null;
+            /**
+             * Status
+             * @default pending
+             * @enum {string}
+             */
+            status: "pending" | "approved" | "rejected" | "activated";
+            /** Requested At */
+            requested_at?: string | null;
+            /** Decided At */
+            decided_at?: string | null;
+            /** Activated At */
+            activated_at?: string | null;
+            /** Decided By Student Id */
+            decided_by_student_id?: string | null;
+            /** Reject Reason */
+            reject_reason?: string | null;
+            /** Id */
+            id: number;
         };
         /** SubscriptionPayload */
         SubscriptionPayload: {
@@ -2383,6 +2542,39 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    member_signup_auth_member_signup_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupRequestCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupRequestRead"];
                 };
             };
             /** @description Validation Error */
@@ -3359,6 +3551,106 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HeroItemRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_signup_requests_admin_signup_requests__get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                q?: string | null;
+                status?: ("pending" | "approved" | "rejected" | "activated") | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupRequestListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    approve_signup_request_admin_signup_requests__signup_request_id__approve_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                signup_request_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupApproveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reject_signup_request_admin_signup_requests__signup_request_id__reject_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                signup_request_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SignupRejectPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SignupRequestRead"];
                 };
             };
             /** @description Validation Error */

--- a/packages/schemas/openapi.json
+++ b/packages/schemas/openapi.json
@@ -1365,6 +1365,48 @@
         }
       }
     },
+    "/auth/member/signup": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Member Signup",
+        "description": "\uc2e0\uaddc \uac00\uc785\uc2e0\uccad \uc0dd\uc131.",
+        "operationId": "member_signup_auth_member_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRequestCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignupRequestRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/auth/member/logout": {
       "post": {
         "tags": [
@@ -2801,6 +2843,196 @@
                     ]
                   },
                   "title": "Response Delete Admin Hero Item Admin Hero  Hero Item Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/signup-requests/": {
+      "get": {
+        "tags": [
+          "admin-signup-requests"
+        ],
+        "summary": "List Signup Requests",
+        "operationId": "list_signup_requests_admin_signup_requests__get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "pending",
+                    "approved",
+                    "rejected",
+                    "activated"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignupRequestListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/signup-requests/{signup_request_id}/approve": {
+      "post": {
+        "tags": [
+          "admin-signup-requests"
+        ],
+        "summary": "Approve Signup Request",
+        "operationId": "approve_signup_request_admin_signup_requests__signup_request_id__approve_post",
+        "parameters": [
+          {
+            "name": "signup_request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Signup Request Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignupApproveResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/signup-requests/{signup_request_id}/reject": {
+      "post": {
+        "tags": [
+          "admin-signup-requests"
+        ],
+        "summary": "Reject Signup Request",
+        "operationId": "reject_signup_request_admin_signup_requests__signup_request_id__reject_post",
+        "parameters": [
+          {
+            "name": "signup_request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Signup Request Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupRejectPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignupRequestRead"
                 }
               }
             }
@@ -4818,6 +5050,289 @@
           "endpoint_tail"
         ],
         "title": "SendLogRead"
+      },
+      "SignupActivationContextResponse": {
+        "properties": {
+          "signup_request_id": {
+            "type": "integer",
+            "title": "Signup Request Id"
+          },
+          "student_id": {
+            "type": "string",
+            "title": "Student Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "cohort": {
+            "type": "integer",
+            "title": "Cohort"
+          }
+        },
+        "type": "object",
+        "required": [
+          "signup_request_id",
+          "student_id",
+          "email",
+          "name",
+          "cohort"
+        ],
+        "title": "SignupActivationContextResponse"
+      },
+      "SignupApproveResponse": {
+        "properties": {
+          "request": {
+            "$ref": "#/components/schemas/SignupRequestRead"
+          },
+          "activation_context": {
+            "$ref": "#/components/schemas/SignupActivationContextResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "request",
+          "activation_context"
+        ],
+        "title": "SignupApproveResponse"
+      },
+      "SignupRejectPayload": {
+        "properties": {
+          "reason": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reason"
+        ],
+        "title": "SignupRejectPayload"
+      },
+      "SignupRequestCreate": {
+        "properties": {
+          "student_id": {
+            "type": "string",
+            "title": "Student Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "cohort": {
+            "type": "integer",
+            "title": "Cohort"
+          },
+          "major": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Major"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "student_id",
+          "email",
+          "name",
+          "cohort"
+        ],
+        "title": "SignupRequestCreate"
+      },
+      "SignupRequestListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SignupRequestRead"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "SignupRequestListResponse"
+      },
+      "SignupRequestRead": {
+        "properties": {
+          "student_id": {
+            "type": "string",
+            "title": "Student Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "cohort": {
+            "type": "integer",
+            "title": "Cohort"
+          },
+          "major": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Major"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "activated"
+            ],
+            "title": "Status",
+            "default": "pending"
+          },
+          "requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested At"
+          },
+          "decided_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided At"
+          },
+          "activated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activated At"
+          },
+          "decided_by_student_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decided By Student Id"
+          },
+          "reject_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reject Reason"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "student_id",
+          "email",
+          "name",
+          "cohort",
+          "id"
+        ],
+        "title": "SignupRequestRead"
       },
       "SubscriptionPayload": {
         "properties": {

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from http import HTTPStatus
+from typing import cast
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api import models
+from apps.api.db import get_db
+from apps.api.main import app
+
+
+def _run_in_test_session(fn: Callable[[AsyncSession], Awaitable[None]]) -> None:
+    override = app.dependency_overrides.get(get_db)
+    if override is None:
+        raise RuntimeError("get_db override not found")
+
+    async def _run() -> None:
+        async for session in override():
+            await fn(session)
+            return
+        raise RuntimeError("test session was not yielded")
+
+    asyncio.run(_run())
+
+
+def test_member_signup_success(client: TestClient) -> None:
+    response = client.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116001",
+            "email": "s116001@test.example.com",
+            "name": "신청자",
+            "cohort": 2024,
+            "major": "경제학",
+            "phone": "010-1234-5678",
+            "note": "가입 신청합니다.",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.CREATED
+    body = response.json()
+    assert body["student_id"] == "s116001"
+    assert body["status"] == "pending"
+    assert body["phone"] == "010-1234-5678"
+    assert body["note"] == "가입 신청합니다."
+
+
+def test_member_signup_duplicate_pending_returns_409(client: TestClient) -> None:
+    payload = {
+        "student_id": "s116002",
+        "email": "s116002@test.example.com",
+        "name": "신청자",
+        "cohort": 2024,
+    }
+    first = client.post("/auth/member/signup", json=payload)
+    assert first.status_code == HTTPStatus.CREATED
+
+    second = client.post("/auth/member/signup", json=payload)
+    assert second.status_code == HTTPStatus.CONFLICT
+    assert second.json()["code"] == "signup_already_pending"
+
+
+def test_member_signup_active_member_conflict_returns_409(client: TestClient) -> None:
+    async def _seed_active_member(session: AsyncSession) -> None:
+        session.add(
+            models.Member(
+                student_id="s116003",
+                email="s116003@test.example.com",
+                name="기존회원",
+                cohort=2020,
+                roles="member",
+                status="active",
+            )
+        )
+        await session.commit()
+
+    _run_in_test_session(_seed_active_member)
+
+    response = client.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116003",
+            "email": "s116003@test.example.com",
+            "name": "신청자",
+            "cohort": 2024,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["code"] == "member_already_active"
+
+
+def test_admin_signup_review_approve_and_reject(
+    admin_login: TestClient,
+    member_login: TestClient,
+) -> None:
+    create_res = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116004",
+            "email": "s116004@test.example.com",
+            "name": "승인대상",
+            "cohort": 2024,
+            "note": "승인 요청",
+        },
+    )
+    assert create_res.status_code == HTTPStatus.CREATED
+    signup_id = create_res.json()["id"]
+
+    forbidden_res = member_login.get("/admin/signup-requests")
+    assert forbidden_res.status_code == HTTPStatus.FORBIDDEN
+    assert forbidden_res.json()["detail"] == "admin_permission_required"
+
+    relogin_res = admin_login.post(
+        "/auth/login",
+        json={"student_id": "__seed__admin", "password": "__seed__"},
+    )
+    assert relogin_res.status_code == HTTPStatus.OK
+
+    list_res = admin_login.get("/admin/signup-requests?status=pending")
+    assert list_res.status_code == HTTPStatus.OK
+    assert list_res.json()["total"] >= 1
+
+    approve_res = admin_login.post(f"/admin/signup-requests/{signup_id}/approve")
+    assert approve_res.status_code == HTTPStatus.OK
+    approve_body = approve_res.json()
+    assert approve_body["request"]["status"] == "approved"
+    assert approve_body["request"]["decided_by_student_id"] == "__seed__admin"
+    assert approve_body["activation_context"]["signup_request_id"] == signup_id
+
+    async def _assert_approved_member(session: AsyncSession) -> None:
+        stmt = select(models.Member).where(models.Member.student_id == "s116004")
+        member = (await session.execute(stmt)).scalars().first()
+        assert member is not None
+        assert cast(str, member.status) == "active"
+
+    _run_in_test_session(_assert_approved_member)
+
+    reject_create = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116005",
+            "email": "s116005@test.example.com",
+            "name": "반려대상",
+            "cohort": 2024,
+        },
+    )
+    assert reject_create.status_code == HTTPStatus.CREATED
+    reject_id = reject_create.json()["id"]
+
+    reject_res = admin_login.post(
+        f"/admin/signup-requests/{reject_id}/reject",
+        json={"reason": "학번 확인 불가"},
+    )
+    assert reject_res.status_code == HTTPStatus.OK
+    reject_body = reject_res.json()
+    assert reject_body["status"] == "rejected"
+    assert reject_body["reject_reason"] == "학번 확인 불가"


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항:
  - Epic #113의 #116 단계로, 신규 가입신청 진입점과 관리자 심사(승인/반려) API를 표준화해야 합니다.
- 목표/범위(Scope):
  - Public: `POST /auth/member/signup`
  - Admin: `GET /admin/signup-requests`, `POST /admin/signup-requests/{id}/approve`, `POST /admin/signup-requests/{id}/reject`
  - `admin_signup` 권한 가드 + roles 단일 파서 도입
  - `signup_requests.phone/note` 스키마 확장
- 비범위(Out of Scope):
  - 활성화 토큰 소비/검증(#117)
  - 로그인 게이트(#117)
  - 권한 토글 API(#118)

## 주요 변경사항
- API:
  - `apps/api/routers/auth.py`
    - `POST /auth/member/signup` 추가
  - `apps/api/routers/admin_signup_requests.py` (신규)
    - 관리자 심사 목록/승인/반려 API 추가
  - `apps/api/services/signup_service.py` (신규)
    - 신청 생성/조회/승인/반려 비즈니스 로직 추가
  - `apps/api/services/roles_service.py` (신규)
    - roles 단일 파서 및 권한 판단 유틸 추가
  - `apps/api/services/auth_service.py`
    - `require_permission()` 추가
    - 관리자 로그인 세션 roles를 `members.roles` 기준으로 설정하도록 보정
  - `apps/api/repositories/signup_requests.py` (신규)
    - 가입신청 CRUD/검색/카운트 repository 추가
- Web:
  - 변경 없음
- 스키마/마이그레이션:
  - `apps/api/models.py` / `apps/api/schemas.py`
    - `signup_requests.phone`, `signup_requests.note` 반영
  - `apps/api/migrations/versions/b6d2e8f1c4a7_add_phone_note_to_signup_requests.py`
    - 컬럼 확장 마이그레이션 추가
  - `packages/schemas/openapi.json`, `packages/schemas/index.d.ts` 재생성
- 문서:
  - `docs/dev_log_260218.md` 업데이트

## 스크린샷/데모(선택)
- [ ] UI 변경이 있는 경우 캡처/동영상 첨부

## 테스트 노트
- 수동 테스트 절차:
  - `ruff check ...` (변경 Python 파일)
  - `pyright ...` (변경 Python 파일)
  - `pytest -q tests/api/test_signup_requests_api.py tests/api/test_auth.py tests/api/test_reset_data.py`
  - `make db-test-reset`
  - `DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test alembic -c apps/api/alembic.ini upgrade head`
  - `DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test alembic -c apps/api/alembic.ini downgrade -1`
  - `DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test alembic -c apps/api/alembic.ini upgrade head`
  - `bandit -r apps/api -x apps/api/migrations -q`
- 예상 영향 범위:
  - 인증/세션 roles 해석
  - 가입신청 도메인 및 관리자 심사 경로
  - OpenAPI/DTO 산출물

## 배포/롤백
- 배포 전 체크(마이그레이션 등):
  - API 배포 전 Alembic head 적용 필요
- 롤백 전략:
  - `b6d2e8f1c4a7` downgrade 가능
 - 다운타임/락 리스크: ( ) 없음  (x) 경미  ( ) 주의 — 세부: [x] 배포 시 알림  [x] 롤백 절차 검증

---

## Draft 체크리스트(초안 단계)
- [x] 문제 정의와 범위를 템플릿에 명시했다
- [x] API/DB/Web 중 어디를 건드리는지 표시했다
- [x] 남은 TODO를 본문에 정리했다(작은 단위 권장)
- [ ] 필요 시 와이어프레임/모형/샘플 데이터 첨부
- [x] (계획서 포함 시) 본 PR에서 계획 범위를 전부 구현할 것임을 명시했다

## Ready for Review 체크리스트(검토 요청 시)
- 일반
  - [ ] Conventional Commits 규칙을 따른다(`type(scope): subject`, 72자 이내)
  - [ ] 한국어 커밋/PR 설명, 한국어 코드 주석(베이스 문서 규정 준수)
  - [ ] `docs/dev_log_YYMMDD.md` 최신 항목 포함(비-문서 변경 푸시용)
- 품질/규칙(Repo Guards와 일치)
  - [ ] 린트 우회 주석 없음(`eslint-disable`, `@ts-...`, `# type: ignore`, `# noqa` 등)
  - [ ] 모듈 600줄 이하, 순환복잡도 ≤ 10, import cycle 없음
  - [ ] TS에 `any`/이중 캐스트/과도한 non-null 미사용, Python에 `Any` 기반 페이로드 회피
- API
  - [ ] 로컬 `pyright` 통과, `ruff` 통과(우회 주석 없이)
  - [ ] 마이그레이션이 있으면 `alembic -c apps/api/alembic.ini upgrade head` 확인
  - [ ] 파괴적 변경(락/다운타임 가능)이면 라벨과 설명을 PR 본문에 명시
  - [ ] 레이트리밋/보안 헤더 영향 검토(변경 시 `docs/security_hardening.md` 반영)
- Web
  - [ ] 로컬 `pnpm -C apps/web build` 성공(경고/에러 없음)
  - [ ] ESLint(Flat config) 통과, 우회 주석 없음
  - [ ] Tailwind 유틸/토큰 사용 검증(필요 시 스냅샷 첨부)
- 보안/컴플라이언스
  - [ ] 비밀/자격증명/토큰 미포함, `.env` 변경 없음
  - [ ] 외부 데이터/로그에 개인 식별 가능 정보 미노출
- 문서
  - [ ] 변경 사항이 `docs/architecture.md`, `docs/pwa_push.md`, `docs/versions.md` 등과 모순되지 않음
  - [ ] (계획서 포함 시) 계획서 범위를 본 PR에서 전부 구현 완료했고, 문서/SSOT를 반영했다

Closes #116
