### PR TITLE
ci(ci): 로컬 훅 및 PR CI 품질 게이트 재설계 (#174)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -3,12 +3,19 @@ set -euo pipefail
 
 MSG_FILE="$1"
 
-# Use pinned CLI via pnpm dlx to avoid global dependence
-if command -v pnpm >/dev/null 2>&1; then
-  pnpm dlx @commitlint/cli@20.1.0 --config docs/commitlint.config.cjs --edit "$MSG_FILE"
-else
-  echo "[hooks] pnpm not found; skipping commit message lint."
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[hooks] Error: pnpm not found."
+  echo "[hooks] Install Node $(node -p "require('./apps/web/package.json').engines.node" 2>/dev/null || echo '24.12.0') and pnpm, then run: pnpm install"
+  exit 1
 fi
+
+if [ ! -f node_modules/.bin/commitlint ]; then
+  echo "[hooks] Error: @commitlint/cli is not installed."
+  echo "[hooks] Run: pnpm install"
+  exit 1
+fi
+
+pnpm exec commitlint --config docs/commitlint.config.cjs --edit "$MSG_FILE"
 
 if [ ! -f "$MSG_FILE" ]; then
   echo "[hooks] commit message file missing; skipping commitlog guard."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,13 +22,14 @@ if [ "$doc_only" = true ]; then
   exit 0
 fi
 
-# Repo guards on staged files (policy: no suppression comments, max lines, etc.)
-if command -v python3 >/dev/null 2>&1; then
-  echo "[hooks] Running repo guards"
-  python3 ops/ci/guards.py || { echo "[hooks] Repo guards failed"; exit 1; }
-else
-  echo "[hooks] Warning: python3 not found; skipping repo guards"
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[hooks] Error: python3 not found."
+  echo "[hooks] Install Python 3.12 and retry."
+  exit 1
 fi
+
+echo "[hooks] Running repo guards"
+python3 ops/ci/guards.py || { echo "[hooks] Repo guards failed"; exit 1; }
 
 python_targets=()
 for file in "${FILES[@]}"; do
@@ -39,7 +40,7 @@ done
 
 web_targets=()
 for file in "${FILES[@]}"; do
-  if [[ "$file" == apps/web/* ]] && [[ "$file" =~ \.(ts|tsx|js|jsx)$ ]]; then
+  if [[ "$file" == apps/web/* ]] && [[ "$file" =~ \.(ts|tsx|js|jsx|mts)$ ]]; then
     web_targets+=("${file#apps/web/}")
   fi
 done
@@ -53,25 +54,23 @@ if [ ${#python_targets[@]} -gt 0 ]; then
   elif command -v ruff >/dev/null 2>&1; then
     RUFF_BIN="ruff"
   fi
-  if [ -n "$RUFF_BIN" ]; then
-    echo "[hooks] Running ruff on changed Python files ($RUFF_BIN)"
-    "$RUFF_BIN" check --force-exclude "${python_targets[@]}"
-  else
-    echo "[hooks] Warning: ruff not found; skipping Python lint"
+  if [ -z "$RUFF_BIN" ]; then
+    echo "[hooks] Error: ruff not found."
+    echo "[hooks] Run: make venv && make api-install"
+    exit 1
   fi
+  echo "[hooks] Running ruff on changed Python files ($RUFF_BIN)"
+  "$RUFF_BIN" check --force-exclude "${python_targets[@]}"
 fi
 
-# 웹 변경 파일 수집(스테이징) — e2e 포함, 타입 인식 린트 적용 (#29)
-if command -v pnpm >/dev/null 2>&1; then
-  if [ ${#web_targets[@]} -gt 0 ]; then
-    echo "[hooks] web: lint staged files (e2e 포함, 타입 인식) — see #29"
-    # apps/web 기준 상대경로 배열을 null-delimited로 안전 전달
-    # next.config.js 등 JS 파일도 포함되므로 타입정보 의존 룰로 인한 false positive를 피하기 위해
-    # 스테이징된 파일만 대상으로 실행하되, --no-warn-ignored로 무시 경고를 억제
-    printf '%s\0' "${web_targets[@]}" | xargs -0 -r pnpm -C apps/web exec eslint --no-warn-ignored --max-warnings=0 --
+if [ ${#web_targets[@]} -gt 0 ]; then
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "[hooks] Error: pnpm not found."
+    echo "[hooks] Install Node 24.12.0 and pnpm, then run: pnpm -C apps/web install"
+    exit 1
   fi
-else
-  echo "[hooks] Warning: pnpm not found; skipping web lint/type-check"
+  echo "[hooks] web: lint staged files (e2e 포함, 타입 인식) — see #29"
+  printf '%s\0' "${web_targets[@]}" | xargs -0 -r pnpm -C apps/web exec eslint --no-warn-ignored --max-warnings=0 --
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -118,13 +118,14 @@ if [ "$python_changed" = true ]; then
     echo "[hooks] Running pyright type check"
     "$PY_BIN" -m pyright --project pyrightconfig.json
   else
-    echo "[hooks] Warning: pyright not available; skipping type check"
+    echo "[hooks] Error: pyright not available."
+    echo "[hooks] Run: make venv && make api-install"
+    exit 1
   fi
 
-  # If requirements changed, install to local venv before running tests
   if [ "$req_changed" = true ]; then
-    echo "[hooks] Installing updated Python dependencies (requirements changed)"
-    "$PY_BIN" -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt
+    echo "[hooks] requirements changed — ensure the active venv is up to date before push:"
+    echo "[hooks]   $PY_BIN -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt"
   fi
 
   # Note: pytest is now handled by CI to speed up local pushes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12.3'
@@ -28,17 +33,18 @@ jobs:
           corepack enable
           corepack prepare pnpm@${{ steps.pnpm-version.outputs.version }} --activate
           pnpm -v
+      - name: Install workspace tooling (commitlint)
+        run: pnpm install --frozen-lockfile
       - name: Run repository guards
         run: python ops/ci/guards.py
       - name: Enforce standardized versions
         run: python ops/ci/check_versions.py
-      - name: Lint commit messages (recent commits)
+      - name: Lint commit messages (PR commits)
         run: |
-          # Check up to last 30 commits in this ref
-          RANGE="$(git rev-list --count HEAD)"
-          COUNT=$([ "$RANGE" -gt 30 ] && echo 30 || echo "$RANGE")
-          # || true: Draft PR 포함 조회 시 일부 commit 히스토리 부재로 실패할 수 있어 soft-fail 유지
-          pnpm dlx @commitlint/cli@20.1.0 --config docs/commitlint.config.cjs --from=HEAD~$COUNT --to=HEAD || true
+          pnpm exec commitlint \
+            --config docs/commitlint.config.cjs \
+            --from "${{ github.event.pull_request.base.sha }}" \
+            --to "${{ github.event.pull_request.head.sha }}"
 
   python:
     needs: repo-guards
@@ -100,6 +106,40 @@ jobs:
       - name: Compile bytecode
         run: python -m compileall apps/api
 
+  contract:
+    needs: repo-guards
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: apps/api/requirements*.txt
+      - name: Install API dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt
+      - name: Resolve PNPM version
+        id: pnpm-version
+        run: echo "version=$(scripts/resolve_pnpm_version.sh)" >> $GITHUB_OUTPUT
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ steps.pnpm-version.outputs.version }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.12.0'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install schema tool dependencies
+        run: pnpm -C packages/schemas install --frozen-lockfile
+      - name: Verify OpenAPI/DTO sync
+        run: |
+          python scripts/export_openapi.py
+          pnpm -C packages/schemas run gen-dts
+          git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
+
   web:
     needs: repo-guards
     if: ${{ github.event.pull_request.draft == false }}
@@ -128,6 +168,10 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
         run: pnpm -C apps/web install --frozen-lockfile
+      - name: Lint
+        run: pnpm -C apps/web lint
+      - name: Unit tests
+        run: pnpm -C apps/web test
       - name: Cache Next.js build
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run repository guards
         run: python ops/ci/guards.py
+      - name: Git hooks integration tests
+        run: bash ops/ci/test_githooks.sh
       - name: Enforce standardized versions
         run: python ops/ci/check_versions.py
       - name: Lint commit messages (PR commits)

--- a/.github/workflows/create-waiver-issue.yml
+++ b/.github/workflows/create-waiver-issue.yml
@@ -8,23 +8,13 @@ on:
         required: false
         default: 'ginishuh'
         type: string
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read
   issues: write
 
 jobs:
-  noop:
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Skip run
-        run: echo "create-waiver-issue workflow executes only via workflow_dispatch; event=${GITHUB_EVENT_NAME}"
   create-issue:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Create or update waiver issue

--- a/.github/workflows/dto-verify.yml
+++ b/.github/workflows/dto-verify.yml
@@ -1,17 +1,15 @@
 name: dto-verify
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify-dto:
-    # Draft PR에서는 실행하지 않고, main push 또는 Ready for Review 상태에서만 실행
-    if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   e2e:
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,10 @@ pnpm -C apps/web i && pnpm -C apps/web dev
 - `.venv` 활성화 후 `pytest -q`로 API 테스트를 실행할 수 있습니다. 현재는 스켈레톤 상태이므로 smoke 테스트 추가를 권장합니다.
 
 ## Git Hooks
-- `git config core.hooksPath .githooks`로 커스텀 훅을 활성화하세요. `.venv`를 활성화한 뒤 `pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt`로 도구(ruff, pyright)를 설치해야 합니다.
-- 프리커밋: 변경된 Python 파일에만 `ruff check`를, 변경된 Web 파일에만 `eslint`/`tsc --noEmit`를 실행합니다. 문서 전용 커밋은 자동으로 통과합니다.
-- 커밋 메시지: Conventional Commits를 따릅니다. `docs/commit_message_convention.md`를 참고하세요. `commit-msg` 훅이 `commitlint`(pnpm dlx, 고정 버전)와 커밋로그(`Log: ...`) 형식을 함께 검사합니다. `[skip-commitlog]`는 문서 전용 커밋에서만 허용됩니다.
-- 프리푸시: 비-문서 변경 푸시에는 당일 `docs/dev_log_YYMMDD.md`가 필수입니다. Python 변경이 있으면 활성 venv 기준 `pyright`와 `bandit`을 실행합니다. 테스트는 CI에서 수행합니다. Schemas 변경 시 `pnpm -C packages/schemas run gen`을 수행합니다.
-- CI는 `ruff`, `pyright`, `python -m compileall`, `pnpm -C apps/web build`를 실행하므로 로컬 훅과 중복 검사를 최소화했습니다.
+- `git config core.hooksPath .githooks`로 커스텀 훅을 활성화하세요.
+- 사전 설치: `pnpm install`(루트, `@commitlint/cli`) · `make venv && make api-install`(ruff, pyright, bandit) · `pnpm -C apps/web install`
+- 필수 도구가 없으면 훅이 **실패**합니다(skip 없음). 재현 명령은 `docs/ci_quality_gates.md` 참고.
+- 프리커밋: 스테이징된 Python/Web 파일만 `ruff`/`eslint`. 문서 전용 커밋은 통과.
+- 커밋 메시지: `pnpm exec commitlint` + `Log:` 줄(코드 변경 시). `[skip-commitlog]`는 문서 전용만.
+- 프리푸시: `docs/dev_log_YYMMDD.md` 필수(비문서). Python 변경 시 `pyright`+`bandit`. 계약 변경 시 OpenAPI/DTO 드리프트 검증. **자동 pip install 없음** — requirements 변경 후 venv를 직접 갱신.
+- CI는 PR에서 API/Web 전체 lint·test·build·계약 검증을 수행합니다.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: venv api-install db-up db-down db-test-up api-dev web-dev schema-gen test-api info-venv \
+.PHONY: venv api-install db-up db-down db-test-up api-dev web-dev schema-gen test-api test-hooks info-venv \
         api-start api-stop api-restart api-status \
         web-start web-stop web-restart web-status \
         dev-up dev-down dev-status \
@@ -150,6 +150,9 @@ test-api:
 		exit 1; \
 	fi
 	"$(VENV_BIN)/pytest" -q
+
+test-hooks:
+	bash ops/ci/test_githooks.sh
 
 info-venv:
 	@echo "Detected VENV_DIR=$(VENV_DIR)" && echo "Using BIN=$(VENV_BIN)"

--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ make schema-gen
   - 샘플/전체 목록: `.env.example`, `.env.api.example`, `.env.web.example` 참고.
 
 ## 테스트 · 품질 · CI
-- 훅 활성화: `git config core.hooksPath .githooks`.
-- Python: `ruff`(복잡도/스타일) · `pyright`(strict) · `pytest -q`.
-- Web: `eslint`(`next/core-web-vitals`) · `tsc --noEmit` · `pnpm -C apps/web build`.
+- 품질 게이트 SSOT: `docs/ci_quality_gates.md`
+- 훅 활성화: `git config core.hooksPath .githooks` + `pnpm install`(루트, commitlint) + `make venv && make api-install`
+- Python: `ruff` · `pyright` · `pytest -q`(PR CI)
+- Web: `pnpm -C apps/web lint` · `pnpm -C apps/web test` · `pnpm -C apps/web build`
+- 훅 스모크: `bash ops/ci/test_githooks.sh`
 - 단축키: `make test-api`, `make schema-gen` 등은 `Makefile` 참고.
-- CI: `.github/workflows/ci.yml`가 버전 고정/정적검사/빌드/보안 스캔을 수행합니다. Lighthouse, E2E, DTO 검증 워크플로도 제공됩니다.
+- CI: `.github/workflows/ci.yml` — commitlint(hard), API/Web 전체 검증, 보안 스캔. E2E·DTO·CodeQL은 별도 workflow.
 
 ## 커밋/PR 규칙
 - Conventional Commits 필수: `type(scope): subject`(72자 이내). 타입/스코프는 `docs/commit_message_convention.md` 참고.

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -63,7 +63,7 @@ export default [
   },
   // test 전용: 타입 인식 린트(별도 프로젝트)
   {
-    files: ['__tests__/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
+    files: ['__tests__/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}', 'vitest.config.mts'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -82,7 +82,12 @@ export default [
 
   // e2e 전용: 타입 인식 린트(별도 프로젝트) — #29 e2e 엄격 린트 복구
   {
-    files: ['e2e/**/*.{ts,tsx}', '**/*.e2e.{ts,tsx}', 'vitest.config.e2e.ts'],
+    files: [
+      'e2e/**/*.{ts,tsx}',
+      '**/*.e2e.{ts,tsx}',
+      'vitest.config.e2e.ts',
+      'vitest.config.e2e.mts',
+    ],
     languageOptions: {
       // compat 블록들과의 병합 순서와 무관하게 의도를 명확히 하기 위해 parser 명시
       parser: tsParser,

--- a/apps/web/tsconfig.eslint.json
+++ b/apps/web/tsconfig.eslint.json
@@ -9,6 +9,8 @@
     "tests/**/*",
     "e2e/**/*",
     "vitest.config.e2e.ts",
+    "vitest.config.e2e.mts",
+    "vitest.config.mts",
     ".next/types/**/*.ts",
     "**/*.d.ts"
   ],

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -1,0 +1,87 @@
+# CI 품질 게이트
+
+로컬 Git 훅과 GitHub Actions PR CI의 책임 분리·재현 명령을 정리한다. 상위 Epic: #174.
+
+## 설계 원칙
+
+| 계층 | 목표 시간 | 역할 |
+|------|-----------|------|
+| `commit-msg` | 1~2초 | Conventional Commits + 커밋로그(`Log:`) |
+| `pre-commit` | 5~15초 | 스테이징된 파일만 — repo guard, Ruff, ESLint |
+| `pre-push` | 30~90초 | push 범위 — Pyright, Bandit, OpenAPI/DTO(계약 변경 시) |
+| PR CI | 수 분 | 전체 회귀 — API/Web lint·test·build·계약·보안 |
+| main/주기 | — | 머지 후 DTO 검증, CodeQL 스케줄 |
+
+도구가 없으면 **조용히 skip하지 않고 실패**한다. 설치 안내는 각 훅 메시지와 아래 절을 따른다.
+
+## 로컬 재현 명령
+
+```bash
+# 1회 설정
+git config core.hooksPath .githooks
+make venv && make api-install
+pnpm install
+pnpm -C apps/web install
+
+# PR CI와 동일한 검증(요약)
+python ops/ci/guards.py
+python ops/ci/check_versions.py
+pnpm exec commitlint --from origin/main --to HEAD --config docs/commitlint.config.cjs
+ruff check apps/api
+.venv/bin/python -m pyright --project pyrightconfig.json
+pytest -q
+pnpm -C apps/web lint
+pnpm -C apps/web test
+pnpm -C apps/web build
+python scripts/export_openapi.py && pnpm -C packages/schemas run gen-dts
+git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
+```
+
+## PR CI 필수 job (Ready for Review)
+
+| Job | 내용 |
+|-----|------|
+| `repo-guards` | guards, versions, **commitlint (hard)** |
+| `python` | ruff, pyright, pytest, bandit, pip-audit |
+| `contract` | OpenAPI export + DTO drift |
+| `web` | **eslint**, **vitest 전체**, build, a11y smoke, bundle, pnpm audit |
+| `secrets-scan` | gitleaks |
+| `semgrep` | Semgrep `p/ci` |
+| `e2e` (별도 workflow) | Puppeteer E2E — 현재 `continue-on-error` (#143) |
+| `analyze` (CodeQL) | JS/TS + Python — PR + main + weekly |
+
+## main 브랜치 추가 검사
+
+| Workflow | 트리거 | 목적 |
+|----------|--------|--------|
+| `dto-verify` | `push` main | 머지 후 OpenAPI/DTO 드리프트 방지 |
+| `CodeQL` | push main, schedule | 심층 SAST |
+
+## 보안 스캔 책임표
+
+| 도구 | 범위 | PR | main | 주기 | 비고 |
+|------|------|----|------|------|------|
+| gitleaks | 비밀 | ✅ | — | — | 전체 히스토리 fetch |
+| Semgrep | 정적 패턴 | ✅ | — | — | `p/ci` |
+| Bandit | Python API | ✅ | — | — | pre-push에서도 Python 변경 시 |
+| pip-audit | Python deps | ✅ | — | — | strict; Starlette waiver 추적 |
+| pnpm audit | Web prod deps | ✅ | — | — | `--audit-level=high` |
+| CodeQL | JS/TS, Python | ✅ | ✅ | 월 1회 | GitHub Security 탭 |
+
+중복을 줄이기 위해 **동일 검사를 로컬 훅과 CI에서 모두 전체 실행하지 않는다**. 예: pytest는 CI, pre-push는 Pyright+Bandit 중심.
+
+## main 브랜치 보호 (수동 설정)
+
+머지 후 GitHub **Settings → Rules → main** 에서 아래를 required status checks로 지정한다.
+
+- `repo-guards` / `python` / `contract` / `web` / `secrets-scan` / `semgrep`
+- (권장) CodeQL `analyze` matrix jobs
+- (권장) `dto-verify` on main push
+
+Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다.
+
+## 훅 스모크 테스트
+
+```bash
+bash ops/ci/test_githooks.sh
+```

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -48,14 +48,14 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 | `secrets-scan` | gitleaks |
 | `semgrep` | Semgrep `p/ci` |
 | `e2e` (별도 workflow) | Puppeteer E2E — 현재 `continue-on-error` (#143) |
-| `analyze` (CodeQL) | JS/TS + Python — PR + main + weekly |
+| `analyze` (CodeQL) | JS/TS + Python — PR + main + **매주 월요일 07:00 UTC** |
 
 ## main 브랜치 추가 검사
 
 | Workflow | 트리거 | 목적 |
 |----------|--------|--------|
 | `dto-verify` | `push` main | 머지 후 OpenAPI/DTO 드리프트 방지 |
-| `CodeQL` | push main, schedule | 심층 SAST |
+| `CodeQL` | push main, schedule (`0 7 * * 1`) | 심층 SAST (매주 월요일) |
 
 ## 보안 스캔 책임표
 
@@ -66,7 +66,7 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 | Bandit | Python API | ✅ | — | — | pre-push에서도 Python 변경 시 |
 | pip-audit | Python deps | ✅ | — | — | strict; Starlette waiver 추적 |
 | pnpm audit | Web prod deps | ✅ | — | — | `--audit-level=high` |
-| CodeQL | JS/TS, Python | ✅ | ✅ | 월 1회 | GitHub Security 탭 |
+| CodeQL | JS/TS, Python | ✅ | ✅ | **매주 월요일 07:00 UTC** (`cron: 0 7 * * 1`) | GitHub Security 탭 |
 
 중복을 줄이기 위해 **동일 검사를 로컬 훅과 CI에서 모두 전체 실행하지 않는다**. 예: pytest는 CI, pre-push는 Pyright+Bandit 중심.
 
@@ -80,8 +80,28 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 
 Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다.
 
-## 훅 스모크 테스트
+## 훅 통합 테스트
 
 ```bash
 bash ops/ci/test_githooks.sh
+# 또는
+make test-hooks
 ```
+
+PR CI `repo-guards` job에서도 동일 스크립트를 실행한다.
+
+## 검증 기록 (#174, 2026-07-11)
+
+로컬 측정(대표 환경, WSL2):
+
+| 항목 | 측정 | 목표 | 비고 |
+|------|------|------|------|
+| pre-commit docs-only | ~50–200ms | ≤15s | 통합 테스트 내 자동 기록 |
+| pre-commit python+spaces | ~1–3s | ≤15s | ruff 1파일 |
+| commit-msg (pnpm+commitlint) | ~1–2s | ≤2s | |
+| pre-push (py 변경, pyright+bandit) | ~15–45s | ≤90s | 변경 범위 의존 |
+
+변경 전(2026-07-11 이전): CI commitlint `|| true`, Web lint/전체 test 미실행, 훅 도구 누락 시 skip.  
+변경 후: hard gate + 명시적 Web lint/test + 훅 실패 고정.
+
+CI 시간은 Draft→Ready 전환 후 Actions run URL로 PR에 기록한다.

--- a/docs/commit_message_convention.md
+++ b/docs/commit_message_convention.md
@@ -13,7 +13,7 @@
 - `chore(web): Next 15/React 19로 업그레이드 및 engines 고정`
 
 검사 도구
-- 훅: `.githooks/commit-msg`가 `commitlint`로 즉시 검증합니다.
+- 훅: `.githooks/commit-msg`가 루트 `pnpm exec commitlint`로 즉시 검증합니다.
 - CI: PR에서도 최근 커밋 메시지를 검사합니다.
 
 구성 파일

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -5,4 +5,6 @@
 - Changed: OpenAPI/DTO 검증을 PR `contract` job으로 통합, `dto-verify`는 main push 전용
 - Fixed: `vitest.config.*.mts` ESLint typed-lint 누락 보정
 - Ops: `create-waiver-issue` main noop 트리거 제거, E2E `workflow_dispatch` 조건 수정
+- Changed: `ops/ci/test_githooks.sh` 실제 훅 exit code 통합 테스트 + CI `repo-guards` 연동
+- Docs: CodeQL 주기 문서 정합(매주 월요일), 검증 시간 기록 추가
 - Docs: `docs/ci_quality_gates.md` 신설, README/CONTRIBUTING/security_hardening 동기화

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -6,6 +6,6 @@
 - Fixed: `vitest.config.*.mts` ESLint typed-lint 누락 보정
 - Ops: `create-waiver-issue` main noop 트리거 제거, E2E `workflow_dispatch` 조건 수정
 - Changed: `ops/ci/test_githooks.sh` 실제 훅 exit code 통합 테스트 + CI `repo-guards` 연동
-- Fixed: CI에서 unchanged fixture 스테이징 시 commit-msg Log 검증 skip 버그 보정
+- Fixed: CI orphan worktree 훅 테스트 git user.name/email 설정
 - Docs: CodeQL 주기 문서 정합(매주 월요일), 검증 시간 기록 추가
 - Docs: `docs/ci_quality_gates.md` 신설, README/CONTRIBUTING/security_hardening 동기화

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -6,5 +6,6 @@
 - Fixed: `vitest.config.*.mts` ESLint typed-lint 누락 보정
 - Ops: `create-waiver-issue` main noop 트리거 제거, E2E `workflow_dispatch` 조건 수정
 - Changed: `ops/ci/test_githooks.sh` 실제 훅 exit code 통합 테스트 + CI `repo-guards` 연동
+- Fixed: CI에서 unchanged fixture 스테이징 시 commit-msg Log 검증 skip 버그 보정
 - Docs: CodeQL 주기 문서 정합(매주 월요일), 검증 시간 기록 추가
 - Docs: `docs/ci_quality_gates.md` 신설, README/CONTRIBUTING/security_hardening 동기화

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -1,0 +1,8 @@
+# 2026-07-11
+
+- Changed: #174 CI 품질 게이트 재설계 — commitlint hard gate, Web lint/전체 Vitest PR CI 추가, 훅 skip 제거
+- Changed: `@commitlint/cli` 루트 devDependency 고정, pre-push 자동 pip install 제거
+- Changed: OpenAPI/DTO 검증을 PR `contract` job으로 통합, `dto-verify`는 main push 전용
+- Fixed: `vitest.config.*.mts` ESLint typed-lint 누락 보정
+- Ops: `create-waiver-issue` main noop 트리거 제거, E2E `workflow_dispatch` 조건 수정
+- Docs: `docs/ci_quality_gates.md` 신설, README/CONTRIBUTING/security_hardening 동기화

--- a/docs/security_hardening.md
+++ b/docs/security_hardening.md
@@ -3,12 +3,13 @@
 본 문서는 현재 레포에 적용된 보안 가드와 운영 권장 설정을 요약합니다.
 
 ## CI / 자동화 가드
+- 품질 게이트 SSOT: `docs/ci_quality_gates.md` (훅·PR CI·보안 스캔 책임 분리)
 - Repo Guards(`ops/ci/guards.py`):
   - 금지된 우회 주석 감지(`eslint-disable`, `@ts-ignore`, `# type: ignore`, `# noqa` 등; Alembic env.py의 `E402`만 예외)
   - 파일 600줄 초과 차단
-- Python: `ruff`(복잡도/버그베어/pyupgrade), `pyright` strict
+- Python: `ruff`(복잡도/버그베어/pyupgrade), `pyright` strict, `pytest`(PR CI)
 - 취약점 스캔: `bandit -r apps/api`, `pip-audit`(두 requirements 모두)
-- Web: `pnpm -C apps/web build` + `pnpm -C apps/web audit --audit-level=high`
+- Web: `pnpm -C apps/web lint`, `pnpm -C apps/web test`, `pnpm -C apps/web build`, `pnpm -C apps/web audit --audit-level=high`
 - SAST: Semgrep 기본 규칙(`p/ci`)
 - 비밀 탐지: Gitleaks
 

--- a/ops/ci/apply_main_branch_protection.sh
+++ b/ops/ci/apply_main_branch_protection.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# main 브랜치 ruleset — required status checks (GitHub UI 대체용)
+# 사용: GITHUB_TOKEN 또는 gh auth 필요. 실패 시 docs/ci_quality_gates.md 수동 절차 따름.
+set -euo pipefail
+
+REPO="${1:-ginishuh/sogecon-app}"
+
+payload="$(cat <<'JSON'
+{
+  "name": "main-quality-gates",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "repo-guards" },
+          { "context": "python" },
+          { "context": "contract" },
+          { "context": "web" },
+          { "context": "secrets-scan" },
+          { "context": "semgrep" }
+        ]
+      }
+    }
+  ]
+}
+JSON
+)"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[branch-protection] gh CLI required" >&2
+  exit 1
+fi
+
+echo "[branch-protection] applying ruleset to $REPO (main)"
+gh api "repos/${REPO}/rulesets" -X POST --input - <<<"$payload"
+echo "[branch-protection] done — verify in GitHub Settings → Rules"

