### PR TITLE
fix(api,web): consume_limit 누적 등록 버그 수정 및 PWA/알림 UI 개선

### DIFF
--- a/apps/api/ratelimit.py
+++ b/apps/api/ratelimit.py
@@ -28,17 +28,30 @@ class _LimiterProto(Protocol):
         ...
 
 
+# 데코레이트된 함수 캐시: limiter.limit() 재등록으로 인한 _route_limits 누적 방지
+_consume_cache: dict[str, Callable[[Request], None]] = {}
+
+
 def consume_limit(limiter: Limiter, request: Request, limit_value: str) -> None:
-    """요청 단위 레이트리밋 토큰 소비(테스트 클라이언트 분기에서 활용)."""
+    """요청 단위 레이트리밋 토큰 소비(테스트 클라이언트 분기에서 활용).
 
-    def _consume(request: Request) -> None:
-        return None
-
+    동일 (limiter id, path, limit_value) 조합에 대해 데코레이트된 함수를
+    한 번만 생성·등록하고 이후에는 캐시된 함수를 재사용하여
+    _route_limits 누적에 의한 다중 토큰 차감 버그를 방지합니다.
+    """
     path_key = request.url.path.strip("/").replace("/", "_") or "root"
     limit_key = (
         limit_value.replace("/", "_").replace(" ", "").replace("-", "_").lower()
     )
-    _consume.__name__ = f"consume_{path_key}_{limit_key}"
+    cache_key = f"{id(limiter)}:{path_key}:{limit_key}"
 
-    limiter_typed: _LimiterProto = cast(_LimiterProto, limiter)
-    limiter_typed.limit(limit_value)(_consume)(request)
+    if cache_key not in _consume_cache:
+
+        def _consume(request: Request) -> None:
+            return None
+
+        _consume.__name__ = f"consume_{path_key}_{limit_key}"
+        limiter_typed: _LimiterProto = cast(_LimiterProto, limiter)
+        _consume_cache[cache_key] = limiter_typed.limit(limit_value)(_consume)
+
+    _consume_cache[cache_key](request)

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -87,6 +87,8 @@ export default async function RootLayout({
         {/* 이미지 CDN preconnect */}
         <link rel="preconnect" href="https://cdn.jsdelivr.net" />
         <link rel="manifest" href="/manifest.json" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
       </head>
       <body>

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -11,6 +11,7 @@ import { HeaderDropdown } from './header-dropdown';
 import { hasPermissionSession, isAdminSession } from '../lib/rbac';
 import { ADMIN_NAV_LINKS } from './admin-nav-links';
 import { InstallAppButton } from './install-app-button';
+import { HeaderNotifyCTA } from './header-notify-cta';
 
 const ABOUT_ITEMS = [
   { href: '/about/greeting', label: '총동문회장 인사말' },
@@ -99,6 +100,7 @@ function DesktopAuthButtons({ status, name }: { status: string; name?: string })
     return (
       <div className="hidden lg:flex items-center gap-2">
         <InstallAppButton />
+        <HeaderNotifyCTA />
         <Link
           href="/me"
           className="flex items-center gap-1.5 px-3 py-2 text-sm text-neutral-ink no-underline hover:no-underline hover:text-brand-700 transition-colors"


### PR DESCRIPTION
## Summary
- **consume_limit 누적 등록 버그 수정**: `limiter.limit()` 데코레이터가 매 호출마다 SlowAPI 내부 `_route_limits`에 누적 등록되어 요청당 토큰이 다중 차감되던 버그 수정. 캐시 딕셔너리(`_consume_cache`)로 동일 조합은 한 번만 등록.
  - 영향 범위: 알림 발송(`/admin/notifications/send`), 구독/해지, 로그인, 문의 등 `consume_limit` 사용 전 엔드포인트
  - 실제 증상: VPS에서 정상적인 1회 발송에도 429 반환 확인 (2026-02-24 09:38:05)
- **모바일 PWA beforeinstallprompt 타이밍 이슈 수정**: 모듈 스코프에서 이벤트를 선 캡처하여 React `useEffect` 등록 전 이벤트 유실 방지
- **iOS Safari PWA 메타태그 추가**: `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`
- **데스크톱 헤더에 알림 구독 버튼 배치**: `HeaderNotifyCTA` 컴포넌트가 미사용 상태였던 것을 `DesktopAuthButtons`에 배치

## Test plan
- [x] `test_notifications_auth.py` 4건 통과
- [x] `test_notifications_rate_concurrency.py` 1건 통과
- [x] `test_support_contact.py` 3건 통과 (consume_limit 사용)
- [x] TypeScript 타입 체크 — 이번 수정 파일 에러 없음
- [ ] VPS 배포 후 알림 발송 429 재현 안 되는지 확인
- [ ] 모바일 Chrome에서 PWA 설치 프롬프트 동작 확인
- [ ] 데스크톱에서 알림 구독 종 아이콘 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)