### PR TITLE
ci(ci): 자동 E2E를 hard gate로 복구

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,8 +54,6 @@ jobs:
             if curl -fsS http://localhost:3000 >/dev/null; then echo "web up"; exit 0; fi; sleep 1; done
           echo "web not responding"; curl -v http://localhost:3000 || true; exit 1
       - name: Run E2E (CDP/Puppeteer)
-        # E2E 안정화 전까지 soft-fail 유지; 안정 후 제거 예정 (#143)
-        continue-on-error: true
         env:
           WEB_BASE_URL: http://localhost:3000
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.chrome.outputs.chrome-path }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,21 +44,31 @@ jobs:
           chrome-version: stable
       - name: Build web
         run: pnpm -C apps/web build
+      - name: Start deterministic mock API
+        run: |
+          node apps/web/e2e/mock-api-server.mjs > mock-api.log 2>&1 &
+          echo $! > mock-api.pid
       - name: Start web (background)
         run: |
           pnpm -C apps/web start &
           echo $! > web.pid
       - name: Wait for web
         run: |
+          for i in {1..30}; do
+            if curl -fsS http://localhost:3001/healthz >/dev/null; then echo "mock API up"; break; fi; sleep 1;
+          done
+          curl -fsS http://localhost:3001/healthz >/dev/null || { cat mock-api.log; exit 1; }
           for i in {1..60}; do
             if curl -fsS http://localhost:3000 >/dev/null; then echo "web up"; exit 0; fi; sleep 1; done
           echo "web not responding"; curl -v http://localhost:3000 || true; exit 1
       - name: Run E2E (CDP/Puppeteer)
         env:
           WEB_BASE_URL: http://localhost:3000
+          E2E_MOCK_API_CONTROL_URL: http://localhost:3001
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: pnpm -C apps/web e2e
       - name: Stop web
         if: always()
         run: |
           if [ -f web.pid ]; then kill $(cat web.pid) || true; fi
+          if [ -f mock-api.pid ]; then kill $(cat mock-api.pid) || true; fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      WEB_BASE_URL: http://127.0.0.1:3000
+      NEXT_PUBLIC_WEB_API_BASE: http://127.0.0.1:3001
+      E2E_MOCK_API_CONTROL_URL: http://127.0.0.1:3001
     steps:
       - uses: actions/checkout@v4
       - name: Resolve PNPM version
@@ -55,16 +59,14 @@ jobs:
       - name: Wait for web
         run: |
           for i in {1..30}; do
-            if curl -fsS http://localhost:3001/healthz >/dev/null; then echo "mock API up"; break; fi; sleep 1;
+            if curl -fsS http://127.0.0.1:3001/healthz >/dev/null; then echo "mock API up"; break; fi; sleep 1;
           done
-          curl -fsS http://localhost:3001/healthz >/dev/null || { cat mock-api.log; exit 1; }
+          curl -fsS http://127.0.0.1:3001/healthz >/dev/null || { cat mock-api.log; exit 1; }
           for i in {1..60}; do
-            if curl -fsS http://localhost:3000 >/dev/null; then echo "web up"; exit 0; fi; sleep 1; done
-          echo "web not responding"; curl -v http://localhost:3000 || true; exit 1
+            if curl -fsS http://127.0.0.1:3000 >/dev/null; then echo "web up"; exit 0; fi; sleep 1; done
+          echo "web not responding"; curl -v http://127.0.0.1:3000 || true; exit 1
       - name: Run E2E (CDP/Puppeteer)
         env:
-          WEB_BASE_URL: http://localhost:3000
-          E2E_MOCK_API_CONTROL_URL: http://localhost:3001
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: pnpm -C apps/web e2e
       - name: Stop web