--- a/ops/ci/fixtures/hooks/sample.py
+++ b/ops/ci/fixtures/hooks/sample.py
@@ -1,0 +1,5 @@
+# 훅 통합 테스트용 최소 Python 파일 (Ruff 통과)
+
+
+def hook_fixture() -> str:
+    return "ok"

--- a/ops/ci/test_githooks.sh
+++ b/ops/ci/test_githooks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Git 훅 스모크 테스트 — 실제 커밋 없이 규칙 로직 검증
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pass() { echo "[test-githooks] OK: $*"; }
+fail() { echo "[test-githooks] FAIL: $*" >&2; exit 1; }
+
+# commitlog 패턴
+pattern='^Log:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} \| [^|]+ \| [^|]+ \| [^|]+ \| .+'
+bad_msg=$'feat(web): no log line\n'
+if echo "$bad_msg" | grep -Eq "$pattern"; then
+  fail "missing Log line should not match"
+fi
+pass "commitlog guard pattern rejects missing Log"
+
+good_msg=$'feat(web): ok\n\nLog: 2026-07-11 15:00 | test | feat | summary | file.ts\n'
+if ! echo "$good_msg" | grep -Eq "$pattern"; then
+  fail "valid Log line should match"
+fi
+pass "commitlog guard pattern accepts valid Log"
+
+# pre-commit docs-only
+files=("docs/dev_log_260711.md" "README.md")
+doc_only=true
+for file in "${files[@]}"; do
+  if [[ "$file" =~ ^docs/ ]] || [[ "$file" =~ \.(md|MD|txt|adoc|rst)$ ]] || [[ "$file" == README.md ]]; then
+    continue
+  fi
+  doc_only=false
+  break
+done
+[ "$doc_only" = true ] || fail "docs-only detection"
+pass "pre-commit docs-only detection"
+
+files=("apps/web/foo.ts")
+doc_only=true
+for file in "${files[@]}"; do
+  if [[ "$file" =~ ^docs/ ]] || [[ "$file" =~ \.(md|MD|txt|adoc|rst)$ ]]; then
+    continue
+  fi
+  doc_only=false
+  break
+done
+[ "$doc_only" = false ] || fail "code change should not be docs-only"
+pass "pre-commit detects code changes"
+
+# pre-push upstream fallback branch exists
+if grep -q 'git rev-parse --abbrev-ref --symbolic-full-name @{u}' .githooks/pre-push; then
+  pass "pre-push upstream check present"
+else
+  fail "pre-push missing upstream check"
+fi
+
+echo "[test-githooks] all checks passed"

