### PR TITLE
fix(web): 회원가입 입력 null value 런타임 오류 수정

### DIFF
--- a/apps/web/__tests__/hero-item-form.test.tsx
+++ b/apps/web/__tests__/hero-item-form.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+import { HeroItemForm } from '../components/hero-item-form';
+
+vi.mock('../components/image-upload', () => ({
+  ImageUpload: () => <div data-testid="image-upload-mock" />,
+}));
+
+describe('HeroItemForm', () => {
+  it('입력 변경 후 제출 시 최신 폼 값으로 payload를 생성한다', () => {
+    const onSubmit = vi.fn();
+    render(<HeroItemForm onSubmit={(payload) => onSubmit(payload)} />);
+
+    const targetTypeSelect = screen.getByLabelText('대상 종류') as HTMLSelectElement;
+    const targetIdInput = screen.getByPlaceholderText('예: 123') as HTMLInputElement;
+    const enabledCheckbox = screen.getByLabelText('홈 배너 노출') as HTMLInputElement;
+    const pinnedCheckbox = screen.getByLabelText('홈 배너 상단 고정') as HTMLInputElement;
+    const titleInput = screen.getByLabelText('제목(옵션)') as HTMLInputElement;
+    const descriptionInput = screen.getByLabelText('설명(옵션)') as HTMLTextAreaElement;
+
+    fireEvent.change(targetTypeSelect, { target: { value: 'event' } });
+    fireEvent.change(targetIdInput, { target: { value: '42' } });
+    fireEvent.click(enabledCheckbox);
+    fireEvent.click(pinnedCheckbox);
+    fireEvent.change(titleInput, { target: { value: '  테스트 제목  ' } });
+    fireEvent.change(descriptionInput, { target: { value: '  테스트 설명  ' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      target_type: 'event',
+      target_id: 42,
+      enabled: false,
+      pinned: true,
+      title_override: '테스트 제목',
+      description_override: '테스트 설명',
+      image_override: null,
+    });
+  });
+});

--- a/apps/web/__tests__/signup-page.test.tsx
+++ b/apps/web/__tests__/signup-page.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+import SignupPage from '../app/signup/page';
+import { renderWithProviders } from '../tests/render-with-providers';
+
+const showMock = vi.fn();
+
+vi.mock('../components/toast', () => ({
+  useToast: () => ({ show: showMock }),
+}));
+
+describe('SignupPage', () => {
+  beforeEach(() => {
+    showMock.mockReset();
+  });
+
+  it('입력 변경 시 이벤트 객체 수명과 무관하게 값이 반영된다', () => {
+    renderWithProviders(<SignupPage />);
+
+    const studentIdInput = screen.getByLabelText('학번') as HTMLInputElement;
+    const nameInput = screen.getByLabelText('이름') as HTMLInputElement;
+    const emailInput = screen.getByLabelText('이메일') as HTMLInputElement;
+    const cohortInput = screen.getByLabelText('기수') as HTMLInputElement;
+    const noteInput = screen.getByLabelText('메모(선택)') as HTMLTextAreaElement;
+
+    fireEvent.change(studentIdInput, { target: { value: '20260001' } });
+    fireEvent.change(nameInput, { target: { value: '홍길동' } });
+    fireEvent.change(emailInput, { target: { value: 'hong@example.com' } });
+    fireEvent.change(cohortInput, { target: { value: '58' } });
+    fireEvent.change(noteInput, { target: { value: '테스트 메모' } });
+
+    expect(studentIdInput.value).toBe('20260001');
+    expect(nameInput.value).toBe('홍길동');
+    expect(emailInput.value).toBe('hong@example.com');
+    expect(cohortInput.value).toBe('58');
+    expect(noteInput.value).toBe('테스트 메모');
+  });
+});

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -154,9 +154,10 @@ export default function SignupPage() {
             required
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.studentId}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, studentId: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, studentId: value }));
+            }}
           />
         </label>
 
@@ -166,9 +167,10 @@ export default function SignupPage() {
             required
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.name}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, name: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, name: value }));
+            }}
           />
         </label>
 
@@ -179,9 +181,10 @@ export default function SignupPage() {
             type="email"
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.email}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, email: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, email: value }));
+            }}
           />
         </label>
 
