### PR TITLE
test(api): add consume_limit regression coverage

### DIFF
--- a/tests/test_ratelimit_consume.py
+++ b/tests/test_ratelimit_consume.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from slowapi import Limiter
+from starlette.requests import Request
+
+from apps.api import ratelimit
+
+
+def _build_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "client": ("1.2.3.4", 12345),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+@pytest.fixture(autouse=True)
+def clear_consume_cache() -> Generator[None, None, None]:
+    ratelimit._consume_cache.clear()
+    yield
+    ratelimit._consume_cache.clear()
+
+
+def test_consume_limit_reuses_decorated_consumer_per_path_and_limit() -> None:
+    limiter = Limiter(key_func=lambda request: "1.2.3.4")
+    path = "/notifications/admin/notifications/send"
+    limit_value = "6/minute"
+    route_key = "apps.api.ratelimit.consume_notifications_admin_notifications_send_6_minute"
+
+    for _ in range(6):
+        ratelimit.consume_limit(limiter, _build_request(path), limit_value)
+
+    assert len(limiter._route_limits.get(route_key, [])) == 1
+    assert len(ratelimit._consume_cache) == 1
+


### PR DESCRIPTION
## 변경 사항
- `consume_limit` 캐시 재사용 동작에 대한 회귀 테스트 추가
- 동일 path/limit 조합 반복 호출 시 `_route_limits`가 누적되지 않는지 검증

## 테스트
- `.venv/bin/pytest -q tests/test_ratelimit_consume.py`

## 배경
- 최근 `consume_limit` 누적 등록 버그 수정에 대한 재발 방지 목적입니다.