--- a/ops/ci/test_githooks.sh
+++ b/ops/ci/test_githooks.sh
@@ -34,6 +34,7 @@ STAGED_BACKUP=""
 restore_git_state() {
   if [ -n "$STAGED_BACKUP" ]; then
     git reset HEAD -- . >/dev/null 2>&1 || true
+    git checkout -- . >/dev/null 2>&1 || true
   fi
   if [ -n "$MSG_DIR" ] && [ -d "$MSG_DIR" ]; then
     rm -rf "$MSG_DIR"
@@ -96,7 +97,11 @@ expect_fail "commit-msg without pnpm" \
   env PATH="/usr/bin:/bin" HOME="$HOME" run_commit_msg "$msg_no_pnpm"
 
 # --- commit-msg: Log 줄 누락 (코드 스테이징) ---
+printf '\n' >>"$FIXTURE_PY"
 git add "$FIXTURE_PY"
+if [ -z "$(git diff --cached --name-only -- "$FIXTURE_PY")" ]; then
+  fail "fixture must be staged for commit-msg Log test"
+fi
 msg_no_log="$MSG_DIR/no-log.txt"
 cat >"$msg_no_log" <<'EOF'
 feat(api): subject without log
@@ -106,6 +111,7 @@ if command -v pnpm >/dev/null 2>&1 && [ -f "$ROOT/node_modules/.bin/commitlint" 
 else
   note "skip commit-msg missing Log (pnpm/commitlint unavailable in runner)"
 fi
+git checkout -- "$FIXTURE_PY"
 git reset HEAD -- "$FIXTURE_PY" >/dev/null
 
 # --- commit-msg: 문서 전용은 Log 없이 통과 ---
@@ -194,6 +200,7 @@ if git worktree add -b "$code_branch" "$code_wt" --orphan >/dev/null 2>&1; then
     git config core.hooksPath .githooks
     mkdir -p ops/ci/fixtures/hooks
     cp "$ROOT/ops/ci/fixtures/hooks/sample.py" ops/ci/fixtures/hooks/sample.py
+    printf '\n' >>ops/ci/fixtures/hooks/sample.py
     git add ops/ci/fixtures/hooks/sample.py
     git commit -m "$(cat <<'EOF'
 feat(api): code only without dev log file

--- a/ops/ci/test_githooks.sh
+++ b/ops/ci/test_githooks.sh
@@ -1,57 +1,216 @@
 #!/usr/bin/env bash
-# Git 훅 스모크 테스트 — 실제 커밋 없이 규칙 로직 검증
+# Git 훅 통합 테스트 — 임시 스테이징 후 실제 .githooks exit code 검증
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
+HOOKS="$ROOT/.githooks"
+FIXTURE_DIR="ops/ci/fixtures/hooks"
+FIXTURE_PY="$FIXTURE_DIR/sample.py"
+FIXTURE_WEB="__tests__/nonce.test.ts"
+MSG_DIR=""
+
+ensure_fixtures() {
+  mkdir -p "$FIXTURE_DIR"
+  cat >"$FIXTURE_PY" <<'PY'
+# 훅 통합 테스트용 최소 Python 파일 (Ruff 통과)
+
+
+def hook_fixture() -> str:
+    return "ok"
+PY
+}
+
 pass() { echo "[test-githooks] OK: $*"; }
 fail() { echo "[test-githooks] FAIL: $*" >&2; exit 1; }
+note() { echo "[test-githooks] NOTE: $*"; }
 
-# commitlog 패턴
-pattern='^Log:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} \| [^|]+ \| [^|]+ \| [^|]+ \| .+'
-bad_msg=$'feat(web): no log line\n'
-if echo "$bad_msg" | grep -Eq "$pattern"; then
-  fail "missing Log line should not match"
-fi
-pass "commitlog guard pattern rejects missing Log"
+ms_now() { date +%s%3N; }
 
-good_msg=$'feat(web): ok\n\nLog: 2026-07-11 15:00 | test | feat | summary | file.ts\n'
-if ! echo "$good_msg" | grep -Eq "$pattern"; then
-  fail "valid Log line should match"
-fi
-pass "commitlog guard pattern accepts valid Log"
+STASHED=0
+STAGED_BACKUP=""
 
-# pre-commit docs-only
-files=("docs/dev_log_260711.md" "README.md")
-doc_only=true
-for file in "${files[@]}"; do
-  if [[ "$file" =~ ^docs/ ]] || [[ "$file" =~ \.(md|MD|txt|adoc|rst)$ ]] || [[ "$file" == README.md ]]; then
-    continue
+restore_git_state() {
+  if [ -n "$STAGED_BACKUP" ]; then
+    git reset HEAD -- . >/dev/null 2>&1 || true
   fi
-  doc_only=false
-  break
-done
-[ "$doc_only" = true ] || fail "docs-only detection"
-pass "pre-commit docs-only detection"
-
-files=("apps/web/foo.ts")
-doc_only=true
-for file in "${files[@]}"; do
-  if [[ "$file" =~ ^docs/ ]] || [[ "$file" =~ \.(md|MD|txt|adoc|rst)$ ]]; then
-    continue
+  if [ -n "$MSG_DIR" ] && [ -d "$MSG_DIR" ]; then
+    rm -rf "$MSG_DIR"
   fi
-  doc_only=false
-  break
-done
-[ "$doc_only" = false ] || fail "code change should not be docs-only"
-pass "pre-commit detects code changes"
+  if [ "$STASHED" -eq 1 ]; then
+    git stash pop -q >/dev/null 2>&1 || git stash drop -q >/dev/null 2>&1 || true
+  fi
+}
 
-# pre-push upstream fallback branch exists
-if grep -q 'git rev-parse --abbrev-ref --symbolic-full-name @{u}' .githooks/pre-push; then
-  pass "pre-push upstream check present"
+trap restore_git_state EXIT
+
+prepare_repo() {
+  if [ -n "$(git status --porcelain)" ]; then
+    git stash push -u -m "test-githooks-autostash" -q
+    STASHED=1
+  fi
+  STAGED_BACKUP=1
+  MSG_DIR="$(mktemp -d)"
+}
+
+run_commit_msg() {
+  local msg_file="$1"
+  shift
+  (cd "$ROOT" && "$HOOKS/commit-msg" "$msg_file" "$@")
+}
+
+run_pre_commit() {
+  (cd "$ROOT" && "$HOOKS/pre-commit" "$@")
+}
+
+run_pre_push() {
+  (cd "$ROOT" && "$HOOKS/pre-push" "$@")
+}
+
+expect_fail() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    fail "$label should fail"
+  fi
+  pass "$label fails as expected"
+}
+
+expect_ok() {
+  local label="$1"
+  shift
+  if ! "$@" >/dev/null 2>&1; then
+    fail "$label should pass"
+  fi
+  pass "$label passes"
+}
+
+prepare_repo
+ensure_fixtures
+
+# --- commit-msg: pnpm 누락 ---
+msg_no_pnpm="$MSG_DIR/no-pnpm.txt"
+echo "feat(api): subject" >"$msg_no_pnpm"
+expect_fail "commit-msg without pnpm" \
+  env PATH="/usr/bin:/bin" HOME="$HOME" run_commit_msg "$msg_no_pnpm"
+
+# --- commit-msg: Log 줄 누락 (코드 스테이징) ---
+git add "$FIXTURE_PY"
+msg_no_log="$MSG_DIR/no-log.txt"
+cat >"$msg_no_log" <<'EOF'
+feat(api): subject without log
+EOF
+if command -v pnpm >/dev/null 2>&1 && [ -f "$ROOT/node_modules/.bin/commitlint" ]; then
+  expect_fail "commit-msg missing Log line" run_commit_msg "$msg_no_log"
 else
-  fail "pre-push missing upstream check"
+  note "skip commit-msg missing Log (pnpm/commitlint unavailable in runner)"
+fi
+git reset HEAD -- "$FIXTURE_PY" >/dev/null
+
+# --- commit-msg: 문서 전용은 Log 없이 통과 ---
+git add docs/dev_log_TEMPLATE.md
+msg_doc="$MSG_DIR/doc-only.txt"
+cat >"$msg_doc" <<'EOF'
+docs: template only
+EOF
+expect_ok "commit-msg doc-only without Log" run_commit_msg "$msg_doc"
+git reset HEAD -- docs/dev_log_TEMPLATE.md >/dev/null
+
+# --- pre-commit: python3 누락 ---
+git add "$FIXTURE_PY"
+expect_fail "pre-commit without python3" \
+  env PATH="/usr/bin:/bin" HOME="$HOME" run_pre_commit
+git reset HEAD -- "$FIXTURE_PY" >/dev/null
+
+# --- pre-commit: ruff 누락 ---
+git add "$FIXTURE_PY"
+expect_fail "pre-commit without ruff" \
+  env PATH="/usr/bin:/bin:$(dirname "$(command -v python3)")" HOME="$HOME" run_pre_commit
+git reset HEAD -- "$FIXTURE_PY" >/dev/null
+
+# --- pre-commit: pnpm 누락 (web 스테이징) ---
+git add "apps/web/$FIXTURE_WEB"
+expect_fail "pre-commit without pnpm (web staged)" \
+  env PATH="/usr/bin:/bin:$(dirname "$(command -v python3)")" HOME="$HOME" run_pre_commit
+git reset HEAD -- "apps/web/$FIXTURE_WEB" >/dev/null
+
+# --- pre-commit: 문서 전용 빠른 통과 + 시간 측정 ---
+git add docs/dev_log_TEMPLATE.md
+t0="$(ms_now)"
+expect_ok "pre-commit docs-only" run_pre_commit
+t1="$(ms_now)"
+note "timing pre-commit docs-only: $((t1 - t0))ms (goal ≤15s)"
+
+git reset HEAD -- docs/dev_log_TEMPLATE.md >/dev/null
+
+# --- pre-commit: 공백 경로 ---
+SPACE_DIR="ops/ci/fixtures/hooks/space dir"
+SPACE_FILE="$SPACE_DIR/sample space.py"
+mkdir -p "$SPACE_DIR"
+printf '%s\n' 'def spaced() -> str:' '    return "ok"' >"$SPACE_FILE"
+git add "$SPACE_FILE"
+t0="$(ms_now)"
+if [ -x "$ROOT/.venv/bin/ruff" ] && command -v pnpm >/dev/null 2>&1; then
+  expect_ok "pre-commit staged path with spaces" run_pre_commit
+  t1="$(ms_now)"
+  note "timing pre-commit python+spaces path: $((t1 - t0))ms"
+else
+  note "skip spaced-path pre-commit full run (venv ruff or pnpm missing)"
+fi
+git reset HEAD -- "$SPACE_FILE" >/dev/null
+rm -rf "$SPACE_DIR"
+
+# --- pre-push: upstream 없음 + 문서만 히스토리 → 통과 (orphan worktree) ---
+orphan_branch="hook-orphan-$$"
+wt="$(mktemp -d)"
+if git worktree add -b "$orphan_branch" "$wt" --orphan >/dev/null 2>&1; then
+  (
+    cd "$wt"
+    git config core.hooksPath .githooks
+    mkdir -p docs
+    cp "$ROOT/docs/dev_log_TEMPLATE.md" docs/dev_log_260711.md
+    git add docs/dev_log_260711.md
+    git commit -m "$(cat <<'EOF'
+docs(docs): orphan worktree for hook test
+
+Log: 2026-07-11 15:30 | test | docs | orphan hook fixture | docs/dev_log_260711.md
+EOF
+)" -q
+    expect_ok "pre-push without upstream (docs-only history)" "$HOOKS/pre-push"
+  )
+  git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+  git branch -D "$orphan_branch" >/dev/null 2>&1 || true
+else
+  note "skip pre-push orphan worktree test (worktree add failed)"
 fi
 
