### PR TITLE
chore(ci): main ruleset 적용 스크립트를 upsert로 보강

### DIFF
--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -78,6 +78,13 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 - (권장) CodeQL `analyze` matrix jobs
 - (권장) `dto-verify` on main push
 
+또는 `ops/ci/apply_main_branch_protection.sh`로 upsert한다(기존 `main-quality-gates` ruleset이 있으면 PUT, 없으면 POST).
+
+```bash
+bash ops/ci/apply_main_branch_protection.sh              # 기본: ginishuh/sogecon-app
+bash ops/ci/apply_main_branch_protection.sh OWNER/REPO   # 다른 포크
+```
+
 Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다.
 
 ## 훅 통합 테스트

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -15,4 +15,5 @@
 - Ops: CI 번들 한도 1125→1127KB(프레임워크 패치로 +1KB, admin 제외 기준 1126KB)
 - Notes: `pnpm -C apps/web audit --prod` high 0건 확인; standalone Web `127.0.0.1:4300` 200 확인; Windows Codex E2E는 PR Ready 전 수동 검증 예정
 - Fixed: API `pip-audit` 취약점 해소 — FastAPI 0.139.0(Starlette 1.x), python-multipart 0.0.32, cryptography 48.0.1, Pillow 12.3.0, pytest 9.0.3 + pytest-asyncio 1.4.0
-- Ops: main ruleset `python` required check 복원 준비(audit 녹색 후)
+- Ops: main ruleset `python`/`web` required check 복원 완료 (`main-quality-gates`)
+- Ops: `ops/ci/apply_main_branch_protection.sh`를 기존 ruleset PUT upsert로 보강

--- a/ops/ci/apply_main_branch_protection.sh
+++ b/ops/ci/apply_main_branch_protection.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# main 브랜치 ruleset — required status checks (GitHub UI 대체용)
-# 사용: GITHUB_TOKEN 또는 gh auth 필요. 실패 시 docs/ci_quality_gates.md 수동 절차 따름.
+# main 브랜치 ruleset upsert — required status checks (GitHub UI 대체용)
+# 사용: gh auth 필요. 기존 `main-quality-gates`가 있으면 PUT, 없으면 POST.
+# 실패 시 docs/ci_quality_gates.md 수동 절차를 따른다.
 set -euo pipefail
 
 REPO="${1:-ginishuh/sogecon-app}"
+RULESET_NAME="main-quality-gates"
 
 payload="$(cat <<'JSON'
 {
@@ -51,6 +53,24 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "[branch-protection] applying ruleset to $REPO (main)"
-gh api "repos/${REPO}/rulesets" -X POST --input - <<<"$payload"
+echo "[branch-protection] looking up ruleset '${RULESET_NAME}' on ${REPO}"
+existing_id="$(
+  gh api "repos/${REPO}/rulesets" --paginate \
+    --jq ".[] | select(.name==\"${RULESET_NAME}\") | .id" \
+    | head -n 1
+)"
+
+if [[ -n "${existing_id}" ]]; then
+  echo "[branch-protection] updating ruleset id=${existing_id} (PUT)"
+  result="$(gh api "repos/${REPO}/rulesets/${existing_id}" -X PUT --input - <<<"${payload}")"
+else
+  echo "[branch-protection] creating ruleset (POST)"
+  result="$(gh api "repos/${REPO}/rulesets" -X POST --input - <<<"${payload}")"
+fi
+
+echo "${result}" | jq -r '
+  "id=\(.id) name=\(.name) enforcement=\(.enforcement)",
+  (.rules[] | select(.type=="required_status_checks") |
+    "required checks: " + ([.parameters.required_status_checks[].context] | join(", ")))
+'
 echo "[branch-protection] done — verify in GitHub Settings → Rules"


### PR DESCRIPTION
## Summary
- `ops/ci/apply_main_branch_protection.sh`가 기존 `main-quality-gates` ruleset을 찾아 **PUT upsert**, 없으면 POST
- `docs/ci_quality_gates.md`에 사용법 추가
- 로컬 스모크: id=18799810 PUT 성공, required checks 6개 확인

## Test plan
- [x] `bash ops/ci/apply_main_branch_protection.sh` → updating ruleset id=18799810
- [ ] CI repo-guards 통과


Made with [Cursor](https://cursor.com)