### PR TITLE
fix(api): bcrypt 5 비밀번호 정책 마이그레이션

### DIFF
--- a/apps/api/passwords.py
+++ b/apps/api/passwords.py
@@ -1,0 +1,37 @@
+"""bcrypt 비밀번호 해시·검증 정책."""
+
+from __future__ import annotations
+
+import bcrypt
+
+BCRYPT_MAX_PASSWORD_BYTES = 72
+BCRYPT_LENGTH_ERROR_MESSAGE = "비밀번호는 UTF-8 기준 72바이트 이하여야 합니다."
+
+
+def encode_password_for_hash(password: str) -> bytes:
+    """신규 해시용 비밀번호를 인코딩하고 bcrypt 길이 정책을 검증합니다."""
+    encoded = password.encode("utf-8")
+    if len(encoded) > BCRYPT_MAX_PASSWORD_BYTES:
+        raise ValueError(BCRYPT_LENGTH_ERROR_MESSAGE)
+    return encoded
+
+
+def validate_password_for_hash(password: str) -> str:
+    """Pydantic 요청 검증에서 사용하는 신규 비밀번호 검증기입니다."""
+    encode_password_for_hash(password)
+    return password
+
+
+def hash_password(password: str) -> str:
+    """길이 검증을 통과한 신규 비밀번호를 bcrypt로 해시합니다."""
+    encoded = encode_password_for_hash(password)
+    return bcrypt.hashpw(encoded, bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """기존 bcrypt 4의 72바이트 절삭 검증 의미를 보존합니다."""
+    encoded = password.encode("utf-8")[:BCRYPT_MAX_PASSWORD_BYTES]
+    try:
+        return bcrypt.checkpw(encoded, password_hash.encode("utf-8"))
+    except ValueError:
+        return False

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -6,7 +6,7 @@ alembic==1.18.5
 pydantic-settings==2.14.2
 python-multipart==0.0.32
 slowapi==0.1.10
-bcrypt==4.2.0
+bcrypt==5.0.0
 itsdangerous==2.2.0
 email-validator==2.3.0
 pywebpush==2.3.0

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -8,13 +8,16 @@
 """
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel
+from pydantic import AfterValidator, BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import schemas
 from ..config import get_settings
 from ..db import get_db
+from ..passwords import validate_password_for_hash
 from ..ratelimit import consume_limit
 from ..services import signup_service
 from ..services.auth_service import (
@@ -51,6 +54,8 @@ def _is_test_client(request: Request) -> bool:
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+NewPassword = Annotated[str, AfterValidator(validate_password_for_hash)]
+
 
 # ---- 요청 페이로드 ----
 
@@ -67,12 +72,12 @@ class MemberLoginPayload(BaseModel):
 
 class MemberActivatePayload(BaseModel):
     token: str
-    password: str
+    password: NewPassword
 
 
 class ChangePasswordPayload(BaseModel):
     current_password: str
-    new_password: str
+    new_password: NewPassword
 
 
 # ---- 통합 로그인/로그아웃 ----

--- a/apps/api/seed_data.py
+++ b/apps/api/seed_data.py
@@ -13,18 +13,12 @@ import secrets
 import sys
 from pathlib import Path
 
-import bcrypt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.db import get_db_session
 from apps.api.models import Member, MemberAuth, Visibility
-
-
-def hash_password(password: str) -> str:
-    """비밀번호 해시화"""
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
-
+from apps.api.passwords import hash_password
 
 _seed_secret_cache: dict[str, str] = {}
 

--- a/apps/api/seed_production.py
+++ b/apps/api/seed_production.py
@@ -12,17 +12,12 @@ import os
 import sys
 from pathlib import Path
 
-import bcrypt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.db import get_db_session
 from apps.api.models import Member, MemberAuth, Visibility
-
-
-def hash_password(password: str) -> str:
-    """비밀번호 해시화"""
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+from apps.api.passwords import hash_password
 
 
 def load_required_secret(env_name: str) -> str:

--- a/apps/api/services/auth_service.py
+++ b/apps/api/services/auth_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
 from ..errors import ApiError
+from ..passwords import hash_password, verify_password
 from ..ratelimit import consume_limit
 from ..repositories import auth as auth_repo
 from ..repositories import members as members_repo
@@ -213,12 +214,10 @@ async def login_member(
         if settings.app_env == "prod" and not _is_test_client(request):
             consume_limit(limiter_login, request, settings.rate_limit_login)
 
-    bcrypt = __import__("bcrypt")
-
     member, creds = await auth_repo.get_member_with_auth_by_student_id(db, student_id)
     if member is None or creds is None:
         raise ApiError(code="login_failed", detail="login_failed", status=401)
-    if not bcrypt.checkpw(password.encode(), creds.password_hash.encode()):
+    if not verify_password(password, cast(str, creds.password_hash)):
         raise ApiError(code="login_failed", detail="login_failed", status=401)
     if cast(str, member.status) == "pending":
         raise ApiError(
@@ -265,8 +264,7 @@ async def activate_member(
     member = await resolve_activation_member(db, payload.student_id)
 
     # 비밀번호 해시 생성 및 저장
-    bcrypt = __import__("bcrypt")
-    pwd_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    pwd_hash = hash_password(password)
     await auth_repo.create_or_update_member_auth(
         db,
         member_id=cast(int, member.id),
@@ -300,15 +298,14 @@ async def change_member_password(
     if settings.app_env == "prod" and not _is_test_client(request):
         consume_limit(limiter_login, request, settings.rate_limit_login)
 
-    bcrypt = __import__("bcrypt")
     auth_row = await auth_repo.get_member_auth_by_student_id(db, member.student_id)
 
     if auth_row is None:
         raise HTTPException(status_code=401, detail="unauthorized")
-    if not bcrypt.checkpw(current_password.encode(), auth_row.password_hash.encode()):
+    if not verify_password(current_password, cast(str, auth_row.password_hash)):
         raise HTTPException(status_code=401, detail="login_failed")
 
-    new_hash = bcrypt.hashpw(new_password.encode(), bcrypt.gensalt()).decode()
+    new_hash = hash_password(new_password)
     await auth_repo.update_member_auth_password(db, auth_row, new_hash)
     return {"ok": "true"}
 

--- a/apps/web/__tests__/api.test.ts
+++ b/apps/web/__tests__/api.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { apiFetch, ApiError } from '../lib/api';
+
+describe('apiFetch 오류 정규화', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('Pydantic 422 detail 배열을 사용자 메시지로 변환한다', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            detail: [
+              {
+                type: 'value_error',
+                loc: ['body', 'password'],
+                msg: 'Value error, 비밀번호는 UTF-8 기준 72바이트 이하여야 합니다.',
+              },
+            ],
+          }),
+          { status: 422, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+
+    await expect(apiFetch('/auth/member/activate')).rejects.toEqual(
+      new ApiError(422, '비밀번호는 UTF-8 기준 72바이트 이하여야 합니다.')
+    );
+  });
+});

--- a/apps/web/__tests__/password-page.test.tsx
+++ b/apps/web/__tests__/password-page.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ChangePasswordPage from '../app/settings/password/page';
+
+const changePasswordMock = vi.fn();
+const toastShowMock = vi.fn();
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ status: 'authorized' }),
+}));
+
+vi.mock('../components/toast', () => ({
+  useToast: () => ({ show: toastShowMock }),
+}));
+
+vi.mock('../services/member', () => ({
+  changePassword: (...args: unknown[]) => changePasswordMock(...args),
+}));
+
+describe('비밀번호 변경 화면', () => {
+  beforeEach(() => {
+    changePasswordMock.mockReset();
+    toastShowMock.mockReset();
+  });
+
+  it('UTF-8 72바이트 초과를 화면에 안내하고 요청하지 않는다', () => {
+    render(<ChangePasswordPage />);
+
+    fireEvent.change(screen.getByLabelText('현재 비밀번호'), {
+      target: { value: 'current-password' },
+    });
+    fireEvent.change(screen.getByLabelText('새 비밀번호'), {
+      target: { value: '한'.repeat(25) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '변경' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '비밀번호는 UTF-8 기준 72바이트 이하여야 합니다.'
+    );
+    expect(changePasswordMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/password.test.ts
+++ b/apps/web/__tests__/password.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPasswordWithinBcryptLimit } from '../lib/password';
+
+describe('bcrypt 비밀번호 길이 정책', () => {
+  it.each(['a'.repeat(72), '한'.repeat(24)])('UTF-8 72바이트를 허용한다', (password) => {
+    expect(isPasswordWithinBcryptLimit(password)).toBe(true);
+  });
+
+  it.each(['a'.repeat(73), '한'.repeat(25)])('UTF-8 72바이트 초과를 거부한다', (password) => {
+    expect(isPasswordWithinBcryptLimit(password)).toBe(false);
+  });
+});

--- a/apps/web/app/activate/page.tsx
+++ b/apps/web/app/activate/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from '../../components/toast';
 import { useAuth } from '../../hooks/useAuth';
 import { ApiError } from '../../lib/api';
 import { apiErrorToMessage } from '../../lib/error-map';
+import { isPasswordWithinBcryptLimit, PASSWORD_TOO_LONG_MESSAGE } from '../../lib/password';
 import { activate } from '../../services/member';
 
 type Feedback = {
@@ -48,6 +49,11 @@ function ActivateForm() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isPasswordWithinBcryptLimit(password)) {
+      setFeedback({ tone: 'error', message: PASSWORD_TOO_LONG_MESSAGE });
+      toast.show(PASSWORD_TOO_LONG_MESSAGE, { type: 'error' });
+      return;
+    }
     setBusy(true);
     setFeedback(null);
     try {

--- a/apps/web/app/settings/password/page.tsx
+++ b/apps/web/app/settings/password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useToast } from '../../../components/toast';
 import { useAuth } from '../../../hooks/useAuth';
+import { isPasswordWithinBcryptLimit, PASSWORD_TOO_LONG_MESSAGE } from '../../../lib/password';
 import { changePassword } from '../../../services/member';
 
 export default function ChangePasswordPage() {
@@ -14,6 +15,10 @@ export default function ChangePasswordPage() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isPasswordWithinBcryptLimit(nw)) {
+      toast.show(PASSWORD_TOO_LONG_MESSAGE, { type: 'error' });
+      return;
+    }
     setBusy(true);
     try {
       await changePassword({ current_password: cur, new_password: nw });
@@ -44,4 +49,3 @@ export default function ChangePasswordPage() {
     </div>
   );
 }
-

--- a/apps/web/app/settings/password/page.tsx
+++ b/apps/web/app/settings/password/page.tsx
@@ -12,20 +12,27 @@ export default function ChangePasswordPage() {
   const [cur, setCur] = useState('');
   const [nw, setNw] = useState('');
   const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isPasswordWithinBcryptLimit(nw)) {
+      setFeedback({ tone: 'error', message: PASSWORD_TOO_LONG_MESSAGE });
       toast.show(PASSWORD_TOO_LONG_MESSAGE, { type: 'error' });
       return;
     }
     setBusy(true);
+    setFeedback(null);
     try {
       await changePassword({ current_password: cur, new_password: nw });
-      toast.show('비밀번호가 변경되었습니다.', { type: 'success' });
+      const message = '비밀번호가 변경되었습니다.';
+      setFeedback({ tone: 'success', message });
+      toast.show(message, { type: 'success' });
       setCur(''); setNw('');
     } catch {
-      toast.show('비밀번호 변경에 실패했습니다.', { type: 'error' });
+      const message = '비밀번호 변경에 실패했습니다.';
+      setFeedback({ tone: 'error', message });
+      toast.show(message, { type: 'error' });
     } finally {
       setBusy(false);
     }
@@ -38,6 +45,14 @@ export default function ChangePasswordPage() {
         <p className="mb-3 text-sm text-text-secondary">로그인 후 이용하세요.</p>
       ) : null}
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        {feedback ? (
+          <p
+            className={feedback.tone === 'success' ? 'text-sm text-state-success' : 'text-sm text-state-error'}
+            role="status"
+          >
+            {feedback.message}
+          </p>
+        ) : null}
         <label className="text-sm">현재 비밀번호
           <input type="password" className="mt-1 w-full rounded border px-3 py-2" value={cur} onChange={(e) => setCur(e.target.value)} />
         </label>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -32,7 +32,7 @@ export type ProblemDetails = {
   type?: string;
   title?: string;
   status: number;
-  detail?: string;
+  detail?: unknown;
   code?: string;
 };
 
@@ -46,13 +46,30 @@ export class ApiError extends Error {
 async function parseError(res: Response): Promise<never> {
   try {
     const problem = (await res.json()) as ProblemDetails;
-    const msg = problem.detail || problem.title || `HTTP ${res.status}`;
+    const msg = detailToMessage(problem.detail) ?? problem.title ?? `HTTP ${res.status}`;
     throw new ApiError(problem.status ?? res.status, msg, problem.code);
   } catch (e) {
     if (e instanceof ApiError) throw e;
     const text = await res.text().catch(() => '');
     throw new ApiError(res.status, text || `HTTP ${res.status}`);
   }
+}
+
+function detailToMessage(detail: unknown): string | undefined {
+  if (typeof detail === 'string' && detail) return detail;
+  if (!Array.isArray(detail)) return undefined;
+
+  for (const item of detail) {
+    if (!isRecord(item)) continue;
+    const message = item['msg'];
+    if (typeof message !== 'string' || !message) continue;
+    return message.replace(/^Value error,\s*/, '');
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null;
 }
 
 async function parseOk<T>(res: Response): Promise<T | void> {

--- a/apps/web/lib/password.ts
+++ b/apps/web/lib/password.ts
@@ -1,0 +1,6 @@
+export const BCRYPT_MAX_PASSWORD_BYTES = 72;
+export const PASSWORD_TOO_LONG_MESSAGE = '비밀번호는 UTF-8 기준 72바이트 이하여야 합니다.';
+
+export function isPasswordWithinBcryptLimit(password: string): boolean {
+  return new TextEncoder().encode(password).byteLength <= BCRYPT_MAX_PASSWORD_BYTES;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,7 @@
 - 프런트 처리: `code`를 기준으로 UX 분기(예: `member_exists` → 필드 하이라이트, `rsvp_exists` → 안내 토스트).
 
 ## 인증/권한(요약)
+- 비밀번호: bcrypt 5를 사용하며 신규 설정은 UTF-8 기준 72바이트 이하만 허용한다. 기존 bcrypt 4 해시는 로그인 시 첫 72바이트 검증 의미를 보존해 재해시 없이 호환한다.
 - 로그인: `POST /auth/login`(email, password) → 세션 쿠키 발급(HttpOnly, SameSite=Lax; prod Secure).
 - 세션 조회: `GET /auth/me` → `{ id, email }`.
 - 로그아웃: `POST /auth/logout` → 세션 제거.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -22,3 +22,6 @@
 - Changed: #183 Vitest 3.2.4 → 4.1.10, Vite 6.4.3 → 8.1.4, jsdom 25.0.1 → 29.1.1로 마이그레이션
 - Fixed: Vitest 3용 Vite 보안 override를 제거하고 workspace 직접 핀으로 의존성 해석을 단일화
 - Notes: Web 30파일 93테스트와 CDP E2E 3파일 3흐름에서 silent skip 없이 호환성 확인
+- Changed: #184 bcrypt 4.2.0 → 5.0.0으로 업데이트하고 해시·검증·seed 정책을 공통화
+- Fixed: 신규 비밀번호는 UTF-8 72바이트를 초과하면 거부하고 기존 bcrypt 4 해시는 절삭 검증 호환 유지 (frontend impact)
+- Tests: ASCII·Unicode 72/73바이트 경계, 운영 형식 hash fixture, 로그인·활성화·비밀번호 변경 검증 추가

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -25,3 +25,4 @@
 - Changed: #184 bcrypt 4.2.0 → 5.0.0으로 업데이트하고 해시·검증·seed 정책을 공통화
 - Fixed: 신규 비밀번호는 UTF-8 72바이트를 초과하면 거부하고 기존 bcrypt 4 해시는 절삭 검증 호환 유지 (frontend impact)
 - Tests: ASCII·Unicode 72/73바이트 경계, 운영 형식 hash fixture, 로그인·활성화·비밀번호 변경 검증 추가
+- Fixed: #184 Windows E2E 반영 — Pydantic 422 detail 배열을 한국어 문자열로 정규화하고 clean production 재기동 절차 검증 (frontend impact)

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -26,3 +26,4 @@
 - Fixed: 신규 비밀번호는 UTF-8 72바이트를 초과하면 거부하고 기존 bcrypt 4 해시는 절삭 검증 호환 유지 (frontend impact)
 - Tests: ASCII·Unicode 72/73바이트 경계, 운영 형식 hash fixture, 로그인·활성화·비밀번호 변경 검증 추가
 - Fixed: #184 Windows E2E 반영 — Pydantic 422 detail 배열을 한국어 문자열로 정규화하고 clean production 재기동 절차 검증 (frontend impact)
+- Fixed: #184 재검증 반영 — 비밀번호 변경의 72바이트 초과 거부를 인라인 상태 메시지로 안내 (frontend impact)

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -18,7 +18,7 @@
 - pydantic-settings==2.14.2
 - python-multipart==0.0.32
 - slowapi==0.1.10
-- bcrypt==4.2.0
+- bcrypt==5.0.0
 - itsdangerous==2.2.0
 - email-validator==2.3.0
 - pywebpush==2.3.0

--- a/ops/ci/check_versions.py
+++ b/ops/ci/check_versions.py
@@ -165,7 +165,7 @@ def check_requirements() -> None:
             "pydantic-settings==2.14.2",
             "python-multipart==0.0.32",
             "slowapi==0.1.10",
-            "bcrypt==4.2.0",
+            "bcrypt==5.0.0",
             "itsdangerous==2.2.0",
             "email-validator==2.3.0",
             "pywebpush==2.3.0",

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -103,6 +103,52 @@ def test_login_failure(client: TestClient) -> None:
     assert res.json()["code"] == "login_failed"
 
 
+def test_login_preserves_legacy_password_truncation(client: TestClient) -> None:
+    password_prefix = "a" * 72
+    _seed_admin(client, "legacy-long-password", password_prefix)
+
+    res = client.post(
+        "/auth/login",
+        json={
+            "student_id": "legacy-long-password",
+            "password": f"{password_prefix}legacy-suffix",
+        },
+    )
+
+    assert res.status_code == HTTPStatus.OK
+
+
+def test_activate_rejects_new_password_over_72_utf8_bytes(
+    client: TestClient,
+) -> None:
+    res = client.post(
+        "/auth/member/activate",
+        json={"token": "not-used", "password": "한" * 25},
+    )
+
+    assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert "UTF-8 기준 72바이트" in str(res.json())
+
+
+def test_change_password_rejects_new_password_over_72_utf8_bytes(
+    client: TestClient,
+) -> None:
+    _seed_admin(client, "password-boundary", "current-password")
+    login = client.post(
+        "/auth/login",
+        json={"student_id": "password-boundary", "password": "current-password"},
+    )
+    assert login.status_code == HTTPStatus.OK
+
+    res = client.post(
+        "/auth/member/change-password",
+        json={"current_password": "current-password", "new_password": "a" * 73},
+    )
+
+    assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert "UTF-8 기준 72바이트" in str(res.json())
+
+
 def test_login_pending_member_returns_pending_reason(client: TestClient) -> None:
     override = app.dependency_overrides.get(get_db)
     if override is None:

--- a/tests/api/test_password_policy.py
+++ b/tests/api/test_password_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from apps.api.passwords import hash_password, verify_password
+from apps.api.routers.auth import (
+    ChangePasswordPayload,
+    LoginPayload,
+    MemberActivatePayload,
+)
+
+LEGACY_PASSWORD = "legacy-password-운영"
+LEGACY_BCRYPT_4_HASH = (
+    "$2b$12$zVYuyuib/I0jLZcq3V7Cq.9xiN6P0ZZffpBsxL4UvDq0/A79GJH0a"
+)
+
+
+@pytest.mark.parametrize("password", ["a" * 72, "한" * 24])
+def test_hash_password_accepts_72_utf8_bytes(password: str) -> None:
+    password_hash = hash_password(password)
+
+    assert verify_password(password, password_hash)
+
+
+@pytest.mark.parametrize("password", ["a" * 73, "한" * 25])
+def test_hash_password_rejects_more_than_72_utf8_bytes(password: str) -> None:
+    with pytest.raises(ValueError, match="UTF-8 기준 72바이트"):
+        hash_password(password)
+
+
+def test_verify_password_accepts_existing_bcrypt_4_hash() -> None:
+    assert verify_password(LEGACY_PASSWORD, LEGACY_BCRYPT_4_HASH)
+
+
+def test_verify_password_preserves_legacy_truncation_for_existing_members() -> None:
+    password_prefix = "a" * 72
+    password_hash = hash_password(password_prefix)
+
+    assert verify_password(f"{password_prefix}legacy-suffix", password_hash)
+
+
+def test_verify_password_rejects_malformed_hash() -> None:
+    assert not verify_password("password", "not-a-bcrypt-hash")
+
+
+@pytest.mark.parametrize(
+    ("payload_type", "payload"),
+    [
+        (MemberActivatePayload, {"token": "token", "password": "한" * 25}),
+        (
+            ChangePasswordPayload,
+            {"current_password": "current", "new_password": "a" * 73},
+        ),
+    ],
+)
+def test_new_password_payload_rejects_more_than_72_utf8_bytes(
+    payload_type: type[MemberActivatePayload] | type[ChangePasswordPayload],
+    payload: dict[str, str],
+) -> None:
+    with pytest.raises(ValidationError, match="UTF-8 기준 72바이트"):
+        payload_type.model_validate(payload)
+
+
+def test_login_payload_keeps_legacy_long_password_compatibility() -> None:
+    payload = LoginPayload(student_id="legacy", password="a" * 73)
+
+    assert len(payload.password.encode("utf-8")) == 73


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항: bcrypt 5.0.0이 72바이트 초과 입력을 `ValueError`로 거부하므로 기존 회원 로그인을 깨지 않으면서 신규 비밀번호 정책을 명시합니다.
- 목표/범위(Scope): bcrypt 5.0.0, 공통 해시·검증 모듈, 로그인·활성화·비밀번호 변경·seed 호환, ASCII/Unicode 경계 검증입니다.
- 비범위(Out of Scope): 인증 방식 교체, 기존 회원 일괄 재해시, DB migration입니다.

## 주요 변경사항
- API: `bcrypt 4.2.0 → 5.0.0`.
- 신규 해시: UTF-8 기준 72바이트 이하만 허용하며 초과 시 API 422.
- 기존 검증: bcrypt 4가 적용하던 첫 72바이트 의미를 명시적으로 보존해 기존 해시를 재생성하지 않고 로그인 가능.
- 공통화: 로그인·활성화·비밀번호 변경·개발/운영 seed가 `apps/api/passwords.py`를 사용.
- Web: 활성화·새 비밀번호 변경에서 같은 UTF-8 byte 정책을 요청 전에 안내.
- 문서/가드: versions, architecture, version guard, dev log 동기화.

## 공식 변경 근거
- bcrypt PyPI: https://pypi.org/project/bcrypt/
- bcrypt 5.0.0 changelog: 72바이트 초과 `hashpw` 입력은 `ValueError`

## 테스트 노트
- `.venv/bin/pytest -q`: 184 PASS
- 인증 집중 테스트: 21 PASS
- Web: 33 files / 99 tests PASS
- Ruff 변경 파일 PASS
- Pyright 0 errors (기존 warning 2)
- ESLint PASS
- Next.js 16 production build PASS
- requirements 기반 `pip-audit`: 0건
- version guard / repo guard / pip check PASS
- 운영 형식 `$2b$12$...` bcrypt 4 fixture 검증 PASS
- 추가 Web 회귀: 422 detail 정규화·비밀번호 화면 인라인 상태 포함 3 files / 6 tests PASS
- Windows production visible E2E PASS: 로그인/session, Web 75바이트 사전 거부, API 422, 정확히 72바이트 변경, 기존 비밀번호 401, 72바이트 로그인, 원래 비밀번호 복원, 활성화·재로그인, Desktop/Mobile, Console error 0, API 5xx 0.
- stale Next server 제거 후 `.next` clean build/start; `/settings/password` Document·chunks 200.

## 배포/롤백
- 운영 영향: 기존 해시는 재해시 없이 검증됩니다. 신규 활성화·비밀번호 변경은 UTF-8 72바이트를 초과하면 거부됩니다.
- DB migration: 없음.
- 롤백: PR 전체 단독 revert 후 bcrypt 4.2.0 requirements 재설치·API 재배포. 본 PR에서 생성한 bcrypt 5 `$2b$` 해시는 bcrypt 4에서도 검증 가능합니다.
- 다운타임/락 리스크: (x) 없음  ( ) 경미  ( ) 주의

## Draft 체크리스트
- [x] bcrypt 5 및 공통 정책 구현
- [x] 72/73바이트·Unicode·기존 hash fixture 검증
- [x] API/Web 전체 자동 검증
- [x] `@그록` 한글 Draft 리뷰 및 지적 반영
- [x] Windows 로그인·활성화·비밀번호 변경 visible E2E
- [ ] Ready CI 전체 통과

Closes #184