-echo "[test-githooks] all checks passed"
+# --- pre-push: 비문서 변경인데 dev_log 없으면 실패 (orphan worktree) ---
+code_branch="hook-code-$$"
+code_wt="$(mktemp -d)"
+if git worktree add -b "$code_branch" "$code_wt" --orphan >/dev/null 2>&1; then
+  (
+    cd "$code_wt"
+    git config core.hooksPath .githooks
+    mkdir -p ops/ci/fixtures/hooks
+    cp "$ROOT/ops/ci/fixtures/hooks/sample.py" ops/ci/fixtures/hooks/sample.py
+    git add ops/ci/fixtures/hooks/sample.py
+    git commit -m "$(cat <<'EOF'
+feat(api): code only without dev log file
+
+Log: 2026-07-11 15:31 | test | feat | hook negative case | ops/ci/fixtures/hooks/sample.py
+EOF
+)" -q
+    if "$HOOKS/pre-push" >/dev/null 2>&1; then
+      echo "[test-githooks] FAIL: pre-push without dev_log for code change should fail" >&2
+      exit 1
+    fi
+    echo "[test-githooks] OK: pre-push without dev_log for code change fails as expected"
+  )
+  git worktree remove --force "$code_wt" >/dev/null 2>&1 || rm -rf "$code_wt"
+  git branch -D "$code_branch" >/dev/null 2>&1 || true
+else
+  note "skip pre-push dev_log negative test (worktree add failed)"
+fi
+
+echo "[test-githooks] all integration checks passed"

