### PR TITLE
fix(ci): Dependabot 커밋 범위를 허용

### DIFF
--- a/docs/commit_message_convention.md
+++ b/docs/commit_message_convention.md
@@ -3,7 +3,7 @@
 - 형식: `type(scope): subject`
 - 길이: 제목(헤더) 72자 이내
 - 타입(type): `feat|fix|refactor|perf|test|chore|build|ci|docs`
-- 스코프(scope): `api|web|schemas|infra|docs|ops|ci|build`
+- 스코프(scope): `api|web|schemas|infra|docs|ops|ci|build|deps|deps-dev`
 - 문체: 명령형, 현재 시제. 한국어 권장.
 - 본문(선택): 배경/의도 → 핵심 변경점 → 영향(마이그레이션, 호환성)
 - 푸터(선택): 관련 이슈/문서, BREAKING CHANGE
@@ -11,6 +11,11 @@
 예시
 - `feat(api): SlowAPI 기반 레이트리밋 추가(기본 120/min)`
 - `chore(web): Next 15/React 19로 업그레이드 및 engines 고정`
+- `build(deps): actions/cache를 6으로 업데이트`
+- `build(deps-dev): httpx 개발 의존성을 업데이트`
+
+`deps`와 `deps-dev` 스코프는 Dependabot을 포함한 운영·개발 의존성 자동화 커밋에
+사용합니다. 자동화 커밋도 일반 커밋과 동일하게 commitlint 검사를 통과해야 합니다.
 
 검사 도구
 - 훅: `.githooks/commit-msg`가 루트 `pnpm exec commitlint`로 즉시 검증합니다.
@@ -18,4 +23,3 @@
 
 구성 파일
 - `docs/commitlint.config.cjs`
-

--- a/docs/commitlint.config.cjs
+++ b/docs/commitlint.config.cjs
@@ -21,8 +21,12 @@ module.exports = {
       ]
     ],
     'type-case': [2, 'always', 'lower-case'],
-    // scopes are lowercase identifiers for areas of the monorepo
-    'scope-enum': [2, 'always', ['api', 'web', 'schemas', 'infra', 'docs', 'ops', 'ci', 'build']],
+    // scopes identify monorepo areas or dependency-update intent
+    'scope-enum': [
+      2,
+      'always',
+      ['api', 'web', 'schemas', 'infra', 'docs', 'ops', 'ci', 'build', 'deps', 'deps-dev']
+    ],
     'scope-case': [2, 'always', 'lower-case'],
     // Allow Korean or mixed-language subjects; do not enforce subject-case
     'subject-case': [0],

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -33,3 +33,4 @@
 - Ops: #187 npm/pip/GitHub Actions 월간 Dependabot과 advisory 기반 security update 정책 구축
 - Docs: major 독립 PR·자동 병합 금지·취약점 SLA·waiver 필수 메타데이터를 문서화하고 설정 검증 CI 추가
 - Fixed: #187 리뷰 반영 — directory·group 구조·minor/patch allowlist를 CI에서 fail-closed 검증
+- Fixed: Dependabot 표준 `build(deps)`·`build(deps-dev)` 커밋을 정식 scope로 허용하고 허용·거부 훅 회귀 테스트 추가

--- a/ops/ci/test_githooks.sh
+++ b/ops/ci/test_githooks.sh
@@ -130,6 +130,24 @@ expect_ok() {
   pass "$label passes"
 }
 
