### PR TITLE
feat(web): 회원가입 연락처 필수화 및 테스트 보강

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -244,15 +244,15 @@ class SignupRequestCreate(BaseModel):
     name: str
     cohort: int
     major: str | None = None
-    phone: str | None = None
+    phone: str
     note: str | None = None
 
     @field_validator("phone")
     @classmethod
-    def _validate_phone(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
+    def _validate_phone(cls, value: str) -> str:
         trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("전화번호는 필수 입력값입니다.")
         if not _PHONE_PATTERN.fullmatch(trimmed):
             raise ValueError("전화번호는 숫자, +, -, 공백으로만 7~20자 입력해주세요.")
         return normalize_phone_digits(trimmed)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -252,7 +252,7 @@ class SignupRequestCreate(BaseModel):
     def _validate_phone(cls, value: str) -> str:
         trimmed = value.strip()
         if not trimmed:
-            raise ValueError("전화번호는 필수 입력값입니다.")
+            raise ValueError("전화번호를 입력해 주세요.")
         if not _PHONE_PATTERN.fullmatch(trimmed):
             raise ValueError("전화번호는 숫자, +, -, 공백으로만 7~20자 입력해주세요.")
         return normalize_phone_digits(trimmed)

--- a/apps/web/__tests__/about-pages.test.tsx
+++ b/apps/web/__tests__/about-pages.test.tsx
@@ -5,9 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import GreetingPage from '../app/about/greeting/page';
 import OrgPage from '../app/about/org/page';
 import HistoryPage from '../app/about/history/page';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { SiteHeader } from '../components/site-header';
-import { ToastProvider } from '../components/toast';
+import { renderSiteHeaderWithProviders } from './helpers/render-site-header-with-providers';
 
 // DrawerMenu dynamic import mock
 vi.mock('../components/lazy', () => ({
@@ -34,17 +32,6 @@ vi.mock('../components/require-admin', () => ({
 afterEach(() => {
   cleanup();
 });
-
-function renderSiteHeaderWithProviders() {
-  const queryClient = new QueryClient();
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <SiteHeader />
-      </ToastProvider>
-    </QueryClientProvider>
-  );
-}
 
 describe('About static pages', () => {
   it('renders greeting page hero and sections', () => {

--- a/apps/web/__tests__/about-pages.test.tsx
+++ b/apps/web/__tests__/about-pages.test.tsx
@@ -5,8 +5,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import GreetingPage from '../app/about/greeting/page';
 import OrgPage from '../app/about/org/page';
 import HistoryPage from '../app/about/history/page';
-import { SiteHeader } from '../components/site-header';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SiteHeader } from '../components/site-header';
+import { ToastProvider } from '../components/toast';
 
 // DrawerMenu dynamic import mock
 vi.mock('../components/lazy', () => ({
@@ -33,6 +34,17 @@ vi.mock('../components/require-admin', () => ({
 afterEach(() => {
   cleanup();
 });
+
+function renderSiteHeaderWithProviders() {
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <SiteHeader />
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
 
 describe('About static pages', () => {
   it('renders greeting page hero and sections', () => {
@@ -63,12 +75,7 @@ describe('About static pages', () => {
 
 describe('SiteHeader navigation', () => {
   it('exposes about links through drawer menu', () => {
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        <SiteHeader />
-      </QueryClientProvider>
-    );
+    renderSiteHeaderWithProviders();
     const toggleButton = screen.getByLabelText('전체 메뉴 열기');
     fireEvent.click(toggleButton);
 

--- a/apps/web/__tests__/helpers/render-site-header-with-providers.tsx
+++ b/apps/web/__tests__/helpers/render-site-header-with-providers.tsx
@@ -1,0 +1,17 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { SiteHeader } from '../../components/site-header';
+import { ToastProvider } from '../../components/toast';
+
+export function renderSiteHeaderWithProviders(): void {
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <SiteHeader />
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/__tests__/helpers/render-site-header-with-providers.tsx
+++ b/apps/web/__tests__/helpers/render-site-header-with-providers.tsx
@@ -6,7 +6,13 @@ import { SiteHeader } from '../../components/site-header';
 import { ToastProvider } from '../../components/toast';
 
 export function renderSiteHeaderWithProviders(): void {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
   render(
     <QueryClientProvider client={queryClient}>
       <ToastProvider>

--- a/apps/web/__tests__/signup-page.test.tsx
+++ b/apps/web/__tests__/signup-page.test.tsx
@@ -37,4 +37,24 @@ describe('SignupPage', () => {
     expect(cohortInput.value).toBe('58');
     expect(noteInput.value).toBe('테스트 메모');
   });
+
+  it('연락처 공백 입력 시 에러를 표시한다', () => {
+    renderWithProviders(<SignupPage />);
+
+    const studentIdInput = screen.getByLabelText('학번') as HTMLInputElement;
+    const nameInput = screen.getByLabelText('이름') as HTMLInputElement;
+    const emailInput = screen.getByLabelText('이메일') as HTMLInputElement;
+    const cohortInput = screen.getByLabelText('기수') as HTMLInputElement;
+    const phoneInput = screen.getByLabelText('연락처') as HTMLInputElement;
+
+    fireEvent.change(studentIdInput, { target: { value: '20260001' } });
+    fireEvent.change(nameInput, { target: { value: '홍길동' } });
+    fireEvent.change(emailInput, { target: { value: 'hong@example.com' } });
+    fireEvent.change(cohortInput, { target: { value: '58' } });
+    fireEvent.change(phoneInput, { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: '가입신청 제출' }));
+
+    expect(screen.getByText('연락처를 입력해 주세요.')).toBeInTheDocument();
+    expect(showMock).toHaveBeenCalledWith('연락처를 입력해 주세요.', { type: 'error' });
+  });
 });

--- a/apps/web/__tests__/site-header-drawer.test.tsx
+++ b/apps/web/__tests__/site-header-drawer.test.tsx
@@ -1,10 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React, { type ReactNode } from 'react';
 import { vi } from 'vitest';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { SiteHeader } from '../components/site-header';
-import { ToastProvider } from '../components/toast';
+import { renderSiteHeaderWithProviders } from './helpers/render-site-header-with-providers';
 
 // DrawerMenu dynamic import mock — 닫기 버튼은 실제 Drawer 헤더에서 제공
 vi.mock('../components/lazy', () => ({
@@ -22,17 +20,6 @@ vi.mock('../components/require-admin', () => ({
     <>{children || fallback || null}</>
   ),
 }));
-
-function renderSiteHeaderWithProviders() {
-  const queryClient = new QueryClient();
-  render(
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <SiteHeader />
-      </ToastProvider>
-    </QueryClientProvider>
-  );
-}
 
 describe('SiteHeader drawer', () => {
   it('opens drawer and closes on button click', async () => {

--- a/apps/web/__tests__/site-header-drawer.test.tsx
+++ b/apps/web/__tests__/site-header-drawer.test.tsx
@@ -2,8 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React, { type ReactNode } from 'react';
 import { vi } from 'vitest';
 
-import { SiteHeader } from '../components/site-header';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SiteHeader } from '../components/site-header';
+import { ToastProvider } from '../components/toast';
 
 // DrawerMenu dynamic import mock — 닫기 버튼은 실제 Drawer 헤더에서 제공
 vi.mock('../components/lazy', () => ({
@@ -22,14 +23,20 @@ vi.mock('../components/require-admin', () => ({
   ),
 }));
 
+function renderSiteHeaderWithProviders() {
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <SiteHeader />
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
 describe('SiteHeader drawer', () => {
   it('opens drawer and closes on button click', async () => {
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        <SiteHeader />
-      </QueryClientProvider>
-    );
+    renderSiteHeaderWithProviders();
     const toggle = screen.getByLabelText('전체 메뉴 열기');
     toggle.focus();
     fireEvent.click(toggle);
@@ -45,12 +52,7 @@ describe('SiteHeader drawer', () => {
   });
 
   it('closes with Escape key', async () => {
-    const qc = new QueryClient();
-    render(
-      <QueryClientProvider client={qc}>
-        <SiteHeader />
-      </QueryClientProvider>
-    );
+    renderSiteHeaderWithProviders();
     const toggle = screen.getByLabelText('전체 메뉴 열기');
     toggle.focus();
     fireEvent.click(toggle);

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -73,8 +73,15 @@ export default function SignupPage() {
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const cohort = parseCohort(form.cohort);
+    const phone = form.phone.trim();
     if (cohort == null) {
       const message = '기수를 숫자로 입력해 주세요.';
+      setFeedback({ tone: 'error', message });
+      show(message, { type: 'error' });
+      return;
+    }
+    if (!phone) {
+      const message = '연락처를 입력해 주세요.';
       setFeedback({ tone: 'error', message });
       show(message, { type: 'error' });
       return;
@@ -87,7 +94,7 @@ export default function SignupPage() {
       name: form.name.trim(),
       cohort,
       major: form.major.trim() || null,
-      phone: form.phone.trim() || null,
+      phone,
       note: form.note.trim() || null,
     });
   };
@@ -215,8 +222,9 @@ export default function SignupPage() {
         </label>
 
         <label className="text-sm text-text-primary">
-          연락처(선택)
+          연락처
           <input
+            required
             className="mt-1 w-full rounded border border-neutral-border px-3 py-2"
             value={form.phone}
             onChange={(e) => {

--- a/docs/dev_log_260301.md
+++ b/docs/dev_log_260301.md
@@ -5,3 +5,5 @@
 - Changed: 회원가입/활성화 관련 API 테스트 payload를 전화번호 포함으로 정렬하고, 전화번호 누락 시 `422` 검증 케이스 추가
 - Fixed: `SiteHeader` 관련 웹 테스트 3건 실패 원인(`ToastProvider` 누락) 보강
 - Docs/Ops: DB `signup_requests.phone`의 `NOT NULL` 강제는 기존 NULL 1건 정리 후 진행하도록 후속 이슈 #171 등록
+- Chore: PR 코멘트 반영으로 `phone` 빈값 검증 메시지 문구를 명확화하고 `422` 테스트에 `phone` loc 검증 추가
+- Chore: `SiteHeader` 테스트 프로바이더 헬퍼를 공용화하고, signup 폼의 연락처 공백 입력 클라이언트 검증 테스트 추가

--- a/docs/dev_log_260301.md
+++ b/docs/dev_log_260301.md
@@ -1,0 +1,7 @@
+# 2026-03-01
+
+- Fixed: 회원가입 신청에서 연락처를 필수 입력으로 전환 (frontend impact)
+- Changed: API `SignupRequestCreate.phone`를 필수로 변경하고 공백 입력 검증을 강화
+- Changed: 회원가입/활성화 관련 API 테스트 payload를 전화번호 포함으로 정렬하고, 전화번호 누락 시 `422` 검증 케이스 추가
+- Fixed: `SiteHeader` 관련 웹 테스트 3건 실패 원인(`ToastProvider` 누락) 보강
+- Docs/Ops: DB `signup_requests.phone`의 `NOT NULL` 강제는 기존 NULL 1건 정리 후 진행하도록 후속 이슈 #171 등록

--- a/docs/dev_log_260301.md
+++ b/docs/dev_log_260301.md
@@ -7,3 +7,4 @@
 - Docs/Ops: DB `signup_requests.phone`의 `NOT NULL` 강제는 기존 NULL 1건 정리 후 진행하도록 후속 이슈 #171 등록
 - Chore: PR 코멘트 반영으로 `phone` 빈값 검증 메시지 문구를 명확화하고 `422` 테스트에 `phone` loc 검증 추가
 - Chore: `SiteHeader` 테스트 프로바이더 헬퍼를 공용화하고, signup 폼의 연락처 공백 입력 클라이언트 검증 테스트 추가
+- Chore: `render-site-header-with-providers`의 `QueryClient` 기본 옵션을 `queries.retry=false`로 정렬해 테스트 플래키 가능성 완화

--- a/packages/schemas/index.d.ts
+++ b/packages/schemas/index.d.ts
@@ -1936,7 +1936,7 @@ export interface components {
             /** Major */
             major?: string | null;
             /** Phone */
-            phone?: string | null;
+            phone: string;
             /** Note */
             note?: string | null;
         };

--- a/packages/schemas/openapi.json
+++ b/packages/schemas/openapi.json
@@ -6181,14 +6181,7 @@
             "title": "Major"
           },
           "phone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
             "title": "Phone"
           },
           "note": {
@@ -6208,7 +6201,8 @@
           "student_id",
           "email",
           "name",
-          "cohort"
+          "cohort",
+          "phone"
         ],
         "title": "SignupRequestCreate"
       },

--- a/tests/api/test_abc_phase1.py
+++ b/tests/api/test_abc_phase1.py
@@ -41,6 +41,7 @@ def _create_signup_and_approve(
             "email": f"{student_id}@example.com",
             "name": "ABC One",
             "cohort": 1,
+            "phone": "010-3000-4000",
         },
     )
     assert signup_res.status_code == HTTPStatus.CREATED
@@ -100,6 +101,7 @@ def test_member_activate_pending_blocked_401(admin_login: TestClient) -> None:
             "email": "abc-pending@example.com",
             "name": "Pending",
             "cohort": 1,
+            "phone": "010-3000-4001",
         },
     )
     assert signup_res.status_code == HTTPStatus.CREATED

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -245,3 +245,5 @@ def test_member_signup_phone_required_422(client: TestClient) -> None:
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    detail = response.json()["detail"]
+    assert any("phone" in str(err.get("loc", "")) for err in detail)

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -56,6 +56,7 @@ def test_member_signup_duplicate_pending_returns_409(client: TestClient) -> None
         "email": "s116002@test.example.com",
         "name": "신청자",
         "cohort": 2024,
+        "phone": "010-2000-3000",
     }
     first = client.post("/auth/member/signup", json=payload)
     assert first.status_code == HTTPStatus.CREATED
@@ -88,6 +89,7 @@ def test_member_signup_active_member_conflict_returns_409(client: TestClient) ->
             "email": "s116003@test.example.com",
             "name": "신청자",
             "cohort": 2024,
+            "phone": "010-2000-3001",
         },
     )
 
@@ -106,6 +108,7 @@ def test_admin_signup_review_approve_and_reject(
             "email": "s116004@test.example.com",
             "name": "승인대상",
             "cohort": 2024,
+            "phone": "010-2000-3002",
             "note": "승인 요청",
         },
     )
@@ -154,6 +157,7 @@ def test_admin_signup_review_approve_and_reject(
             "email": "s116005@test.example.com",
             "name": "반려대상",
             "cohort": 2024,
+            "phone": "010-2000-3003",
         },
     )
     assert reject_create.status_code == HTTPStatus.CREATED
@@ -177,6 +181,7 @@ def test_admin_signup_reissue_token_and_logs(admin_login: TestClient) -> None:
             "email": "s116007@test.example.com",
             "name": "재발급대상",
             "cohort": 2024,
+            "phone": "010-2000-3004",
         },
     )
     assert create_res.status_code == HTTPStatus.CREATED
@@ -216,6 +221,7 @@ def test_reissue_requires_approved_status(admin_login: TestClient) -> None:
             "email": "s116006@test.example.com",
             "name": "재발급대기",
             "cohort": 2024,
+            "phone": "010-2000-3005",
         },
     )
     assert create_res.status_code == HTTPStatus.CREATED
@@ -225,3 +231,17 @@ def test_reissue_requires_approved_status(admin_login: TestClient) -> None:
     assert res.status_code == HTTPStatus.CONFLICT
     body = res.json()
     assert body["code"] == "signup_request_not_approved"
+
+
+def test_member_signup_phone_required_422(client: TestClient) -> None:
+    response = client.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116008",
+            "email": "s116008@test.example.com",
+            "name": "전화없음",
+            "cohort": 2024,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항:
  - 회원가입 신청 시 전화번호를 필수로 전환
  - DB는 기존 `phone IS NULL` 1건이 있어 이번 PR에서 `NOT NULL` 강제는 제외
- 목표/범위(Scope):
  - Web/API 입력 계약 필수화
  - 관련 API 테스트/웹 실패 테스트 보강
  - OpenAPI/DTO 동기화
- 비범위(Out of Scope):
  - DB `signup_requests.phone` 컬럼 `NOT NULL` 전환(후속 이슈 #171)

## 주요 변경사항
- API:
  - `SignupRequestCreate.phone` 필수화 및 공백 입력 검증 강화
  - signup/activation 관련 API 테스트 payload 전화번호 반영
  - 전화번호 누락 시 `422` 테스트 추가
- Web:
  - 가입신청 폼 연락처를 필수 입력으로 변경(`required`, 공백 사전 검증)
  - `SiteHeader` 테스트 3건 실패 원인(`ToastProvider` 누락) 보강
- 스키마/마이그레이션:
  - OpenAPI/DTO 재생성 (`packages/schemas/openapi.json`, `packages/schemas/index.d.ts`)
  - 마이그레이션 없음
- 문서(architecture/pwa_push/versions 등):
  - `docs/dev_log_260301.md` 추가

## 테스트 노트
- 수동 테스트 절차:
  - `/signup`에서 연락처 미입력 제출 시 에러 노출 확인
  - 연락처 입력 후 정상 제출 및 심사 플로우 확인
- 예상 영향 범위:
  - 회원가입 신청 입력/검증 경로
  - Signup DTO를 참조하는 Web 타입 경로

## 배포/롤백
- 배포 전 체크(마이그레이션 등):
  - 마이그레이션 없음
  - 후속 이슈 #171에서 데이터 정리 후 DB `NOT NULL` 전환 예정
- 롤백 전략:
  - Web/API 스키마 커밋 롤백으로 즉시 복구 가능
 - 다운타임/락 리스크: (x) 없음  ( ) 경미  ( ) 주의 — 세부: [ ] 배포 시 알림  [ ] 롤백 절차 검증

## Draft 체크리스트(초안 단계)
- [x] 문제 정의와 범위를 템플릿에 명시했다
- [x] API/DB/Web 중 어디를 건드리는지 표시했다
- [x] 남은 TODO를 본문에 정리했다(작은 단위 권장)
- [ ] 필요 시 와이어프레임/모형/샘플 데이터 첨부
- [x] (계획서 포함 시) 본 PR에서 계획 범위를 전부 구현할 것임을 명시했다