@@ -192,9 +195,10 @@ export default function SignupPage() {
             inputMode="numeric"
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.cohort}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, cohort: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, cohort: value }));
+            }}
           />
         </label>
 
@@ -203,9 +207,10 @@ export default function SignupPage() {
           <input
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.major}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, major: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, major: value }));
+            }}
           />
         </label>
 
@@ -214,9 +219,10 @@ export default function SignupPage() {
           <input
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.phone}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, phone: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, phone: value }));
+            }}
           />
         </label>
 
@@ -226,9 +232,10 @@ export default function SignupPage() {
             rows={4}
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.note}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, note: e.currentTarget.value }))
-            }
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setForm((prev) => ({ ...prev, note: value }));
+            }}
           />
         </label>
 

--- a/apps/web/components/hero-item-form.tsx
+++ b/apps/web/components/hero-item-form.tsx
@@ -118,7 +118,10 @@ export function HeroItemForm({
           <select
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.target_type}
-            onChange={(e) => setForm((prev) => ({ ...prev, target_type: e.currentTarget.value as HeroTargetType }))}
+            onChange={(e) => {
+              const value = e.currentTarget.value as HeroTargetType;
+              setForm((prev) => ({ ...prev, target_type: value }));
+            }}
             disabled={isPending}
           >
             <option value="post">게시글</option>
@@ -133,7 +136,10 @@ export function HeroItemForm({
             type="number"
             min={1}
             value={formatTargetIdValue(form.target_id)}
-            onChange={(e) => setForm((prev) => ({ ...prev, target_id: toInt(e.currentTarget.value) }))}
+            onChange={(e) => {
+              const value = toInt(e.currentTarget.value);
+              setForm((prev) => ({ ...prev, target_id: value }));
+            }}
             disabled={isPending}
             inputMode="numeric"
             placeholder="예: 123"
@@ -149,7 +155,10 @@ export function HeroItemForm({
           <input
             type="checkbox"
             checked={form.enabled}
-            onChange={(e) => setForm((prev) => ({ ...prev, enabled: e.currentTarget.checked }))}
+            onChange={(e) => {
+              const checked = e.currentTarget.checked;
+              setForm((prev) => ({ ...prev, enabled: checked }));
+            }}
             disabled={isPending}
             className="rounded border-neutral-border"
           />
@@ -160,7 +169,10 @@ export function HeroItemForm({
           <input
             type="checkbox"
             checked={form.pinned}
-            onChange={(e) => setForm((prev) => ({ ...prev, pinned: e.currentTarget.checked }))}
+            onChange={(e) => {
+              const checked = e.currentTarget.checked;
+              setForm((prev) => ({ ...prev, pinned: checked }));
+            }}
             disabled={isPending}
             className="rounded border-neutral-border"
           />
@@ -173,7 +185,10 @@ export function HeroItemForm({
         <input
           className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
           value={form.title_override}
-          onChange={(e) => setForm((prev) => ({ ...prev, title_override: e.currentTarget.value }))}
+          onChange={(e) => {
+            const value = e.currentTarget.value;
+            setForm((prev) => ({ ...prev, title_override: value }));
+          }}
           disabled={isPending}
           placeholder="비워두면 대상(행사/게시글) 제목을 사용합니다."
         />
@@ -185,7 +200,10 @@ export function HeroItemForm({
           className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
           rows={3}
           value={form.description_override}
-          onChange={(e) => setForm((prev) => ({ ...prev, description_override: e.currentTarget.value }))}
+          onChange={(e) => {
+            const value = e.currentTarget.value;
+            setForm((prev) => ({ ...prev, description_override: value }));
+          }}
           disabled={isPending}
           placeholder="비워두면 대상 설명/본문을 사용합니다."
         />

--- a/docs/dev_log_260223.md
+++ b/docs/dev_log_260223.md
@@ -3,4 +3,5 @@
 - Fixed: 회원가입(`/signup`) 입력 중 간헐적으로 발생하던 `Cannot read properties of null (reading 'value')` 런타임 오류 수정 (frontend impact)
 - Changed: 입력 핸들러에서 `e.currentTarget.value`를 즉시 캡처한 뒤 상태 업데이트하도록 변경하여 이벤트 수명 주기 영향 제거
 - Added: `__tests__/signup-page.test.tsx` 신규 추가로 회원가입 입력 반영 회귀 테스트 보강
+- Fixed: `hero-item-form.tsx` 동일 패턴(`e.currentTarget` 지연 참조) 6건 일괄 수정 (frontend impact)
 - Notes: `/auth/session` 401은 비로그인 상태에서 인증 확인 요청 시 정상 동작(unauthorized 분기)으로 확인

--- a/docs/dev_log_260223.md
+++ b/docs/dev_log_260223.md
@@ -1,0 +1,6 @@
+# 2026-02-23
+
+- Fixed: 회원가입(`/signup`) 입력 중 간헐적으로 발생하던 `Cannot read properties of null (reading 'value')` 런타임 오류 수정 (frontend impact)
+- Changed: 입력 핸들러에서 `e.currentTarget.value`를 즉시 캡처한 뒤 상태 업데이트하도록 변경하여 이벤트 수명 주기 영향 제거
+- Added: `__tests__/signup-page.test.tsx` 신규 추가로 회원가입 입력 반영 회귀 테스트 보강
+- Notes: `/auth/session` 401은 비로그인 상태에서 인증 확인 요청 시 정상 동작(unauthorized 분기)으로 확인

--- a/docs/dev_log_260223.md
+++ b/docs/dev_log_260223.md
@@ -4,4 +4,5 @@
 - Changed: 입력 핸들러에서 `e.currentTarget.value`를 즉시 캡처한 뒤 상태 업데이트하도록 변경하여 이벤트 수명 주기 영향 제거
 - Added: `__tests__/signup-page.test.tsx` 신규 추가로 회원가입 입력 반영 회귀 테스트 보강
 - Fixed: `hero-item-form.tsx` 동일 패턴(`e.currentTarget` 지연 참조) 6건 일괄 수정 (frontend impact)
+- Added: `__tests__/hero-item-form.test.tsx` 신규 추가로 HeroItemForm 제출 payload 회귀 테스트 보강
 - Notes: `/auth/session` 401은 비로그인 상태에서 인증 확인 요청 시 정상 동작(unauthorized 분기)으로 확인


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항: `/signup` 페이지 입력 도중 간헐적으로 `Cannot read properties of null (reading 'value')` 런타임 오류가 발생했습니다.
- 목표/범위(Scope): 회원가입 폼 입력 핸들러 안정화, 동일 증상 회귀 방지 테스트 추가.
- 비범위(Out of Scope): `/auth/session` 401 응답 정책 변경, 폰트 preload 경고 최적화.

## 주요 변경사항
- API: 없음
- Web: `apps/web/app/signup/page.tsx`의 입력 핸들러에서 `e.currentTarget.value`를 즉시 캡처 후 상태 업데이트하도록 변경
- Web: `apps/web/__tests__/signup-page.test.tsx` 추가(입력 변경 회귀 테스트)
- 스키마/마이그레이션: 없음
- 문서(architecture/pwa_push/versions 등): `docs/dev_log_260223.md` 추가

## 스크린샷/데모(선택)
- [ ] UI 변경이 있는 경우 캡처/동영상 첨부

## 테스트 노트
- 수동 테스트 절차:
  - `/signup` 진입 후 각 입력 필드에 반복 입력 시 콘솔 오류 미발생 확인
  - 가입신청 제출 버튼 동작/유효성 메시지 정상 확인
- 예상 영향 범위:
  - 회원가입 페이지 입력 이벤트 처리 로직
- 남은 TODO:
  - 운영 배포 후 브라우저 콘솔에서 동일 스택 트레이스 재발 여부 모니터링

## 배포/롤백
- 배포 전 체크(마이그레이션 등): 마이그레이션 없음. 웹 빌드/배포만 진행.
- 롤백 전략: 이전 웹 릴리스로 즉시 롤백(standalone/current 심볼릭 링크 되돌리기)
 - 다운타임/락 리스크: (X) 없음  ( ) 경미  ( ) 주의 — 세부: [ ] 배포 시 알림  [ ] 롤백 절차 검증
