### PR TITLE
fix(deps): minimatch 개발 도구 GHSA 제거

### DIFF
--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -75,3 +75,9 @@
 - OpenAPI·TypeScript DTO를 재생성했으며 DB 스키마와 migration 변경은 없다.
 - 그록 리뷰를 반영해 숨김 회원과 미존재 회원의 상세 404 code를 `member_not_found`로 통일하고, RSVP optional 조회도 `rsvp_not_found` code만 미신청으로 변환하도록 좁혔다.
 - Windows visible E2E에서 발견된 이름·기수 변경 요청의 16px 터치 높이를 공통 Button·Field 44px 계약으로 교체하고 모바일 inline form reflow 테스트를 보강했다.
+
+# #131 minimatch 개발 도구 GHSA 제거
+
+- `eslint-plugin-import@2.32.0`의 허용 범위 `minimatch ^3.1.2` 안에서 lockfile을 `3.1.5`로 갱신했다.
+- 강제 major override 없이 `GHSA-3ppc-4f35-3m26`, `GHSA-7r86-cg39-jmmj`, `GHSA-23c5-xmqv-rm74`를 제거했다.
+- production dependency audit 0건을 유지하고 Web lint·test·production build로 개발 도구 호환성을 검증한다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -2388,9 +2392,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -3272,6 +3273,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -3989,7 +3992,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -4850,7 +4853,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -5527,10 +5530,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
-
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
## 배경/목적

- #131의 원래 대상인 `eslint-plugin-import → minimatch@3.1.2` 개발 도구 경로에 ReDoS advisory 3건이 남아 있었습니다.
- 과거 minimatch 10 강제 override는 호환성 회귀를 만들었지만, 현재 `eslint-plugin-import@2.32.0`의 정상 범위 `^3.1.2` 안에서 수정판 3.1.5를 선택할 수 있습니다.

Closes #131

## 변경사항

- lockfile의 `eslint-plugin-import` 전이 의존성을 `minimatch 3.1.2 → 3.1.5`로 갱신했습니다.
- 강제 override와 manifest 변경은 추가하지 않았습니다.
- 같은 lockfile 재해석에서 `@testing-library/dom`의 허용 범위 내 `@babel/runtime 7.29.7`이 선택됐습니다.
- 당일 개발 로그에 제거 근거와 검증 범위를 기록했습니다.

## 보안·운영 영향

- 제거: `GHSA-3ppc-4f35-3m26`, `GHSA-7r86-cg39-jmmj`, `GHSA-23c5-xmqv-rm74`
- production dependency audit는 기존처럼 0건입니다.
- 변경은 개발 도구 lockfile에 한정되며 런타임 코드·DB·API 계약·배포 설정 변화는 없습니다.
- 전체 dev audit의 다른 전이 advisory는 이 PR의 minimatch 제거 범위와 분리합니다.

## 검증

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm -C apps/web audit --prod --audit-level=high` — 0건
- [x] 전체 audit에서 minimatch advisory — 0건
- [x] `pnpm -C apps/web lint`
- [x] `pnpm -C apps/web test` — 48 files, 147 tests
- [x] `pnpm -C apps/web build` — Next.js 16.2.10 production build
- [x] `.venv/bin/python ops/ci/guards.py`
- [x] `.venv/bin/python ops/ci/check_versions.py`
- [x] `git diff --check`

## 롤백

- 이 PR의 단일 커밋 `161cc06`을 revert하고 lockfile 기준으로 재설치합니다.
- DB·migration·운영 데이터 복구는 필요하지 않습니다.