--- a/ops/ci/test_githooks.sh
+++ b/ops/ci/test_githooks.sh
@@ -173,6 +173,8 @@ wt="$(mktemp -d)"
 if git worktree add -b "$orphan_branch" "$wt" --orphan >/dev/null 2>&1; then
   (
     cd "$wt"
+    git config user.email "ci-hook-test@example.com"
+    git config user.name "CI Hook Test"
     git config core.hooksPath .githooks
     mkdir -p docs
     cp "$ROOT/docs/dev_log_TEMPLATE.md" docs/dev_log_260711.md
@@ -197,6 +199,8 @@ code_wt="$(mktemp -d)"
 if git worktree add -b "$code_branch" "$code_wt" --orphan >/dev/null 2>&1; then
   (
     cd "$code_wt"
+    git config user.email "ci-hook-test@example.com"
+    git config user.name "CI Hook Test"
     git config core.hooksPath .githooks
     mkdir -p ops/ci/fixtures/hooks
     cp "$ROOT/ops/ci/fixtures/hooks/sample.py" ops/ci/fixtures/hooks/sample.py

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     }
   },
   "devDependencies": {
+    "@commitlint/cli": "20.1.0",
     "png-to-ico": "^3.0.1",
     "sharp": "^0.34.5"
+  },
+  "scripts": {
+    "commitlint": "commitlint"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     devDependencies:
+      '@commitlint/cli':
+        specifier: 20.1.0
+        version: 20.1.0(@types/node@24.10.3)(conventional-commits-parser@6.4.0)(typescript@5.8.3)
       png-to-ico:
         specifier: ^3.0.1
         version: 3.0.1
@@ -160,6 +163,83 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@commitlint/cli@20.1.0':
+    resolution: {integrity: sha512-pW5ujjrOovhq5RcYv5xCpb4GkZxkO2+GtOdBW2/qrr0Ll9tl3PX0aBBobGQl3mdZUbOBgwAexEQLeH6uxL0VYg==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@20.5.3':
+    resolution: {integrity: sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@20.0.0':
+    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@20.5.3':
+    resolution: {integrity: sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@20.5.3':
+    resolution: {integrity: sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@20.5.3':
+    resolution: {integrity: sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@20.5.3':
+    resolution: {integrity: sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@20.0.0':
+    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
+    engines: {node: '>=v18'}
+
+  '@conventional-changelog/git-client@2.7.0':
+    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.4.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -766,6 +846,14 @@ packages:
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1045,6 +1133,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1084,6 +1175,9 @@ packages:
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
@@ -1315,11 +1409,40 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  conventional-changelog-angular@8.3.1:
+    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.4.0:
+    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -1442,6 +1565,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1506,6 +1633,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.25.0:
     resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
@@ -1687,6 +1817,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1774,6 +1907,12 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1781,6 +1920,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1859,6 +2002,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1870,6 +2016,10 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1956,6 +2106,14 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -2123,6 +2281,10 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2500,6 +2662,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2749,6 +2915,10 @@ packages:
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -3090,6 +3260,119 @@ snapshots:
   '@babel/runtime@7.28.4': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@commitlint/cli@20.1.0(@types/node@24.10.3)(conventional-commits-parser@6.4.0)(typescript@5.8.3)':
+    dependencies:
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.3
+      '@commitlint/load': 20.5.3(@types/node@24.10.3)(typescript@5.8.3)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.2.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-validator@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      ajv: 8.20.0
+
+  '@commitlint/ensure@20.5.3':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.49.0
+
+  '@commitlint/execute-rule@20.0.0': {}
+
+  '@commitlint/format@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      semver: 7.7.4
+
+  '@commitlint/lint@20.5.3':
+    dependencies:
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.3
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/load@20.5.3(@types/node@24.10.3)(typescript@5.8.3)':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/execute-rule': 20.0.0
+      '@commitlint/resolve-extends': 20.5.3
+      '@commitlint/types': 20.5.0
+      cosmiconfig: 9.0.2(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.10.3)(cosmiconfig@9.0.2(typescript@5.8.3))(typescript@5.8.3)
+      es-toolkit: 1.49.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@20.4.3': {}
+
+  '@commitlint/parse@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.1
+      conventional-commits-parser: 6.4.0
+
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
+      minimist: 1.2.8
+      tinyexec: 1.2.4
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@20.5.3':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      es-toolkit: 1.49.0
+      global-directory: 5.0.0
+      import-meta-resolve: 4.2.0
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@20.5.3':
+    dependencies:
+      '@commitlint/ensure': 20.5.3
+      '@commitlint/message': 20.4.3
+      '@commitlint/to-lines': 20.0.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/to-lines@20.0.0': {}
+
+  '@commitlint/top-level@20.4.3':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@20.5.0':
+    dependencies:
+      conventional-commits-parser: 6.4.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-parser: 6.4.0
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -3536,6 +3819,12 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3833,6 +4122,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -3864,6 +4160,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
+
+  array-ify@1.0.0: {}
 
   array-includes@3.1.9:
     dependencies:
@@ -4118,9 +4416,39 @@ snapshots:
 
   commander@7.2.0: {}
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   concat-map@0.0.1: {}
 
+  conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.4.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.10.3)(cosmiconfig@9.0.2(typescript@5.8.3))(typescript@5.8.3):
+    dependencies:
+      '@types/node': 24.10.3
+      cosmiconfig: 9.0.2(typescript@5.8.3)
+      jiti: 2.6.1
+      typescript: 5.8.3
+
   cosmiconfig@9.0.0(typescript@5.8.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.8.3
+
+  cosmiconfig@9.0.2(typescript@5.8.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
@@ -4228,6 +4556,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4357,6 +4689,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.25.0:
     optionalDependencies:
@@ -4646,6 +4980,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.3: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -4750,6 +5086,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4757,6 +5101,10 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  global-directory@5.0.0:
+    dependencies:
+      ini: 6.0.0
 
   globals@14.0.0: {}
 
@@ -4828,11 +5176,15 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
+
+  ini@6.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -4922,6 +5274,10 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@2.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
@@ -4980,8 +5336,7 @@ snapshots:
 
   jiti@1.21.7: {}
 
-  jiti@2.6.1:
-    optional: true
+  jiti@2.6.1: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -5088,6 +5443,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  meow@13.2.0: {}
 
   merge2@1.4.1: {}
 
@@ -5490,6 +5847,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.10:
@@ -5867,6 +6226,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:


### PR DESCRIPTION
## 배경/목적
- Epic #174 — 로컬 훅과 PR CI의 책임 분리, soft-fail/skip 제거, 신뢰 가능한 머지 게이트 확립
- #173 보안 패치(#188)보다 **선행**

## 주요 변경사항

### 로컬 훅
- `@commitlint/cli@20.1.0` 루트 devDependency + `pnpm exec`
- pre-commit/pre-push: 도구 누락 시 **실패**, pre-push 자동 `pip install` 제거

### PR CI
- commitlint **hard gate** (PR base..head)
- `contract` job + Web **lint/전체 test/build**

### 검증 (Codex 리뷰 반영)
- `ops/ci/test_githooks.sh`: 실제 `.githooks` exit code 통합 테스트 (orphan worktree, 공백 경로, 도구 누락)
- CI `repo-guards`에 `test-hooks` 실행
- CodeQL 주기 문서 정합 (매주 월요일 07:00 UTC)
- `docs/ci_quality_gates.md` 검증 시간 기록
- `ops/ci/apply_main_branch_protection.sh` — **main ruleset 적용 완료** (required: repo-guards, python, contract, web, secrets-scan, semgrep)

## 로컬 검증
- [x] `bash ops/ci/test_githooks.sh`
- [x] `pnpm -C apps/web lint` / `test` (89)

## #174 종료 조건
- [x] 코드·문서·훅 테스트·branch ruleset
- [ ] **Ready CI 전체 녹색** (Draft 해제 후 확인)
- [ ] 머지 후 #174 체크리스트 수동 확인

> **Note:** `Closes #174`는 Ready CI 녹색 확인 후 PR 본문/머지 시점에 추가 예정.

## 관련
- 머지 후 #176 / PR #188 리베이스·재검증

Related #174