### PR TITLE
fix(api): FastAPI·파일처리 보안 패치 잔여 gap 마감 (#177)

### DIFF
--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,6 +1,6 @@
 ruff==0.13.2
 pyright==1.1.404
-pytest==9.0.3
+pytest==9.1.1
 pytest-asyncio==1.4.0
 httpx==0.27.2
 bandit==1.9.3

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,7 +10,7 @@ bcrypt==4.2.0
 itsdangerous==2.2.0
 email-validator==2.2.0
 pywebpush==2.0.0
-cryptography==48.0.1
+cryptography==49.0.0
 Pillow==12.3.0
 sentry-sdk[starlette]==2.40.0
 apscheduler==3.11.0

--- a/docs/dev_log_260711.md
+++ b/docs/dev_log_260711.md
@@ -21,3 +21,4 @@
 - Changed: 삭제/rename/pyright 누락/upstream 없음 케이스 보강, `repo-guards`에 ruff 설치 추가
 - Docs: `docs/ci_quality_gates.md` 검증 기록을 실측값(docs-only 12ms, spaces 466ms, commit-msg 841ms)으로 갱신
 - Fixed: pyright 누락 테스트를 `python` shim + `pyright not available` 문구 매칭으로 고정(python runtime 오인 제거)
+- Fixed: #177 API 보안 패치 잔여 gap — cryptography 48.0.1→49.0.0, pytest 9.0.3→9.1.1 (#190 FastAPI/multipart/Pillow 상향분 포함 마감)

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -18,13 +18,13 @@
 - pydantic-settings==2.11.0
 - python-multipart==0.0.32
 - slowapi==0.1.9
-- cryptography==48.0.1
+- cryptography==49.0.0
 - Pillow==12.3.0
 
 ### Dev tools
 - ruff==0.13.2
 - pyright==1.1.404
-- pytest==9.0.3
+- pytest==9.1.1
 - pytest-asyncio==1.4.0
 
 ## Frontend (apps/web)

--- a/ops/ci/check_versions.py
+++ b/ops/ci/check_versions.py
@@ -115,13 +115,13 @@ def check_requirements() -> None:
             "pydantic-settings==2.11.0",
             "python-multipart==0.0.32",
             "slowapi==0.1.9",
-            "cryptography==48.0.1",
+            "cryptography==49.0.0",
             "Pillow==12.3.0",
         ],
         "apps/api/requirements-dev.txt": [
             "ruff==0.13.2",
             "pyright==1.1.404",
-            "pytest==9.0.3",
+            "pytest==9.1.1",
             "pytest-asyncio==1.4.0",
         ],
     }


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항: #177 — FastAPI·Starlette 및 파일 처리 의존성 긴급 보안 패치
- 목표/범위: #190에서 대부분 상향 완료. 잔여 `cryptography 49.0.0`, `pytest 9.1.1` 맞춤 + 검증 마감
- 비범위: #131(web minimatch GHSA, API와 무관), httpx2 전환(Starlette deprecation warning만 존재), Next/Web deps

## 주요 변경사항
- API: `cryptography` 48.0.1 → **49.0.0**, `pytest` 9.0.3 → **9.1.1**
- 이미 main(#190): FastAPI 0.139.0 / python-multipart 0.0.32 / Pillow 12.3.0 / pytest-asyncio 1.4.0 (Starlette 1.3.1 resolver)
- 문서/가드: `docs/versions.md`, `ops/ci/check_versions.py`, `docs/dev_log_260711.md`
- 스키마/마이그레이션: 없음 (OpenAPI/DTO drift 없음)

## 변경 전후 버전
| 패키지 | 이전 | 이후 |
|--------|------|------|
| FastAPI | 0.123.5 | 0.139.0 (#190) |
| Starlette | resolver 결과 | 1.3.1 (#190) |
| python-multipart | 0.0.22 | 0.0.32 (#190) |
| Pillow | 12.1.1 | 12.3.0 (#190) |
| cryptography | 48.0.1 | 49.0.0 |
| pytest | 9.0.3 | 9.1.1 |

## 공식 변경 근거
- [FastAPI 0.139.0 공식 릴리스 노트](https://fastapi.tiangolo.com/release-notes/#01390)
- [Starlette 1.3.1 공식 릴리스 노트](https://www.starlette.io/release-notes/#131-june-12-2026): form parser의 `max_fields`·`max_part_size` 강제 적용
- [python-multipart 0.0.32 공식 PyPI 릴리스](https://pypi.org/project/python-multipart/0.0.32/)
- [Pillow 12.3.0 공식 릴리스 노트](https://pillow.readthedocs.io/en/stable/releasenotes/12.3.0.html)
- [cryptography 49.0.0 공식 변경 기록](https://cryptography.io/en/stable/changelog/#v49-0-0)
- [pytest 9.1.1 공식 변경 기록](https://docs.pytest.org/en/stable/changelog.html#pytest-9-1-1)

## 검증
- [x] `pip-audit --strict` 0건
- [x] `python ops/ci/check_versions.py` OK
- [x] Ruff / Pyright(0 errors)
- [x] `pytest -q` **171 passed**
- [x] Bandit / compileall OK
- [x] OpenAPI/DTO drift 없음
- [x] 업로드·암호화 회귀 테스트 **8 passed**
- [x] `/healthz` HTTP 200, 본문 `{"ok":true}`
- [x] 비정상 multipart: 쓰레기 body 400, 잘린 body 422, 5xx·서버 중단 없음
- [x] 손상 이미지 업로드 422 및 `invalid_image_data`, 공개 URL 미생성
- [x] AES-GCM 동일 임시 32바이트 키 round-trip 및 `enc:v1:` 형식 확인
- [x] Windows Codex 앱 visible E2E: 가입·인증·프로필·정상 이미지 업로드/표시·손상 이미지 거부·세션·접근성 검증
- [x] CI `python` / `web` / `contract` / `repo-guards` / `e2e` 성공
- [x] CodeQL / secrets-scan / semgrep 성공

## 운영 영향
- API Python 의존성만 갱신하며 API 계약과 DB 스키마는 변경하지 않는다.
- 배포 시 새 의존성이 포함된 API 이미지 재빌드와 일반 재기동이 필요하다. DB 마이그레이션은 없다.
- `cryptography 49.0.0`은 32비트 Windows와 x86_64 macOS wheel 지원을 제거하지만, 운영·CI 기준인 64비트 Linux/Python 3.12에는 해당하지 않는다.
- 파일·form parsing, 이미지 디코딩, AES-GCM 경로를 실제 요청과 회귀 테스트로 확인했다.

## 롤백
1. PR #193의 merge commit을 단독 revert한다. #190까지 되돌려야 하는 경우 #190 merge commit도 별도로 revert한다.
2. 직전 정상 API 이미지를 재빌드 또는 재배포하고 API를 재기동한다.
3. `/healthz`, 로그인, 이미지 업로드와 복호화 회귀 테스트를 다시 확인한다.
4. DB·OpenAPI 변경이 없으므로 데이터 마이그레이션 롤백은 필요 없다.

## #131
- Web `pnpm audit` minimatch GHSA 추적 이슈로 **본 PR 범위 밖**이며 계속 별도 추적한다. API 패치만으로 #131 종료 조건을 충족하지 않는다.

## 관련
- 이슈: #177
- Epic: #173
- 선행: #190

Made with [Cursor](https://cursor.com)
