### PR TITLE
chore(ci): #131 web audit GHSA ignore 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,9 @@ jobs:
         run: pnpm -C apps/web exec vitest run __tests__/a11y-smoke.test.tsx --silent
       - name: Bundle size check (raw JS total ≤ 1125KB)
         run: node apps/web/scripts/check-bundle-size.mjs --max-kb 1125 --exclude-prefix app/admin/
-      - name: Dependency audit (pnpm, prod only + temporary GHSA waiver)
+      - name: Dependency audit (pnpm, prod only)
         run: |
-          pnpm -C apps/web audit --audit-level=high --prod \
-            --ignore GHSA-3ppc-4f35-3m26
+          pnpm -C apps/web audit --audit-level=high --prod
 
   secrets-scan:
     if: ${{ github.event.pull_request.draft == false }}

--- a/docs/dev_log_260220.md
+++ b/docs/dev_log_260220.md
@@ -7,3 +7,4 @@
 - Fixed: 테스트 간 로그인 레이트리밋 누적으로 인한 간헐적 401 실패를 `tests/api/conftest.py` limiter reset fixture로 안정화(PR #130)
 - Changed: 서비스 DTO 11개 파일의 수동 타입을 OpenAPI 생성 스키마(Schema<K> 헬퍼)로 전환 (#126)
 - Fixed: 리뷰 반영 — CreatePostPayload에서 view_count 제외, CommentCreate에서 author_id 차단
+- Changed: #131 임시 예외 정리 — CI web audit에서 `--ignore GHSA-3ppc-4f35-3m26` 제거(계속 `--prod` 기준)


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항:
  - CI web audit 단계에서 `--ignore GHSA-3ppc-4f35-3m26` 임시 예외를 제거해야 함(#131)
- 목표/범위(Scope):
  - `.github/workflows/ci.yml`의 web audit 명령에서 GHSA ignore 제거
  - dev_log에 변경 이력 반영
- 비범위(Out of Scope):
  - devDependencies 전체 경로(full audit) 취약점 해소

## 주요 변경사항
- API: 없음
- Web: 없음
- CI:
  - `pnpm -C apps/web audit --audit-level=high --prod --ignore GHSA-3ppc-4f35-3m26`
  - -> `pnpm -C apps/web audit --audit-level=high --prod`
- 문서:
  - `docs/dev_log_260220.md` 항목 추가

## 테스트 노트
- `pnpm -C apps/web audit --audit-level=high --prod` ✅ 통과
- 참고: `pnpm -C apps/web audit --audit-level=high`는 여전히 GHSA-3ppc-4f35-3m26로 실패(업스트림 체인 영향)

## 배포/롤백
- 배포 전 체크: 없음
- 롤백 전략: 본 PR revert
- 다운타임/락 리스크: (x) 없음

Refs: #131