+expect_rejected() {
+  local label="$1"
+  local needle="$2"
+  shift 2
+  local out ec
+  set +e
+  out="$("$@" 2>&1)"
+  ec=$?
+  set -e
+  if [ "$ec" -eq 0 ] || [ "$ec" -eq 127 ]; then
+    fail "$label should reject with a real validation error (ec=$ec). output: $out"
+  fi
+  if ! printf '%s\n' "$out" | grep -Fq "$needle"; then
+    fail "$label missing expected validation '$needle' (ec=$ec). output: $out"
+  fi
+  pass "$label rejects as expected (ec=$ec)"
+}
+
 assert_staged_names() {
   local label="$1"
   shift
@@ -243,6 +261,31 @@ docs: template only
 EOF
 expect_ok "commit-msg doc-only without Log" \
   env PATH="$PATH" HOME="$HOME" "$BASH_BIN" "$HOOKS/commit-msg" "$msg_doc"
+git reset HEAD -- "docs/_hook_test_doc.md" >/dev/null
+rm -f "docs/_hook_test_doc.md"
+
+# --- commit-msg: Dependabot 표준 build(deps) 스코프 통과 ---
+stage_modify "docs/_hook_test_doc.md" "dependabot-scope-$$"
+msg_dependabot="$MSG_DIR/dependabot-scope.txt"
+cat >"$msg_dependabot" <<'EOF'
+build(deps): actions/cache를 6으로 업데이트
+EOF
+expect_ok "commit-msg accepts build(deps)" \
+  env PATH="$PATH" HOME="$HOME" "$BASH_BIN" "$HOOKS/commit-msg" "$msg_dependabot"
+
+msg_dependabot_dev="$MSG_DIR/dependabot-dev-scope.txt"
+cat >"$msg_dependabot_dev" <<'EOF'
+build(deps-dev): httpx 개발 의존성을 업데이트
+EOF
+expect_ok "commit-msg accepts build(deps-dev)" \
+  env PATH="$PATH" HOME="$HOME" "$BASH_BIN" "$HOOKS/commit-msg" "$msg_dependabot_dev"
+
+msg_unknown_scope="$MSG_DIR/unknown-scope.txt"
+cat >"$msg_unknown_scope" <<'EOF'
+build(unknown): 잘못된 범위를 사용
+EOF
+expect_rejected "commit-msg rejects unknown scope" "scope-enum" \
+  env PATH="$PATH" HOME="$HOME" "$BASH_BIN" "$HOOKS/commit-msg" "$msg_unknown_scope"
 git reset HEAD -- "docs/_hook_test_doc.md" >/dev/null
 rm -f "docs/_hook_test_doc.md"
 


### PR DESCRIPTION
## 배경/목적
- 문제/요구사항: Dependabot이 생성한 PR #204~#209의 표준 커밋 `build(deps): ...`가 commitlint scope 계약과 충돌해 `repo-guards`가 실패했습니다.
- 목표/범위(Scope): `deps`·`deps-dev` scope를 정식 허용하고 실제 commit-msg 훅의 허용·거부 회귀 테스트와 문서를 동기화합니다.
- 비범위(Out of Scope): Dependabot actor 우회, commitlint 비활성화, 개별 의존성 업데이트 내용 변경은 포함하지 않습니다.

## 주요 변경사항
- API: 없음
- Web: 없음
- 스키마/마이그레이션: 없음
- 문서: 커밋 scope 계약과 예시를 `deps`까지 확장했습니다.
- CI: 실제 `.githooks/commit-msg`에서 `build(deps)`·`build(deps-dev)` 통과와 미등록 scope 거부를 검증합니다.

## 테스트 노트
- `python ops/ci/guards.py`
- `bash ops/ci/test_githooks.sh`
- `python ops/ci/check_versions.py`
- `python ops/ci/check_dependabot.py`
- 올바른 `build(deps)` 통과 및 잘못된 `build(unknown)` 거부 확인

## 배포/롤백
- 배포 영향: 런타임·DB 영향 없음. PR 커밋 메시지 검증 범위만 확장됩니다.
- 롤백 전략: 본 PR을 revert하면 기존 scope 목록으로 즉시 복원됩니다.
- 다운타임/락 리스크: 없음

## Draft 체크리스트
- [x] 문제 정의와 범위를 템플릿에 명시했다
- [x] API/DB/Web 변경 없음과 CI 변경을 표시했다
- [x] 그록 리뷰의 `deps-dev`·거부 경로 보강을 반영했다
- [x] 남은 TODO: Ready CI 통과 확인

