### PR TITLE
feat(web): add visible PWA install button and fallback guidance

### DIFF
--- a/apps/web/components/drawer-menu.tsx
+++ b/apps/web/components/drawer-menu.tsx
@@ -7,6 +7,7 @@ import { NotifyCTA } from './notify-cta';
 import { logoutAll } from '../services/auth';
 import { useAuth } from '../hooks/useAuth';
 import { ADMIN_NAV_LINKS } from './admin-nav-links';
+import { InstallAppButton } from './install-app-button';
 import {
   hasPermissionSession,
   isAdminSession,
@@ -269,6 +270,10 @@ export function DrawerMenu({ status, onClose }: DrawerMenuProps) {
           )}
         </div>
       </RequireAdmin>
+
+      <div className="border-t border-neutral-border pt-4">
+        <InstallAppButton variant="drawer" />
+      </div>
 
       {/* 푸시 알림 구독 CTA */}
       <NotifyCTA />

--- a/apps/web/components/install-app-button.tsx
+++ b/apps/web/components/install-app-button.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from 'react';
+import { useToast } from './toast';
+import { usePwaInstallPrompt } from '../hooks/usePwaInstallPrompt';
+
+type InstallAppButtonProps = {
+  variant?: 'desktop' | 'drawer';
+};
+
+export function InstallAppButton({ variant = 'desktop' }: InstallAppButtonProps) {
+  const toast = useToast();
+  const { canPromptInstall, isInstalled, isIOSSafari, promptInstall } = usePwaInstallPrompt();
+  const [busy, setBusy] = useState(false);
+
+  if (isInstalled) return null;
+
+  const onClick = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      if (canPromptInstall) {
+        const outcome = await promptInstall();
+        if (outcome === 'accepted') {
+          toast.show('설치 요청을 보냈습니다. 설치가 완료되면 앱 아이콘이 추가됩니다.', {
+            type: 'success',
+            durationMs: 3500,
+          });
+          return;
+        }
+        if (outcome === 'dismissed') {
+          toast.show('설치가 취소되었습니다.', { type: 'info' });
+          return;
+        }
+      }
+
+      if (isIOSSafari) {
+        toast.show('Safari 공유 버튼에서 "홈 화면에 추가"를 선택해 주세요.', {
+          type: 'info',
+          durationMs: 4500,
+        });
+        return;
+      }
+
+      toast.show('브라우저 메뉴에서 "앱 설치" 또는 "홈 화면에 추가"를 선택해 주세요.', {
+        type: 'info',
+        durationMs: 4500,
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (variant === 'drawer') {
+    return (
+      <button
+        type="button"
+        disabled={busy}
+        onClick={onClick}
+        className="w-full rounded-[10px] border border-brand-primary px-3 py-2.5 text-sm text-brand-primary transition-colors hover:bg-brand-primary/5 disabled:opacity-50"
+      >
+        앱 설치하기
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={onClick}
+      className="px-3 py-2 text-sm text-brand-700 border border-brand-700 rounded-lg hover:bg-brand-50 transition-colors disabled:opacity-50"
+    >
+      앱 설치
+    </button>
+  );
+}

--- a/apps/web/components/install-app-button.tsx
+++ b/apps/web/components/install-app-button.tsx
@@ -69,7 +69,7 @@ export function InstallAppButton({ variant = 'desktop' }: InstallAppButtonProps)
       type="button"
       disabled={busy}
       onClick={onClick}
-      className="px-3 py-2 text-sm text-brand-700 border border-brand-700 rounded-lg hover:bg-brand-50 transition-colors disabled:opacity-50"
+      className="px-3 py-2 text-sm text-brand-primary border border-brand-primary rounded-lg hover:bg-brand-primary/5 transition-colors disabled:opacity-50"
     >
       앱 설치
     </button>

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -10,6 +10,7 @@ import { logoutAll } from '../services/auth';
 import { HeaderDropdown } from './header-dropdown';
 import { hasPermissionSession, isAdminSession } from '../lib/rbac';
 import { ADMIN_NAV_LINKS } from './admin-nav-links';
+import { InstallAppButton } from './install-app-button';
 
 const ABOUT_ITEMS = [
   { href: '/about/greeting', label: '총동문회장 인사말' },
@@ -97,6 +98,7 @@ function DesktopAuthButtons({ status, name }: { status: string; name?: string })
   if (status === 'authorized') {
     return (
       <div className="hidden lg:flex items-center gap-2">
+        <InstallAppButton />
         <Link
           href="/me"
           className="flex items-center gap-1.5 px-3 py-2 text-sm text-neutral-ink no-underline hover:no-underline hover:text-brand-700 transition-colors"
@@ -123,6 +125,7 @@ function DesktopAuthButtons({ status, name }: { status: string; name?: string })
 
   return (
     <div className="hidden lg:flex items-center gap-2">
+      <InstallAppButton />
       <Link
         href="/login"
         className="px-3 py-2 text-sm text-white bg-brand-700 rounded-lg no-underline hover:no-underline hover:text-white hover:bg-brand-800 transition-colors"

--- a/apps/web/hooks/usePwaInstallPrompt.ts
+++ b/apps/web/hooks/usePwaInstallPrompt.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useState } from 'react';
+
+type InstallOutcome = 'accepted' | 'dismissed' | 'unavailable';
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+};
+
+function isStandaloneMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  const nav = navigator as Navigator & { standalone?: boolean };
+  return window.matchMedia('(display-mode: standalone)').matches || nav.standalone === true;
+}
+
+function isIOSSafari(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent.toLowerCase();
+  const isIOSDevice =
+    /iphone|ipad|ipod/.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+  const isSafari = /safari/.test(ua) && !/crios|fxios|edgios|optios/.test(ua);
+  return isIOSDevice && isSafari;
+}
+
+export function usePwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [iosSafari, setIosSafari] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    setIosSafari(isIOSSafari());
+    const syncInstalled = () => setIsInstalled(isStandaloneMode());
+    syncInstalled();
+
+    const media = window.matchMedia('(display-mode: standalone)');
+    const onDisplayModeChange = () => syncInstalled();
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', onDisplayModeChange);
+    } else {
+      media.addListener(onDisplayModeChange);
+    }
+
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+    };
+    const onAppInstalled = () => {
+      setDeferredPrompt(null);
+      setIsInstalled(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt as EventListener);
+    window.addEventListener('appinstalled', onAppInstalled);
+
+    return () => {
+      if (typeof media.removeEventListener === 'function') {
+        media.removeEventListener('change', onDisplayModeChange);
+      } else {
+        media.removeListener(onDisplayModeChange);
+      }
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt as EventListener);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async (): Promise<InstallOutcome> => {
+    if (!deferredPrompt) return 'unavailable';
+    await deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    if (choice.outcome === 'accepted') {
+      setIsInstalled(true);
+    }
+    return choice.outcome;
+  }, [deferredPrompt]);
+
+  return {
+    canPromptInstall: deferredPrompt !== null,
+    isInstalled,
+    isIOSSafari: iosSafari,
+    promptInstall,
+  };
+}

--- a/docs/dev_log_260224.md
+++ b/docs/dev_log_260224.md
@@ -7,3 +7,4 @@
 - Chore: 더 이상 사용하지 않는 `public/icons/icon-192.svg`, `public/icons/icon-512.svg` 정리
 - Fixed: `app/favicon.ico/route.ts` 제거로 `public/favicon.ico`가 정상 서빙되도록 정리
 - Ops/Docs: `docs/pwa_push.md`에 아이콘 교체 시 `manifest` 버전 쿼리(`?v=YYYYMMDD`) 동시 갱신 규칙 명시
+- Added: 헤더/모바일 드로어에 `앱 설치` 버튼 추가 (`beforeinstallprompt` 지원 시 즉시 설치, iOS Safari는 "홈 화면에 추가" 안내)


### PR DESCRIPTION
## 배경
- 브라우저에서 PWA 설치 진입점이 눈에 잘 보이지 않아 설치가 어렵다는 운영 피드백이 있었습니다.
- 특히 iOS Safari는 자동 설치 프롬프트가 거의 나타나지 않아 수동 안내가 필요했습니다.

## 변경 사항
- 설치 버튼 추가
  - 데스크톱 헤더: `apps/web/components/site-header.tsx`
  - 모바일 드로어: `apps/web/components/drawer-menu.tsx`
- 새 컴포넌트: `apps/web/components/install-app-button.tsx`
  - `beforeinstallprompt` 지원 브라우저: 즉시 설치 프롬프트 호출
  - iOS Safari: "공유 > 홈 화면에 추가" 안내 토스트 노출
  - 기타 브라우저: 메뉴의 "앱 설치/홈 화면에 추가" 안내
- 새 훅: `apps/web/hooks/usePwaInstallPrompt.ts`
  - 설치 가능 이벤트 수집(`beforeinstallprompt`)
  - 설치 완료 상태 감지(`appinstalled`, `display-mode: standalone`)
- 운영 로그 반영: `docs/dev_log_260224.md`

## 검증
- `pnpm -C apps/web build` 성공

## 기대 효과
- 사용자가 설치 경로를 즉시 찾을 수 있어 설치 전환율 개선
- iOS/비지원 브라우저에서도 실패 원인 불명 상태를 줄이고 안내 일관성 확보