--- a/apps/web/e2e/directory-url-sync.spec.ts
+++ b/apps/web/e2e/directory-url-sync.spec.ts
@@ -42,7 +42,7 @@ describe('Directory URL sync (CDP E2E)', () => {
     if (!page) throw new Error('Puppeteer page not initialized');
     await configureMockServer('member');
     await setupDirectoryMocks(page);
-    await page.goto(`${WEB_BASE_URL}/directory`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${WEB_BASE_URL}/directory`, { waitUntil: 'networkidle0' });
 
     // 인증 후 현재 필터 UI가 보이는지 확인한다.
     await page.waitForSelector('fieldset[aria-label="기본 검색 필터"]');

--- a/apps/web/e2e/directory-url-sync.spec.ts
+++ b/apps/web/e2e/directory-url-sync.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import puppeteer, { Browser, Page } from 'puppeteer';
 import { WEB_BASE_URL } from './utils/env';
 import { setupDirectoryMocks } from './utils/mockApi';
+import { configureMockServer } from './utils/mockServer';
 import type { ConsoleMessage } from 'puppeteer';
 
 let browser: Browser | null = null;
@@ -39,6 +40,7 @@ describe('Directory URL sync (CDP E2E)', () => {
 
   it('updates query string when typing filters and changing sort', async () => {
     if (!page) throw new Error('Puppeteer page not initialized');
+    await configureMockServer('member');
     await setupDirectoryMocks(page);
     await page.goto(`${WEB_BASE_URL}/directory`, { waitUntil: 'domcontentloaded' });
 

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -10,18 +10,19 @@ let page: Page | null = null;
 async function moveToNextBanner(page: Page): Promise<boolean> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     try {
-      return await page.evaluate(() => {
+      const clicked = await page.evaluate(() => {
         const button = document.querySelector<HTMLButtonElement>('button[aria-label="다음 배너"]');
         if (!button) return false;
         button.click();
         return true;
       });
+      if (clicked) return true;
     } catch (error) {
       if (!(error instanceof Error) || !error.message.includes('Execution context was destroyed')) {
         throw error;
       }
-      await new Promise((resolve) => setTimeout(resolve, 100));
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error('홈 배너 상호작용 전 페이지 전환이 안정화되지 않았습니다.');
 }
@@ -46,7 +47,7 @@ describe('Home (CDP E2E)', () => {
     if (!page) throw new Error('Puppeteer page not initialized');
     await configureMockServer('member');
     await setupDirectoryMocks(page);
-    await page.goto(`${WEB_BASE_URL}/`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${WEB_BASE_URL}/`, { waitUntil: 'networkidle0' });
 
     await page.waitForFunction(
       () => document.querySelector('section[aria-label="홈 배너"]') !== null,

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import puppeteer, { Browser, Page } from 'puppeteer';
 import { WEB_BASE_URL } from './utils/env';
 import { setupDirectoryMocks } from './utils/mockApi';
+import { configureMockServer } from './utils/mockServer';
 
 let browser: Browser | null = null;
 let page: Page | null = null;
@@ -43,6 +44,7 @@ describe('Home (CDP E2E)', () => {
 
   it('shows the same activity hierarchy and member action contract on mobile', async () => {
     if (!page) throw new Error('Puppeteer page not initialized');
+    await configureMockServer('member');
     await setupDirectoryMocks(page);
     await page.goto(`${WEB_BASE_URL}/`, { waitUntil: 'domcontentloaded' });
 

--- a/apps/web/e2e/mock-api-server.mjs
+++ b/apps/web/e2e/mock-api-server.mjs
@@ -1,0 +1,237 @@
+import { createServer } from 'node:http';
+
+const host = '127.0.0.1';
+const port = Number(process.env.E2E_MOCK_API_PORT ?? '3001');
+const webOrigin = process.env.WEB_BASE_URL ?? 'http://localhost:3000';
+const activationToken = 'mock-activation-token';
+
+let sessionKind = 'member';
+let signupStatus = 'pending';
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin ?? webOrigin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods': 'GET,POST,PATCH,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  };
+}
+
+function sendJson(response, status, body, origin) {
+  response.writeHead(status, {
+    ...corsHeaders(origin),
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+function sessionPayload() {
+  if (sessionKind === 'admin') {
+    return {
+      kind: 'admin',
+      id: 1,
+      student_id: '__seed__admin',
+      email: 'admin@test.example.com',
+      name: 'Admin',
+      roles: ['member', 'admin', 'super_admin', 'admin_signup', 'admin_roles'],
+    };
+  }
+  return {
+    kind: 'member',
+    id: 1,
+    student_id: '20250001',
+    email: 'member@example.com',
+    name: '테스트 회원',
+    roles: ['member'],
+  };
+}
+
+function signupRequestPayload(status) {
+  return {
+    id: 1,
+    student_id: '20251234',
+    email: 'new-member@example.com',
+    name: '신규회원',
+    cohort: 60,
+    major: '경제학',
+    phone: '010-1234-5678',
+    note: '테스트 신청',
+    status,
+    requested_at: '2026-02-18T08:00:00Z',
+    decided_at: status === 'approved' ? '2026-02-18T08:05:00Z' : null,
+    activated_at: null,
+    decided_by_student_id: status === 'approved' ? '__seed__admin' : null,
+    reject_reason: null,
+  };
+}
+
+function activationIssuePayload() {
+  return {
+    request: signupRequestPayload('approved'),
+    activation_context: {
+      signup_request_id: 1,
+      student_id: '20251234',
+      email: 'new-member@example.com',
+      name: '신규회원',
+      cohort: 60,
+    },
+    activation_token: activationToken,
+    activation_issue: {
+      id: 1,
+      signup_request_id: 1,
+      issued_type: 'approve',
+      issued_by_student_id: '__seed__admin',
+      token_tail: 'ion-token',
+      issued_at: '2026-02-18T08:05:00Z',
+    },
+  };
+}
+
+function heroSlides() {
+  return [
+    {
+      id: 1,
+      target_type: 'post',
+      target_id: 1,
+      title: 'E2E 첫 번째 배너',
+      description: 'E2E 첫 번째 배너 설명',
+      image: '/images/home/hero-launch.svg',
+      href: '/posts',
+      unpublished: false,
+    },
+    {
+      id: 2,
+      target_type: 'event',
+      target_id: 1,
+      title: 'E2E 두 번째 배너',
+      description: 'E2E 두 번째 배너 설명',
+      image: '/images/home/hero.svg',
+      href: '/events',
+      unpublished: false,
+    },
+  ];
+}
+
+function directoryMembers(url) {
+  const offset = Number(url.searchParams.get('offset') ?? '0');
+  const limit = Number(url.searchParams.get('limit') ?? '10');
+  return Array.from({ length: Math.min(10, limit) }, (_, index) => {
+    const id = offset + index + 1;
+    return {
+      id,
+      email: `user${id}@example.com`,
+      name: `User ${id}`,
+      cohort: 10,
+      major: 'Economics',
+      company: 'ACME',
+      industry: 'IT',
+      visibility: 'all',
+    };
+  });
+}
+
+const server = createServer(async (request, response) => {
+  const origin = request.headers.origin;
+  const url = new URL(request.url ?? '/', `http://${host}:${port}`);
+  const method = request.method ?? 'GET';
+
+  if (method === 'OPTIONS') {
+    response.writeHead(204, corsHeaders(origin));
+    response.end();
+    return;
+  }
+
+  if (method === 'GET' && url.pathname === '/healthz') {
+    sendJson(response, 200, { ok: true }, origin);
+    return;
+  }
+  if (method === 'POST' && url.pathname === '/__e2e/config') {
+    const body = await readJson(request);
+    sessionKind = body.session === 'admin' ? 'admin' : 'member';
+    signupStatus = 'pending';
+    sendJson(response, 200, { ok: true, session: sessionKind }, origin);
+    return;
+  }
+  if (method === 'GET' && url.pathname === '/auth/session') {
+    sendJson(response, 200, sessionPayload(), origin);
+    return;
+  }
+  if (method === 'POST' && url.pathname === '/auth/member/signup') {
+    signupStatus = 'pending';
+    sendJson(response, 201, signupRequestPayload(signupStatus), origin);
+    return;
+  }
+  if (method === 'GET' && url.pathname === '/admin/signup-requests/') {
+    sendJson(
+      response,
+      200,
+      { items: [signupRequestPayload(signupStatus)], total: 1 },
+      origin
+    );
+    return;
+  }
+  if (method === 'POST' && url.pathname === '/admin/signup-requests/1/approve') {
+    signupStatus = 'approved';
+    sendJson(response, 200, activationIssuePayload(), origin);
+    return;
+  }
+  if (
+    method === 'GET' &&
+    url.pathname === '/admin/signup-requests/1/activation-token-logs'
+  ) {
+    sendJson(
+      response,
+      200,
+      { items: [activationIssuePayload().activation_issue] },
+      origin
+    );
+    return;
+  }
+  if (method === 'POST' && url.pathname === '/auth/member/activate') {
+    sendJson(response, 200, { ok: 'true' }, origin);
+    return;
+  }
+  if (method === 'GET' && url.pathname === '/hero/') {
+    sendJson(response, 200, heroSlides(), origin);
+    return;
+  }
+  if (method === 'GET' && url.pathname === '/members/') {
+    sendJson(response, 200, directoryMembers(url), origin);
+    return;
+  }
+  if (method === 'GET' && url.pathname === '/members/count') {
+    sendJson(response, 200, { count: 25 }, origin);
+    return;
+  }
+  if (method === 'GET' && (url.pathname === '/posts/' || url.pathname === '/events/')) {
+    sendJson(response, 200, [], origin);
+    return;
+  }
+  if (method === 'POST' && url.pathname === '/rum/vitals') {
+    sendJson(response, 200, { ok: true }, origin);
+    return;
+  }
+
+  sendJson(
+    response,
+    404,
+    { code: 'e2e_mock_route_missing', detail: `${method} ${url.pathname}` },
+    origin
+  );
+});
+
+server.listen(port, host, () => {
+  console.log(`[e2e-mock-api] listening on http://${host}:${port}`);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/apps/web/e2e/onboarding-happy-path.spec.ts
+++ b/apps/web/e2e/onboarding-happy-path.spec.ts
@@ -210,7 +210,7 @@ describe('Onboarding happy path (CDP E2E)', () => {
     await configureMockServer('admin');
     await setupOnboardingMocks(page);
 
-    await page.goto(`${WEB_BASE_URL}/signup`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${WEB_BASE_URL}/signup`, { waitUntil: 'networkidle0' });
     await fillFieldByLabel(page, '학번', '20251234');
     await fillFieldByLabel(page, '이름', '신규회원');
     await fillFieldByLabel(page, '이메일', 'new-member@example.com');
@@ -222,7 +222,7 @@ describe('Onboarding happy path (CDP E2E)', () => {
     await page.click('button[type="submit"]');
     await waitForBodyText(page, '가입 신청 완료');
 
-    await page.goto(`${WEB_BASE_URL}/admin/signup-requests`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${WEB_BASE_URL}/admin/signup-requests`, { waitUntil: 'networkidle0' });
     await page.waitForFunction(() => document.body.textContent?.includes('가입신청 심사'));
 
     const clickedApprove = await page.$$eval('button', (buttons) => {
@@ -236,7 +236,7 @@ describe('Onboarding happy path (CDP E2E)', () => {
     await page.waitForFunction(() => document.body.textContent?.includes('최근 발급 대상'));
     await page.waitForFunction(() => document.body.textContent?.includes('토큰 복사'));
 
-    await page.goto(`${WEB_BASE_URL}/activate?token=${ACTIVATE_TOKEN}`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${WEB_BASE_URL}/activate?token=${ACTIVATE_TOKEN}`, { waitUntil: 'networkidle0' });
     await fillFieldByLabel(page, '비밀번호', 'new-password-1234');
     const clickedActivate = await page.$$eval('button', (buttons) => {
       const target = buttons.find((button) => (button.textContent || '').trim() === '비밀번호 만들기 완료');

--- a/apps/web/e2e/onboarding-happy-path.spec.ts
+++ b/apps/web/e2e/onboarding-happy-path.spec.ts
@@ -58,6 +58,7 @@ async function waitForBodyText(page: Page, expected: string) {
 }
 
 async function setupOnboardingMocks(page: Page) {
+  if (process.env.E2E_MOCK_API_CONTROL_URL) return;
   const state: MockState = { signupStatus: 'pending' };
   const routeResponders = createOnboardingRouteResponders(state);
 

--- a/apps/web/e2e/onboarding-happy-path.spec.ts
+++ b/apps/web/e2e/onboarding-happy-path.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import puppeteer, { Browser, Page, HTTPRequest } from 'puppeteer';
 import { WEB_BASE_URL } from './utils/env';
+import { configureMockServer } from './utils/mockServer';
 
 let browser: Browser | null = null;
 let page: Page | null = null;
@@ -205,6 +206,7 @@ describe('Onboarding happy path (CDP E2E)', () => {
   it('signup -> admin approve -> activate 흐름이 동작한다', async () => {
     if (!page) throw new Error('Puppeteer page not initialized');
 
+    await configureMockServer('admin');
     await setupOnboardingMocks(page);
 
     await page.goto(`${WEB_BASE_URL}/signup`, { waitUntil: 'domcontentloaded' });

--- a/apps/web/e2e/utils/mockApi.ts
+++ b/apps/web/e2e/utils/mockApi.ts
@@ -112,6 +112,7 @@ async function respondDirectoryApi(request: HTTPRequest, url: URL): Promise<bool
 }
 
 export async function setupDirectoryMocks(page: Page): Promise<void> {
+  if (process.env.E2E_MOCK_API_CONTROL_URL) return;
   await page.setRequestInterception(true);
   const handler = async (request: HTTPRequest): Promise<void> => {
     try {

--- a/apps/web/e2e/utils/mockServer.ts
+++ b/apps/web/e2e/utils/mockServer.ts
@@ -1,0 +1,15 @@
+type MockSession = 'member' | 'admin';
+
+export async function configureMockServer(session: MockSession): Promise<void> {
+  const controlUrl = process.env.E2E_MOCK_API_CONTROL_URL;
+  if (!controlUrl) return;
+
+  const response = await fetch(`${controlUrl.replace(/\/$/, '')}/__e2e/config`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E mock API reset failed: HTTP ${response.status}`);
+  }
+}

--- a/apps/web/vitest.config.e2e.mts
+++ b/apps/web/vitest.config.e2e.mts
@@ -4,9 +4,9 @@ export default defineConfig({
   test: {
     include: ['e2e/**/*.spec.ts'],
     environment: 'node',
+    fileParallelism: false,
     testTimeout: 60_000,
     hookTimeout: 60_000,
     reporters: 'default',
   },
 });
-

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -74,7 +74,7 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 
 머지 후 GitHub **Settings → Rules → main** 에서 아래를 required status checks로 지정한다.
 
-- `repo-guards` / `python` / `contract` / `web` / `secrets-scan` / `semgrep`
+- `repo-guards` / `python` / `contract` / `web` / `e2e` / `secrets-scan` / `semgrep`
 - (권장) CodeQL `analyze` matrix jobs
 - (권장) `dto-verify` on main push
 

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -47,7 +47,7 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 | `web` | **eslint**, **vitest 전체**, build, a11y smoke, bundle, pnpm audit |
 | `secrets-scan` | gitleaks |
 | `semgrep` | Semgrep `p/ci` |
-| `e2e` (별도 workflow) | Puppeteer E2E — 현재 `continue-on-error` (#143) |
+| `e2e` (별도 workflow) | Puppeteer E2E — 실패 시 PR을 차단하는 hard gate |
 | `analyze` (CodeQL) | JS/TS + Python — PR + main + **매주 월요일 07:00 UTC** |
 
 ## main 브랜치 추가 검사

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -90,3 +90,4 @@
 - `main-quality-gates` ruleset과 적용 스크립트의 required checks에 `e2e`를 추가해 체크 실패가 실제 병합을 차단하도록 연결했다.
 - quoted YAML key를 포함한 soft-fail 변형과 ruleset의 `e2e` 누락을 pytest fixture로 고정해 가드 자체의 회귀도 검증한다.
 - hard gate 첫 CI에서 드러난 Puppeteer/Next 병렬 실행 flake를 막기 위해 E2E spec 파일을 순차 실행하도록 고정했다.
+- GitHub runner에서 브라우저 interception만으로 불안정했던 API fixture를 Next 서버와 Chromium이 함께 접근하는 deterministic mock API로 보강했다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -81,3 +81,8 @@
 - `eslint-plugin-import@2.32.0`의 허용 범위 `minimatch ^3.1.2` 안에서 lockfile을 `3.1.5`로 갱신했다.
 - 강제 major override 없이 `GHSA-3ppc-4f35-3m26`, `GHSA-7r86-cg39-jmmj`, `GHSA-23c5-xmqv-rm74`를 제거했다.
 - production dependency audit 0건을 유지하고 Web lint·test·production build로 개발 도구 호환성을 검증한다.
+
+# #143 자동 E2E hard gate 복구
+
+- 안정화 기간에 남아 있던 `web-e2e-cdp`의 `continue-on-error`를 제거해 실패가 PR을 차단하도록 복구했다.
+- repo guard에 E2E soft-fail 재도입 금지 검사를 추가하고 CI 품질 게이트 문서를 실제 동작과 맞췄다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -88,3 +88,4 @@
 - repo guard에 E2E soft-fail 재도입 금지 검사를 추가하고 CI 품질 게이트 문서를 실제 동작과 맞췄다.
 - `true`뿐 아니라 표현식·별도 값으로 `continue-on-error` 키를 다시 선언하는 우회도 거부하도록 가드를 강화했다.
 - `main-quality-gates` ruleset과 적용 스크립트의 required checks에 `e2e`를 추가해 체크 실패가 실제 병합을 차단하도록 연결했다.
+- quoted YAML key를 포함한 soft-fail 변형과 ruleset의 `e2e` 누락을 pytest fixture로 고정해 가드 자체의 회귀도 검증한다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -86,3 +86,4 @@
 
 - 안정화 기간에 남아 있던 `web-e2e-cdp`의 `continue-on-error`를 제거해 실패가 PR을 차단하도록 복구했다.
 - repo guard에 E2E soft-fail 재도입 금지 검사를 추가하고 CI 품질 게이트 문서를 실제 동작과 맞췄다.
+- `true`뿐 아니라 표현식·별도 값으로 `continue-on-error` 키를 다시 선언하는 우회도 거부하도록 가드를 강화했다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -92,3 +92,6 @@
 - hard gate 첫 CI에서 드러난 Puppeteer/Next 병렬 실행 flake를 막기 위해 E2E spec 파일을 순차 실행하도록 고정했다.
 - GitHub runner에서 브라우저 interception만으로 불안정했던 API fixture를 Next 서버와 Chromium이 함께 접근하는 deterministic mock API로 보강했다.
 - CI mock server 환경에서는 Puppeteer interception을 비활성화해 단일 fixture 경로만 사용하고, 로컬 단독 실행에서만 기존 interception fallback을 유지한다.
+- GitHub runner의 `localhost` IPv4/IPv6 해석 차이를 제거하기 위해 Web·mock API·빌드 시 API base를 모두 `127.0.0.1`로 고정한다.
+- 홈 Chromium smoke는 배너 섹션의 서버 렌더 뒤 버튼 hydration이 늦는 경우를 재시도해 초기 DOM 타이밍 flake를 제거한다.
+- Chromium smoke는 Next hydration과 초기 client fetch가 안정된 `networkidle0` 이후 조작해 rerender 중 element detach와 execution-context 교체를 피한다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -89,3 +89,4 @@
 - `true`뿐 아니라 표현식·별도 값으로 `continue-on-error` 키를 다시 선언하는 우회도 거부하도록 가드를 강화했다.
 - `main-quality-gates` ruleset과 적용 스크립트의 required checks에 `e2e`를 추가해 체크 실패가 실제 병합을 차단하도록 연결했다.
 - quoted YAML key를 포함한 soft-fail 변형과 ruleset의 `e2e` 누락을 pytest fixture로 고정해 가드 자체의 회귀도 검증한다.
+- hard gate 첫 CI에서 드러난 Puppeteer/Next 병렬 실행 flake를 막기 위해 E2E spec 파일을 순차 실행하도록 고정했다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -87,3 +87,4 @@
 - 안정화 기간에 남아 있던 `web-e2e-cdp`의 `continue-on-error`를 제거해 실패가 PR을 차단하도록 복구했다.
 - repo guard에 E2E soft-fail 재도입 금지 검사를 추가하고 CI 품질 게이트 문서를 실제 동작과 맞췄다.
 - `true`뿐 아니라 표현식·별도 값으로 `continue-on-error` 키를 다시 선언하는 우회도 거부하도록 가드를 강화했다.
+- `main-quality-gates` ruleset과 적용 스크립트의 required checks에 `e2e`를 추가해 체크 실패가 실제 병합을 차단하도록 연결했다.

--- a/docs/dev_log_260712.md
+++ b/docs/dev_log_260712.md
@@ -91,3 +91,4 @@
 - quoted YAML key를 포함한 soft-fail 변형과 ruleset의 `e2e` 누락을 pytest fixture로 고정해 가드 자체의 회귀도 검증한다.
 - hard gate 첫 CI에서 드러난 Puppeteer/Next 병렬 실행 flake를 막기 위해 E2E spec 파일을 순차 실행하도록 고정했다.
 - GitHub runner에서 브라우저 interception만으로 불안정했던 API fixture를 Next 서버와 Chromium이 함께 접근하는 deterministic mock API로 보강했다.
+- CI mock server 환경에서는 Puppeteer interception을 비활성화해 단일 fixture 경로만 사용하고, 로컬 단독 실행에서만 기존 interception fallback을 유지한다.

--- a/ops/ci/apply_main_branch_protection.sh
+++ b/ops/ci/apply_main_branch_protection.sh
@@ -38,6 +38,7 @@ payload="$(cat <<'JSON'
           { "context": "python" },
           { "context": "contract" },
           { "context": "web" },
+          { "context": "e2e" },
           { "context": "secrets-scan" },
           { "context": "semgrep" }
         ]

--- a/ops/ci/guards.py
+++ b/ops/ci/guards.py
@@ -63,6 +63,7 @@ REMOVED_AGENT_FILES = (
     ROOT / "docs/agents_base.md",
     ROOT / "scripts/sync_agents_from_base.sh",
 )
+E2E_WORKFLOW = ROOT / ".github/workflows/e2e.yml"
 
 ALLOWED_NOQA_FILES = {
     ROOT / "apps/api/migrations/env.py": {"E402"},
@@ -201,8 +202,20 @@ def check_agent_harness() -> list[str]:
     return violations
 
 
+def check_workflow_policies() -> list[str]:
+    """필수 E2E가 다시 soft-fail로 약화되지 않게 검증한다."""
+    if not E2E_WORKFLOW.is_file():
+        return [f"{E2E_WORKFLOW}: required E2E workflow is missing"]
+
+    text = E2E_WORKFLOW.read_text(encoding="utf-8")
+    if re.search(r"^\s*continue-on-error:\s*true\s*$", text, re.MULTILINE):
+        return [f"{E2E_WORKFLOW}: E2E must remain a hard gate"]
+    return []
+
+
 def main() -> int:
     all_violations = check_agent_harness()
+    all_violations.extend(check_workflow_policies())
     for path in iter_code_files():
         all_violations.extend(check_banned_comments(path))
         all_violations.extend(check_max_lines(path))

--- a/ops/ci/guards.py
+++ b/ops/ci/guards.py
@@ -64,6 +64,7 @@ REMOVED_AGENT_FILES = (
     ROOT / "scripts/sync_agents_from_base.sh",
 )
 E2E_WORKFLOW = ROOT / ".github/workflows/e2e.yml"
+BRANCH_PROTECTION_SCRIPT = ROOT / "ops/ci/apply_main_branch_protection.sh"
 
 ALLOWED_NOQA_FILES = {
     ROOT / "apps/api/migrations/env.py": {"E402"},
@@ -210,6 +211,12 @@ def check_workflow_policies() -> list[str]:
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
     if re.search(r"^\s*continue-on-error\s*:", text, re.MULTILINE):
         return [f"{E2E_WORKFLOW}: E2E must remain a hard gate"]
+
+    if not BRANCH_PROTECTION_SCRIPT.is_file():
+        return [f"{BRANCH_PROTECTION_SCRIPT}: branch protection script is missing"]
+    protection = BRANCH_PROTECTION_SCRIPT.read_text(encoding="utf-8")
+    if not re.search(r'"context"\s*:\s*"e2e"', protection):
+        return [f"{BRANCH_PROTECTION_SCRIPT}: e2e must remain a required check"]
     return []
 
 

--- a/ops/ci/guards.py
+++ b/ops/ci/guards.py
@@ -208,7 +208,7 @@ def check_workflow_policies() -> list[str]:
         return [f"{E2E_WORKFLOW}: required E2E workflow is missing"]
 
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
-    if re.search(r"^\s*continue-on-error:\s*true\s*$", text, re.MULTILINE):
+    if re.search(r"^\s*continue-on-error\s*:", text, re.MULTILINE):
         return [f"{E2E_WORKFLOW}: E2E must remain a hard gate"]
     return []
 

--- a/ops/ci/guards.py
+++ b/ops/ci/guards.py
@@ -209,7 +209,9 @@ def check_workflow_policies() -> list[str]:
         return [f"{E2E_WORKFLOW}: required E2E workflow is missing"]
 
     text = E2E_WORKFLOW.read_text(encoding="utf-8")
-    if re.search(r"^\s*continue-on-error\s*:", text, re.MULTILINE):
+    if re.search(
+        r"^\s*[\"']?continue-on-error[\"']?\s*:", text, re.MULTILINE
+    ):
         return [f"{E2E_WORKFLOW}: E2E must remain a hard gate"]
 
     if not BRANCH_PROTECTION_SCRIPT.is_file():

--- a/tests/test_repo_guards.py
+++ b/tests/test_repo_guards.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+from ops.ci import guards
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    (
+        "continue-on-error: true",
+        "continue-on-error: ${{ true }}",
+        "continue-on-error: false",
+        '"continue-on-error": true',
+        "'continue-on-error': true",
+    ),
+)
+def test_e2e_workflow_rejects_soft_fail_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, declaration: str
+) -> None:
+    workflow = tmp_path / "e2e.yml"
+    workflow.write_text(f"jobs:\n  e2e:\n    {declaration}\n", encoding="utf-8")
+    protection = tmp_path / "apply-protection.sh"
+    protection.write_text('{ "context": "e2e" }\n', encoding="utf-8")
+    monkeypatch.setattr(guards, "E2E_WORKFLOW", workflow)
+    monkeypatch.setattr(guards, "BRANCH_PROTECTION_SCRIPT", protection)
+
+    assert guards.check_workflow_policies() == [
+        f"{workflow}: E2E must remain a hard gate"
+    ]
+
+
+def test_branch_protection_requires_e2e_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = tmp_path / "e2e.yml"
+    workflow.write_text("jobs:\n  e2e:\n    steps: []\n", encoding="utf-8")
+    protection = tmp_path / "apply-protection.sh"
+    protection.write_text('{ "context": "web" }\n', encoding="utf-8")
+    monkeypatch.setattr(guards, "E2E_WORKFLOW", workflow)
+    monkeypatch.setattr(guards, "BRANCH_PROTECTION_SCRIPT", protection)
+
+    assert guards.check_workflow_policies() == [
+        f"{protection}: e2e must remain a required check"
+    ]


### PR DESCRIPTION
## 배경/목적

- #143에서 자동 E2E 안정화 후 제거하기로 한 `continue-on-error: true`가 “수정 완료” 댓글 이후에도 워크플로에 남아 있었습니다.
- 최근 PR의 `web-e2e-cdp`가 반복 통과하고 있으므로 임시 soft-fail을 제거해 실제 병합 게이트로 복구합니다.

Related to #143
Related to #174

## 변경사항

- `.github/workflows/e2e.yml`의 `continue-on-error`와 오래된 임시 주석을 제거합니다.
- repo guard가 필수 E2E workflow의 `continue-on-error` 키 재도입을 값·표현식과 무관하게 거부하도록 합니다.
- branch protection 적용 스크립트와 실제 `main-quality-gates` required checks에 `e2e`를 추가합니다.
- Next 서버와 Chromium이 함께 접근하는 Node 내장 HTTP deterministic mock API를 CI에서 실행합니다.
- 공유 fixture의 세션 상태가 섞이지 않도록 E2E spec 파일을 순차 실행합니다.
- CI 품질 게이트 문서와 당일 개발 로그를 실제 동작에 맞춥니다.

## 사용자·운영 영향

- 자동 E2E 실패가 더 이상 성공처럼 처리되지 않고 PR을 차단합니다.
- 제품 런타임·API·DB·배포 설정 변화는 없습니다.
- 롤백은 이 PR merge commit을 revert한 뒤 되돌아간 `apply_main_branch_protection.sh`를 실행해 live ruleset도 함께 복원합니다. 롤백 시 E2E 실패는 다시 비차단화됩니다.

## 검증

- [x] `.venv/bin/ruff check ops/ci/guards.py`
- [x] `.venv/bin/python ops/ci/guards.py`
- [x] `true`, 표현식, `false` soft-fail 키 fixture가 repo guard에서 모두 거부되는지 확인
- [x] `.venv/bin/pytest -q tests/test_repo_guards.py` — quoted key·required context 포함 6 passed
- [x] local CI-equivalent mock API + production Web E2E 3회 — 매회 3/3 passed (14.49s, 9.06s, 9.05s)
- [x] mock API health/session reset/unknown-route fail-closed 확인
- [x] `pnpm -C apps/web lint`
- [x] `pnpm -C apps/web test` — 48 files, 147 tests
- [x] `.venv/bin/python ops/ci/check_versions.py`
- [x] ruleset required checks에 `e2e` readback
- [x] `git diff --check`
- [x] Ready CI에서 `web-e2e-cdp` 실제 통과 — head `e088a3e`, GitHub runner 58초 PASS