### PR TITLE
fix(web): stabilize mobile install prompt and push error messaging

### DIFF
--- a/apps/web/components/notify-cta.tsx
+++ b/apps/web/components/notify-cta.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../hooks/useAuth';
 import { usePushSync } from '../hooks/usePushSync';
 import { useToast } from './toast';
 import { ApiError } from '../lib/api';
-import { subscribePush, unsubscribePush } from '../lib/push';
+import { subscribePushWithReason, unsubscribePush } from '../lib/push';
 import { deleteSubscription, saveSubscription } from '../services/notifications';
 
 export function NotifyCTA() {
@@ -26,12 +26,19 @@ export function NotifyCTA() {
         toast.show('VAPID 키가 설정되지 않았습니다(.env 확인).', { type: 'error' });
         return;
       }
-      const result = await subscribePush(vapid);
-      if (!result) {
-        toast.show('권한이 거부되었거나 구독에 실패했습니다. 브라우저 알림 권한을 확인하세요.', { type: 'error' });
+      const attempt = await subscribePushWithReason(vapid);
+      if (!attempt.ok) {
+        const reasonMessage: Record<string, string> = {
+          unsupported: '이 브라우저는 웹 푸시를 지원하지 않습니다.',
+          permission_denied: '브라우저 설정에서 이 사이트의 알림 권한을 허용해 주세요.',
+          permission_dismissed: '알림 권한 요청이 취소되었습니다.',
+          service_worker_unavailable: '서비스 워커 등록에 실패했습니다. 새로고침 후 다시 시도해 주세요.',
+          subscribe_failed: '구독 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.',
+        };
+        toast.show(reasonMessage[attempt.reason] ?? '구독에 실패했습니다.', { type: 'error' });
         return;
       }
-      await saveSubscription({ ...result, ua: navigator.userAgent });
+      await saveSubscription({ ...attempt.result, ua: navigator.userAgent });
       setSubscribed(true);
       toast.show('알림 구독이 활성화되었습니다.', { type: 'success' });
     } catch (e) {


### PR DESCRIPTION
## 변경 사항
- `usePwaInstallPrompt`를 전역 공유 상태로 전환해 `beforeinstallprompt` 이벤트를 버튼 인스턴스 간에 공유
- 모바일에서 숨겨진 버튼이 이벤트를 먼저 소비해 설치 버튼이 항상 안내 토스트로 떨어지던 문제 수정
- 푸시 구독 결과를 원인별(`권한 거부/취소`, `브라우저 미지원`, `SW 등록 실패`, `구독 생성 실패`)로 분리
- 헤더/드로어 알림 CTA의 에러 메시지를 원인별로 안내하도록 개선

## 검증
- `pnpm -C apps/web build`
- `bash ops/web-deploy.sh`
- `https://sogangeconomics.com/` 200
- `https://api.sogangeconomics.com/healthz` 200
