### PR TITLE
fix(api): RSVP 소유권과 세션 권한 authority 강화

### DIFF
--- a/apps/api/repositories/members.py
+++ b/apps/api/repositories/members.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, literal, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.elements import ColumnElement
@@ -11,6 +11,8 @@ from sqlalchemy.sql.elements import ColumnElement
 from .. import models, schemas
 from ..errors import NotFoundError
 from . import escape_like
+
+_SUPER_ADMIN_ROLE_LOCK_ID = 0x534F4745434F4E
 
 
 def _build_member_conditions(
@@ -134,6 +136,35 @@ async def count_members(
         stmt = stmt.where(and_(*conds))
     result = await db.execute(stmt)
     return int(result.scalar() or 0)
+
+
+async def count_active_members_with_role(
+    db: AsyncSession,
+    *,
+    role: str,
+    serialize_super_admin_changes: bool = False,
+) -> int:
+    """쉼표 구분 역할 토큰을 정확히 세고 필요 시 역할 변경을 직렬화한다."""
+    if serialize_super_admin_changes:
+        if role != "super_admin":
+            raise ValueError(
+                "serialized role changes are only supported for super_admin"
+            )
+        await db.execute(select(func.pg_advisory_xact_lock(_SUPER_ADMIN_ROLE_LOCK_ID)))
+
+    roles_with_boundaries = func.concat(
+        literal(","), models.Member.roles, literal(",")
+    )
+    stmt = (
+        select(func.count())
+        .select_from(models.Member)
+        .where(
+            roles_with_boundaries.like(f"%,{role},%"),
+            models.Member.status == "active",
+        )
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one())
 
 
 async def get_member(db: AsyncSession, member_id: int) -> models.Member:

--- a/apps/api/repositories/members.py
+++ b/apps/api/repositories/members.py
@@ -152,6 +152,10 @@ async def count_active_members_with_role(
             )
         await db.execute(select(func.pg_advisory_xact_lock(_SUPER_ADMIN_ROLE_LOCK_ID)))
 
+    # LIKE wildcards (`_` / `%`) must not match arbitrary role tokens.
+    escaped_role = (
+        role.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
     roles_with_boundaries = func.concat(
         literal(","), models.Member.roles, literal(",")
     )
@@ -159,7 +163,7 @@ async def count_active_members_with_role(
         select(func.count())
         .select_from(models.Member)
         .where(
-            roles_with_boundaries.like(f"%,{role},%"),
+            roles_with_boundaries.like(f"%,{escaped_role},%", escape="\\"),
             models.Member.status == "active",
         )
     )

--- a/apps/api/repositories/rsvps.py
+++ b/apps/api/repositories/rsvps.py
@@ -10,9 +10,14 @@ from ..errors import AlreadyExistsError, NotFoundError
 
 
 async def list_rsvps(
-    db: AsyncSession, *, limit: int, offset: int
+    db: AsyncSession, *, member_id: int, limit: int, offset: int
 ) -> Sequence[models.RSVP]:
-    stmt = select(models.RSVP).offset(offset).limit(limit)
+    stmt = (
+        select(models.RSVP)
+        .where(models.RSVP.member_id == member_id)
+        .offset(offset)
+        .limit(limit)
+    )
     result = await db.execute(stmt)
     return result.scalars().all()
 
@@ -25,16 +30,23 @@ async def get_rsvp(db: AsyncSession, member_id: int, event_id: int) -> models.RS
     return rsvp
 
 
-async def create_rsvp(db: AsyncSession, payload: schemas.RSVPCreate) -> models.RSVP:
+async def create_rsvp(
+    db: AsyncSession,
+    *,
+    member_id: int,
+    event_id: int,
+    status: schemas.RSVPLiteral,
+) -> models.RSVP:
     # 복합 PK 중복 방지
-    key: tuple[int, int] = (payload.member_id, payload.event_id)
+    key: tuple[int, int] = (member_id, event_id)
     exists = await db.get(models.RSVP, key)
     if exists is not None:
         raise AlreadyExistsError(code="rsvp_exists", detail="RSVP already exists")
-    data = payload.model_dump()
-    if "status" in data:
-        data["status"] = models.RSVPStatus(data["status"])  # normalize enum
-    rsvp = models.RSVP(**data)
+    rsvp = models.RSVP(
+        member_id=member_id,
+        event_id=event_id,
+        status=models.RSVPStatus(status),
+    )
     db.add(rsvp)
     await db.commit()
     await db.refresh(rsvp)

--- a/apps/api/routers/admin_events.py
+++ b/apps/api/routers/admin_events.py
@@ -104,6 +104,51 @@ async def update_admin_event(
     return schemas.EventRead.model_validate(event)
 
 
+@router.post(
+    "/{event_id}/rsvps/{member_id}",
+    response_model=schemas.RSVPRead,
+    status_code=201,
+)
+async def upsert_member_rsvp(
+    event_id: int,
+    member_id: int,
+    payload: schemas.RSVPStatusUpdate,
+    db: AsyncSession = Depends(get_db),
+    _admin: CurrentUser = Depends(
+        require_permission("admin_events", allow_admin_fallback=False)
+    ),
+) -> schemas.RSVPRead:
+    """관리자 운영용 타 회원 RSVP 생성·변경 경로."""
+    rsvp = await events_service.upsert_rsvp_status(
+        db,
+        event_id=event_id,
+        member_id=member_id,
+        status=payload.status,
+    )
+    return schemas.RSVPRead.model_validate(rsvp)
+
+
+@router.get(
+    "/{event_id}/rsvps/{member_id}",
+    response_model=schemas.RSVPRead,
+)
+async def get_member_rsvp(
+    event_id: int,
+    member_id: int,
+    db: AsyncSession = Depends(get_db),
+    _admin: CurrentUser = Depends(
+        require_permission("admin_events", allow_admin_fallback=False)
+    ),
+) -> schemas.RSVPRead:
+    """관리자 운영용 타 회원 RSVP 조회 경로."""
+    rsvp = await events_service.get_member_rsvp(
+        db,
+        event_id=event_id,
+        member_id=member_id,
+    )
+    return schemas.RSVPRead.model_validate(rsvp)
+
+
 @router.delete("/{event_id}", status_code=204)
 async def delete_admin_event(
     event_id: int,

--- a/apps/api/routers/comments.py
+++ b/apps/api/routers/comments.py
@@ -36,7 +36,7 @@ async def create_comment(
     """댓글 작성 (회원 또는 관리자)"""
     # 보안: author_id는 클라이언트 입력 무시, student_id로 DB에서 member 조회
     # 레거시 세션(admin_users.id가 저장된 경우)에서도 올바른 author_id 사용
-    member = require_member(request)
+    member = await require_member(request, db)
     comment = await comments_service.create_comment_by_student_id(
         db, payload, member.student_id
     )
@@ -54,7 +54,7 @@ async def delete_comment(
     is_admin = False
     requester_id: int
     try:
-        require_admin(request)
+        await require_admin(request, db)
         is_admin = True
         requester_id = 0  # 관리자는 ID 체크 안 함
     except HTTPException as exc_admin:
@@ -63,7 +63,7 @@ async def delete_comment(
             HTTPStatus.FORBIDDEN,
         ):
             raise
-        member = require_member(request)
+        member = await require_member(request, db)
         # require_member 성공 시 member.id는 항상 존재 (primary key 보장)
         if member.id is None:
             raise HTTPException(

--- a/apps/api/routers/events.py
+++ b/apps/api/routers/events.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from typing import cast
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import schemas
 from ..db import get_db
 from ..services import events_service
-from .auth import CurrentAdmin, require_admin
+from .auth import CurrentAdmin, CurrentMember, require_admin, require_member
 
 router = APIRouter(prefix="/events", tags=["events"])
 
@@ -44,8 +46,12 @@ async def create_rsvp(
     event_id: int,
     payload: schemas.RSVPStatusUpdate,
     db: AsyncSession = Depends(get_db),
+    member: CurrentMember = Depends(require_member),
 ) -> schemas.RSVPRead:
     rsvp = await events_service.upsert_rsvp_status(
-        db, event_id=event_id, member_id=payload.member_id, status=payload.status
+        db,
+        event_id=event_id,
+        member_id=cast(int, member.id),
+        status=payload.status,
     )
     return schemas.RSVPRead.model_validate(rsvp)

--- a/apps/api/routers/hero.py
+++ b/apps/api/routers/hero.py
@@ -18,7 +18,7 @@ async def list_hero_slides(
     include_unpublished: bool = Query(False),
     db: AsyncSession = Depends(get_db),
 ) -> list[schemas.HeroSlide]:
-    allow_unpublished = include_unpublished and is_admin(request)
+    allow_unpublished = include_unpublished and await is_admin(db, request)
     return await hero_service.list_hero_slides(
         db, limit=limit, allow_unpublished=allow_unpublished
     )

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -203,7 +203,7 @@ async def get_post(
 ) -> schemas.PostRead:
     post = await posts_service.get_post(db, post_id)
     # 관리자 조회는 통계 왜곡을 피하기 위해 조회수 증가 제외
-    if not is_admin(request):
+    if not await is_admin(db, request):
         # 조회수 증가 후 refresh로 최신 값 반영 (재조회 대신)
         await posts_repo.increment_view_count(db, post_id)
         await db.refresh(post)
@@ -220,7 +220,7 @@ async def create_post(
     db: AsyncSession = Depends(get_db),
 ) -> schemas.PostRead:
     try:
-        admin = require_admin(request)
+        admin = await require_admin(request, db)
         # 보안: 클라이언트가 보낸 author_id를 무시하고 서버에서 강제 주입
         # student_id로 member를 조회하여 author_id 결정 (레거시 세션 호환)
         # 관리자는 pinned, published_at 등 관리자 권한 필드 설정 가능
@@ -236,7 +236,7 @@ async def create_post(
         ):
             raise
         try:
-            member = require_member(request)
+            member = await require_member(request, db)
         except HTTPException as exc_member:
             raise HTTPException(status_code=401, detail="unauthorized") from exc_member
 
@@ -262,7 +262,7 @@ async def update_post(
     db: AsyncSession = Depends(get_db),
 ) -> schemas.PostRead:
     """게시물 수정 (관리자 전용)."""
-    require_admin(request)
+    await require_admin(request, db)
     post = await posts_service.update_admin_post(db, post_id, payload)
     post_read = schemas.PostRead.model_validate(post)
     post_read.author_name = post.author.name if post.author else None
@@ -277,6 +277,6 @@ async def delete_post(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, bool | int]:
     """게시물 삭제 (관리자 전용)."""
-    require_admin(request)
+    await require_admin(request, db)
     deleted_id = await posts_service.delete_admin_post(db, post_id)
     return {"ok": True, "deleted_id": deleted_id}

--- a/apps/api/routers/rsvps.py
+++ b/apps/api/routers/rsvps.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import cast
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import schemas
 from ..db import get_db
 from ..services import rsvps_service
+from .auth import CurrentMember, require_member
 
 router = APIRouter(prefix="/rsvps", tags=["rsvps"])
 
@@ -15,8 +18,14 @@ async def list_rsvps(
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
+    member: CurrentMember = Depends(require_member),
 ) -> list[schemas.RSVPRead]:
-    rsvps = await rsvps_service.list_rsvps(db, limit=limit, offset=offset)
+    rsvps = await rsvps_service.list_rsvps(
+        db,
+        member_id=cast(int, member.id),
+        limit=limit,
+        offset=offset,
+    )
     return [schemas.RSVPRead.model_validate(rsvp) for rsvp in rsvps]
 
 
@@ -25,8 +34,14 @@ async def get_rsvp(
     member_id: int,
     event_id: int,
     db: AsyncSession = Depends(get_db),
+    member: CurrentMember = Depends(require_member),
 ) -> schemas.RSVPRead:
-    rsvp = await rsvps_service.get_rsvp(db, member_id, event_id)
+    rsvp = await rsvps_service.get_rsvp(
+        db,
+        requested_member_id=member_id,
+        actor_member_id=cast(int, member.id),
+        event_id=event_id,
+    )
     return schemas.RSVPRead.model_validate(rsvp)
 
 
@@ -34,6 +49,11 @@ async def get_rsvp(
 async def create_rsvp(
     payload: schemas.RSVPCreate,
     db: AsyncSession = Depends(get_db),
+    member: CurrentMember = Depends(require_member),
 ) -> schemas.RSVPRead:
-    rsvp = await rsvps_service.create_rsvp(db, payload)
+    rsvp = await rsvps_service.create_rsvp(
+        db,
+        member_id=cast(int, member.id),
+        payload=payload,
+    )
     return schemas.RSVPRead.model_validate(rsvp)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -526,8 +526,9 @@ class RSVPBase(BaseModel):
     status: RSVPLiteral = "going"
 
 
-class RSVPCreate(RSVPBase):
-    pass
+class RSVPCreate(BaseModel):
+    event_id: int
+    status: RSVPLiteral = "going"
 
 
 class MemberAuthCreate(BaseModel):
@@ -536,7 +537,6 @@ class MemberAuthCreate(BaseModel):
 
 
 class RSVPStatusUpdate(BaseModel):
-    member_id: int
     status: RSVPLiteral = "going"
 
 

--- a/apps/api/services/auth_service.py
+++ b/apps/api/services/auth_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from http import HTTPStatus
 from typing import Any, cast
 
 from fastapi import Depends, HTTPException, Request
@@ -149,18 +150,24 @@ async def _refresh_user_session(
 # ---- 권한 확인 의존성 ----
 
 
-def require_admin(req: Request) -> CurrentAdmin:
+async def require_admin(
+    req: Request,
+    db: AsyncSession = Depends(get_db),
+) -> CurrentAdmin:
     """관리자 권한 필요 의존성.
 
     통합 세션(`user`)에 roles 'admin' 또는 'super_admin'이 포함되어야 한다.
     """
-    u = _get_user_session(req)
-    if u and ("admin" in u.roles or "super_admin" in u.roles):
-        email = u.email or u.student_id
+    user = _get_user_session(req)
+    if user is not None:
+        user, _member = await _refresh_user_session(db, req, user)
+        if "admin" not in user.roles and "super_admin" not in user.roles:
+            raise HTTPException(status_code=403, detail="admin_required")
+        email = user.email or user.student_id
         return CurrentAdmin(
-            id=u.id if isinstance(u.id, int) else 0,
+            id=user.id if isinstance(user.id, int) else 0,
             email=email,
-            student_id=u.student_id,
+            student_id=user.student_id,
         )
     raise HTTPException(status_code=401, detail="unauthorized")
 
@@ -196,37 +203,59 @@ def require_permission(
     return _dependency
 
 
-def require_super_admin(req: Request) -> CurrentUser:
+async def require_super_admin(
+    req: Request,
+    db: AsyncSession = Depends(get_db),
+) -> CurrentUser:
     """super_admin 권한 필요 의존성."""
     user = _get_user_session(req)
     if user is not None:
+        user, _member = await _refresh_user_session(db, req, user)
         if "super_admin" in user.roles:
             return user
         raise HTTPException(status_code=403, detail="super_admin_required")
     raise HTTPException(status_code=401, detail="unauthorized")
 
 
-def is_admin(req: Request) -> bool:
-    """현재 요청이 관리자 권한인지 여부만 반환(예외 없이)."""
-    u = _get_user_session(req)
-    return bool(u and ("admin" in u.roles or "super_admin" in u.roles))
+async def is_admin(db: AsyncSession, req: Request) -> bool:
+    """현재 DB 상태 기준 관리자 여부를 반환한다.
+
+    공개 경로에서 선택적으로 관리자 기능을 허용하는 용도이므로, 삭제·정지된
+    세션은 제거한 뒤 익명 사용자와 동일하게 ``False``를 반환한다.
+    """
+    user = _get_user_session(req)
+    if user is None:
+        return False
+    try:
+        user, _member = await _refresh_user_session(db, req, user)
+    except HTTPException as exc:
+        if exc.status_code == HTTPStatus.UNAUTHORIZED:
+            return False
+        raise
+    return "admin" in user.roles or "super_admin" in user.roles
 
 
-def require_member(req: Request) -> CurrentMember:
+async def require_member(
+    req: Request,
+    db: AsyncSession = Depends(get_db),
+) -> CurrentMember:
     """멤버 권한 필요 의존성.
 
     통합 세션(`user`)에 roles 'member' 또는 'admin' 또는 'super_admin'이
     포함되면 통과.
     """
-    u = _get_user_session(req)
-    if u and (
-        "member" in u.roles
-        or "admin" in u.roles
-        or "super_admin" in u.roles
-    ):
+    user = _get_user_session(req)
+    if user is not None:
+        user, _member = await _refresh_user_session(db, req, user)
+        if not (
+            "member" in user.roles
+            or "admin" in user.roles
+            or "super_admin" in user.roles
+        ):
+            raise HTTPException(status_code=403, detail="member_required")
         return CurrentMember(
-            student_id=u.student_id,
-            id=u.id if isinstance(u.id, int) else None,
+            student_id=user.student_id,
+            id=user.id if isinstance(user.id, int) else None,
         )
     raise HTTPException(status_code=401, detail="unauthorized")
 

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -120,10 +120,12 @@ async def upsert_rsvp_status(
     cap_int = cast(int, event_obj.capacity)
     if rsvp is None:
         final_status = await _normalize_status(status, None, cap_int)
-        payload = schemas.RSVPCreate(
-            member_id=member_id, event_id=event_id, status=final_status.value
+        rsvp = await rsvps_repo.create_rsvp(
+            db,
+            member_id=member_id,
+            event_id=event_id,
+            status=final_status.value,
         )
-        rsvp = await rsvps_repo.create_rsvp(db, payload)
     else:
         # 타입체커 호환을 위해 setattr 사용
         new_status = await _normalize_status(status, rsvp, cap_int)
@@ -135,3 +137,13 @@ async def upsert_rsvp_status(
             # Postgres: SKIP LOCKED로 경쟁 중복 승급 방지
             await _promote_waitlist_candidate(db, event_id)
     return rsvp
+
+
+async def get_member_rsvp(
+    db: AsyncSession,
+    *,
+    event_id: int,
+    member_id: int,
+) -> models.RSVP:
+    """관리자 운영 경로에서 특정 회원의 RSVP를 조회한다."""
+    return await rsvps_repo.get_rsvp(db, member_id, event_id)

--- a/apps/api/services/events_service.py
+++ b/apps/api/services/events_service.py
@@ -83,6 +83,35 @@ async def _promote_waitlist_candidate(db: AsyncSession, event_id: int) -> None:
         await db.refresh(candidate)
 
 
+async def normalize_rsvp_status_for_capacity(
+    db: AsyncSession,
+    *,
+    event_id: int,
+    capacity: int,
+    requested: schemas.RSVPLiteral,
+    existing: models.RSVP | None,
+) -> models.RSVPStatus:
+    """capacity v1: `going` 요청 시 정원이 가득 찼다면 `waitlist`로 강제."""
+    if requested != "going":
+        return models.RSVPStatus(requested)
+
+    count_stmt = select(func.count(models.RSVP.member_id)).where(
+        models.RSVP.event_id == event_id,
+        models.RSVP.status == models.RSVPStatus.GOING,
+    )
+    result = await db.execute(count_stmt)
+    going_count = int(result.scalar_one())
+    # 업데이트 시 본인 카운트는 제외하여 재요청으로 인한 부당한 대기열 강등을 방지
+    effective = going_count
+    if existing is not None:
+        current: models.RSVPStatus = cast(models.RSVPStatus, existing.status)
+        if current == models.RSVPStatus.GOING:
+            effective -= 1
+    if effective >= capacity:
+        return models.RSVPStatus.WAITLIST
+    return models.RSVPStatus.GOING
+
+
 async def upsert_rsvp_status(
     db: AsyncSession, *, event_id: int, member_id: int, status: schemas.RSVPLiteral
 ) -> models.RSVP:
@@ -94,32 +123,16 @@ async def upsert_rsvp_status(
     event_obj = await events_repo.get_event(db, event_id)
     _ = await members_repo.get_member(db, member_id)
 
-    async def _normalize_status(
-        req: schemas.RSVPLiteral, existing: models.RSVP | None, capacity_int: int
-    ) -> models.RSVPStatus:
-        if req != "going":
-            return models.RSVPStatus(req)
-        # going인 경우 정원 검사
-        count_stmt = select(func.count(models.RSVP.member_id)).where(
-            models.RSVP.event_id == event_id,
-            models.RSVP.status == models.RSVPStatus.GOING,
-        )
-        result = await db.execute(count_stmt)
-        going_count = result.scalar_one()
-        # 업데이트 시 본인 카운트는 제외하여 재요청으로 인한 부당한 대기열 강등을 방지
-        effective = int(going_count)
-        if existing is not None:
-            current: models.RSVPStatus = cast(models.RSVPStatus, existing.status)
-            if current == models.RSVPStatus.GOING:
-                effective -= 1
-        if effective >= capacity_int:
-            return models.RSVPStatus.WAITLIST
-        return models.RSVPStatus.GOING
-
     rsvp = await db.get(models.RSVP, (member_id, event_id))
     cap_int = cast(int, event_obj.capacity)
     if rsvp is None:
-        final_status = await _normalize_status(status, None, cap_int)
+        final_status = await normalize_rsvp_status_for_capacity(
+            db,
+            event_id=event_id,
+            capacity=cap_int,
+            requested=status,
+            existing=None,
+        )
         rsvp = await rsvps_repo.create_rsvp(
             db,
             member_id=member_id,
@@ -128,7 +141,13 @@ async def upsert_rsvp_status(
         )
     else:
         # 타입체커 호환을 위해 setattr 사용
-        new_status = await _normalize_status(status, rsvp, cap_int)
+        new_status = await normalize_rsvp_status_for_capacity(
+            db,
+            event_id=event_id,
+            capacity=cap_int,
+            requested=status,
+            existing=rsvp,
+        )
         setattr(rsvp, "status", new_status)
         await db.commit()
         await db.refresh(rsvp)

--- a/apps/api/services/members_service.py
+++ b/apps/api/services/members_service.py
@@ -545,16 +545,12 @@ async def update_member_roles(
         previous_profile.grade == "super_admin"
         and "super_admin" not in normalized_roles
     ):
-        # super_admin 수 카운트
-        # roles는 normalize/serialize를 거친 쉼표 구분 토큰 문자열이며,
-        # 현재 역할 스키마에서 "super_admin"은 독립 토큰으로만 사용된다.
-        stmt = select(models.Member).where(
-            models.Member.roles.contains("super_admin"),
-            models.Member.status == "active",
+        super_admin_count = await members_repo.count_active_members_with_role(
+            db,
+            role="super_admin",
+            serialize_super_admin_changes=True,
         )
-        result = await db.execute(stmt)
-        super_admin_members = result.scalars().all()
-        if len(super_admin_members) <= 1:
+        if super_admin_count <= 1:
             raise ApiError(
                 code="last_super_admin_forbidden",
                 detail="Cannot remove the last super_admin",

--- a/apps/api/services/members_service.py
+++ b/apps/api/services/members_service.py
@@ -275,6 +275,32 @@ async def get_member_by_student_id(db: AsyncSession, student_id: str) -> models.
     return await members_repo.get_member_by_student_id(db, student_id)
 
 
+async def _ensure_not_deactivating_last_super_admin(
+    db: AsyncSession,
+    *,
+    member: models.Member,
+    next_status: object,
+) -> None:
+    """활성 마지막 super_admin을 비활성 상태로 바꾸지 못하게 막는다."""
+    if not isinstance(next_status, str) or next_status == "active":
+        return
+    if str(member.status) != "active":
+        return
+    if parse_roles(member.roles).grade != "super_admin":
+        return
+    super_admin_count = await members_repo.count_active_members_with_role(
+        db,
+        role="super_admin",
+        serialize_super_admin_changes=True,
+    )
+    if super_admin_count <= 1:
+        raise ApiError(
+            code="last_super_admin_forbidden",
+            detail="Cannot deactivate the last super_admin",
+            status=422,
+        )
+
+
 async def update_member_profile_admin(
     db: AsyncSession, *, member_id: int, data: schemas.AdminMemberUpdate
 ) -> models.Member:
@@ -282,6 +308,14 @@ async def update_member_profile_admin(
     raw_payload = data.model_dump(exclude_unset=True)
     if not raw_payload:
         return await members_repo.get_member(db, member_id)
+
+    member = await members_repo.get_member(db, member_id)
+    if "status" in raw_payload:
+        await _ensure_not_deactivating_last_super_admin(
+            db,
+            member=member,
+            next_status=raw_payload.get("status"),
+        )
 
     sanitized_data: dict[str, object] = {
         key: value.strip() if isinstance(value, str) else value

--- a/apps/api/services/rsvps_service.py
+++ b/apps/api/services/rsvps_service.py
@@ -5,22 +5,47 @@ from collections.abc import Sequence
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models, schemas
+from ..errors import ApiError
 from ..repositories import events as events_repo
 from ..repositories import members as members_repo
 from ..repositories import rsvps as rsvps_repo
 
 
 async def list_rsvps(
-    db: AsyncSession, *, limit: int, offset: int
+    db: AsyncSession, *, member_id: int, limit: int, offset: int
 ) -> Sequence[models.RSVP]:
-    return await rsvps_repo.list_rsvps(db, limit=limit, offset=offset)
+    return await rsvps_repo.list_rsvps(
+        db, member_id=member_id, limit=limit, offset=offset
+    )
 
 
-async def get_rsvp(db: AsyncSession, member_id: int, event_id: int) -> models.RSVP:
-    return await rsvps_repo.get_rsvp(db, member_id, event_id)
+async def get_rsvp(
+    db: AsyncSession,
+    *,
+    requested_member_id: int,
+    actor_member_id: int,
+    event_id: int,
+) -> models.RSVP:
+    if requested_member_id != actor_member_id:
+        raise ApiError(
+            code="rsvp_forbidden",
+            detail="Cannot access another member's RSVP",
+            status=403,
+        )
+    return await rsvps_repo.get_rsvp(db, actor_member_id, event_id)
 
 
-async def create_rsvp(db: AsyncSession, payload: schemas.RSVPCreate) -> models.RSVP:
+async def create_rsvp(
+    db: AsyncSession,
+    *,
+    member_id: int,
+    payload: schemas.RSVPCreate,
+) -> models.RSVP:
     _ = await events_repo.get_event(db, payload.event_id)  # 존재 확인
-    _ = await members_repo.get_member(db, payload.member_id)  # 존재 확인
-    return await rsvps_repo.create_rsvp(db, payload)
+    _ = await members_repo.get_member(db, member_id)  # 존재 확인
+    return await rsvps_repo.create_rsvp(
+        db,
+        member_id=member_id,
+        event_id=payload.event_id,
+        status=payload.status,
+    )

--- a/apps/api/services/rsvps_service.py
+++ b/apps/api/services/rsvps_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +10,7 @@ from ..errors import ApiError
 from ..repositories import events as events_repo
 from ..repositories import members as members_repo
 from ..repositories import rsvps as rsvps_repo
+from .events_service import normalize_rsvp_status_for_capacity
 
 
 async def list_rsvps(
@@ -41,11 +43,18 @@ async def create_rsvp(
     member_id: int,
     payload: schemas.RSVPCreate,
 ) -> models.RSVP:
-    _ = await events_repo.get_event(db, payload.event_id)  # 존재 확인
+    event_obj = await events_repo.get_event(db, payload.event_id)  # 존재 확인
     _ = await members_repo.get_member(db, member_id)  # 존재 확인
+    final_status = await normalize_rsvp_status_for_capacity(
+        db,
+        event_id=int(payload.event_id),
+        capacity=cast(int, event_obj.capacity),
+        requested=payload.status,
+        existing=None,
+    )
     return await rsvps_repo.create_rsvp(
         db,
         member_id=member_id,
         event_id=payload.event_id,
-        status=payload.status,
+        status=final_status.value,
     )

--- a/apps/web/__tests__/event-journey.test.tsx
+++ b/apps/web/__tests__/event-journey.test.tsx
@@ -51,7 +51,7 @@ describe('행사 참여 사용자 여정', () => {
     expect(await screen.findByText('아직 신청하지 않았어요')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '참여 신청하기' }));
 
-    await waitFor(() => expect(upsertEventRsvpMock).toHaveBeenCalledWith(1, 9, 'going'));
+    await waitFor(() => expect(upsertEventRsvpMock).toHaveBeenCalledWith(1, 'going'));
     expect(await screen.findByText('행사 참여 신청이 완료되었습니다.')).toBeInTheDocument();
   });
 
@@ -62,7 +62,7 @@ describe('행사 참여 사용자 여정', () => {
     expect(await screen.findByText('참여 신청 완료')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '참여 신청하기' })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '참여 취소' }));
-    await waitFor(() => expect(upsertEventRsvpMock).toHaveBeenCalledWith(1, 9, 'cancel'));
+    await waitFor(() => expect(upsertEventRsvpMock).toHaveBeenCalledWith(1, 'cancel'));
   });
 
   it('존재하지 않는 행사를 무한 로딩 대신 복구 가능한 안내로 보여준다', async () => {

--- a/apps/web/__tests__/events-service.test.ts
+++ b/apps/web/__tests__/events-service.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('../lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+import { upsertEventRsvp } from '../services/events';
+
+describe('events service RSVP authority', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue(undefined);
+  });
+
+  it('sends only status because the server owns member_id', async () => {
+    await upsertEventRsvp(17, 'going');
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/events/17/rsvp', {
+      method: 'POST',
+      body: JSON.stringify({ status: 'going' }),
+    });
+  });
+});

--- a/apps/web/app/events/[id]/page.tsx
+++ b/apps/web/app/events/[id]/page.tsx
@@ -132,7 +132,7 @@ function makeRsvpMutationFn(memberId: number | null, eventId: number) {
     if (memberId == null) {
       throw new Error('member_id_missing');
     }
-    await upsertEventRsvp(eventId, memberId, status);
+    await upsertEventRsvp(eventId, status);
   };
 }
 

--- a/apps/web/services/events.ts
+++ b/apps/web/services/events.ts
@@ -46,12 +46,11 @@ export async function getEvent(id: number): Promise<Event> {
 
 export async function upsertEventRsvp(
   eventId: number,
-  memberId: number,
   status: RSVPLiteral
 ) {
   return apiFetch(`/events/${eventId}/rsvp`, {
     method: 'POST',
-    body: JSON.stringify({ member_id: memberId, status })
+    body: JSON.stringify({ status })
   });
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,18 @@
 - 세션 조회: `GET /auth/me` → `{ id, email }`.
 - 로그아웃: `POST /auth/logout` → 세션 제거.
 - 보호 라우트: posts/events/members 생성 시 `require_admin` 의존성 적용.
+- 보호 dependency는 세션에 저장된 역할을 권한 근거로 직접 사용하지 않고,
+  요청마다 현재 `Member.status`와 `roles`를 DB에서 재확인한다. 삭제·정지 계정은
+  401로 세션을 무효화하고, 활성 계정의 역할 회수는 기존 세션에도 즉시 반영한다.
 - 레이트리밋: 로그인 시도 `5/min/IP`(SlowAPI), 글로벌 기본 제한은 설정값(`RATE_LIMIT_DEFAULT`).
 
 ## RSVP 규칙
+- 모든 RSVP 조회·생성·상태 변경은 활성 회원 세션이 필요하다.
+- 일반 회원의 RSVP owner는 요청 body의 `member_id`가 아니라 현재 세션의 회원
+  ID로 결정한다. `GET /rsvps/`는 본인 행만 반환하고,
+  `GET /rsvps/{member_id}/{event_id}`도 본인 ID에만 접근할 수 있다.
+- 사무국의 타 회원 RSVP 조회·변경은 `admin_events` 권한으로 보호된
+  `GET|POST /admin/events/{event_id}/rsvps/{member_id}`에서만 수행한다.
 - v1: 정원 초과 시 요청은 `waitlist`로 강제. 기존 참석자의 재요청은 유지.
 - v2: 참석자 `cancel` 시 대기열(created_at 기준) 최상위 1인을 `going`으로 자동 승급(트랜잭션).
 - Web 조회 계약: `GET /rsvps/{member_id}/{event_id}`의 `rsvp_not_found` 404만 정상적인 미신청 상태로 변환합니다. 인증·서버·네트워크 오류는 미신청으로 숨기지 않고 복구 가능한 오류 화면으로 표시합니다.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,10 @@
 - 사무국의 타 회원 RSVP 조회·변경은 `admin_events` 권한으로 보호된
   `GET|POST /admin/events/{event_id}/rsvps/{member_id}`에서만 수행한다.
 - v1: 정원 초과 시 요청은 `waitlist`로 강제. 기존 참석자의 재요청은 유지.
+  `POST /events/{event_id}/rsvp`와 `POST /rsvps/` 생성 경로에 동일하게 적용한다.
 - v2: 참석자 `cancel` 시 대기열(created_at 기준) 최상위 1인을 `going`으로 자동 승급(트랜잭션).
+- 활성 `super_admin`은 역할 강등뿐 아니라 상태 비활성화(`suspended` 등)로도
+  마지막 1명을 제거할 수 없다.
 - Web 조회 계약: `GET /rsvps/{member_id}/{event_id}`의 `rsvp_not_found` 404만 정상적인 미신청 상태로 변환합니다. 인증·서버·네트워크 오류는 미신청으로 숨기지 않고 복구 가능한 오류 화면으로 표시합니다.
 - 사용자 행동: 기본 행동은 참여 신청(`going`)과 참여 취소(`cancel`)이며, 정원 초과 시 `waitlist` 전환은 서버가 결정합니다.
 

--- a/docs/dev_log_260730.md
+++ b/docs/dev_log_260730.md
@@ -1,0 +1,15 @@
+# 2026-07-30 개발 로그
+
+## D1 인증·역할 authority (#246, #249, #265)
+
+- RSVP 목록·상세·생성·행사 상태 변경을 활성 회원 세션으로 보호했다.
+- 일반 회원 RSVP의 `member_id`를 현재 DB에서 재검증한 세션 ID로 강제하고,
+  타 회원 운영은 `admin_events` 전용 API로 분리했다.
+- `require_admin`, `require_super_admin`, `require_member`와 선택적 관리자 판정을
+  현재 회원 상태·역할 DB 재조회 기반으로 통일했다.
+- 마지막 활성 `super_admin` 판정을 정확한 역할 토큰 `COUNT`와 PostgreSQL
+  transaction advisory lock으로 직렬화해 동시 강등에서도 한 명을 보존했다.
+- RSVP 요청 계약에서 client-owned `member_id`를 제거하고 OpenAPI, TypeScript
+  DTO, Web 행사 참여 요청을 동기화했다.
+- 미인증 접근, 타인 ID 주입·조회, 목록 격리, 관리자 운영 권한, 역할 강등,
+  계정 정지·삭제, 정확한 역할 토큰, 동시 강등 회귀 테스트를 추가했다.

--- a/docs/dev_log_260731.md
+++ b/docs/dev_log_260731.md
@@ -1,0 +1,9 @@
+# Dev Log 2026-07-31
+
+## PR #275 P3 follow-up
+
+- Fixed: `POST /rsvps/` 생성 경로도 행사 정원(capacity) 초과 시 `waitlist`로 강제해 `/events/{id}/rsvp`와 동일 규칙 적용
+- Fixed: 활성 마지막 `super_admin`을 `status` 비활성화(`suspended` 등)로 제거하지 못하도록 관리자 회원 수정 경로에 가드 추가
+- Fixed: `count_active_members_with_role` LIKE 패턴에서 `_`/`%` 이스케이프해 역할 토큰 오탐 방지
+- Docs: `architecture.md`에 RSVP create 경로 정원 규칙·마지막 super_admin 상태 보호 반영
+- Tests: create 경로 waitlist, 마지막 SA 정지 거부/비마지막 정지 허용, LIKE 와일드카드 회귀 추가

--- a/packages/schemas/index.d.ts
+++ b/packages/schemas/index.d.ts
@@ -784,6 +784,30 @@ export interface paths {
         patch: operations["update_admin_event_admin_events__event_id__patch"];
         trace?: never;
     };
+    "/admin/events/{event_id}/rsvps/{member_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Member Rsvp
+         * @description 관리자 운영용 타 회원 RSVP 조회 경로.
+         */
+        get: operations["get_member_rsvp_admin_events__event_id__rsvps__member_id__get"];
+        put?: never;
+        /**
+         * Upsert Member Rsvp
+         * @description 관리자 운영용 타 회원 RSVP 생성·변경 경로.
+         */
+        post: operations["upsert_member_rsvp_admin_events__event_id__rsvps__member_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/hero/": {
         parameters: {
             query?: never;
@@ -1833,8 +1857,6 @@ export interface components {
         };
         /** RSVPCreate */
         RSVPCreate: {
-            /** Member Id */
-            member_id: number;
             /** Event Id */
             event_id: number;
             /**
@@ -1859,8 +1881,6 @@ export interface components {
         };
         /** RSVPStatusUpdate */
         RSVPStatusUpdate: {
-            /** Member Id */
-            member_id: number;
             /**
              * Status
              * @default going
@@ -3726,6 +3746,74 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EventRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_member_rsvp_admin_events__event_id__rsvps__member_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: number;
+                member_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RSVPRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upsert_member_rsvp_admin_events__event_id__rsvps__member_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: number;
+                member_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RSVPStatusUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RSVPRead"];
                 };
             };
             /** @description Validation Error */

--- a/packages/schemas/openapi.json
+++ b/packages/schemas/openapi.json
@@ -2607,6 +2607,118 @@
         }
       }
     },
+    "/admin/events/{event_id}/rsvps/{member_id}": {
+      "post": {
+        "tags": [
+          "admin-events"
+        ],
+        "summary": "Upsert Member Rsvp",
+        "description": "\uad00\ub9ac\uc790 \uc6b4\uc601\uc6a9 \ud0c0 \ud68c\uc6d0 RSVP \uc0dd\uc131\u00b7\ubcc0\uacbd \uacbd\ub85c.",
+        "operationId": "upsert_member_rsvp_admin_events__event_id__rsvps__member_id__post",
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          },
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Member Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RSVPStatusUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RSVPRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "admin-events"
+        ],
+        "summary": "Get Member Rsvp",
+        "description": "\uad00\ub9ac\uc790 \uc6b4\uc601\uc6a9 \ud0c0 \ud68c\uc6d0 RSVP \uc870\ud68c \uacbd\ub85c.",
+        "operationId": "get_member_rsvp_admin_events__event_id__rsvps__member_id__get",
+        "parameters": [
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Event Id"
+            }
+          },
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Member Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RSVPRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin/hero/": {
       "get": {
         "tags": [
@@ -6021,10 +6133,6 @@
       },
       "RSVPCreate": {
         "properties": {
-          "member_id": {
-            "type": "integer",
-            "title": "Member Id"
-          },
           "event_id": {
             "type": "integer",
             "title": "Event Id"
@@ -6042,7 +6150,6 @@
         },
         "type": "object",
         "required": [
-          "member_id",
           "event_id"
         ],
         "title": "RSVPCreate"
@@ -6077,10 +6184,6 @@
       },
       "RSVPStatusUpdate": {
         "properties": {
-          "member_id": {
-            "type": "integer",
-            "title": "Member Id"
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -6093,9 +6196,6 @@
           }
         },
         "type": "object",
-        "required": [
-          "member_id"
-        ],
         "title": "RSVPStatusUpdate"
       },
       "ScheduledLogRead": {

--- a/tests/api/test_admin_roles_api.py
+++ b/tests/api/test_admin_roles_api.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apps.api import models
+from apps.api import models, schemas
 from apps.api.db import get_db
 from apps.api.errors import ApiError
 from apps.api.main import app
@@ -257,5 +257,67 @@ def test_service_blocks_removing_last_super_admin(client: TestClient) -> None:
                 roles=["admin", "admin_roles"],
             )
         assert exc.value.code == "last_super_admin_forbidden"
+
+    _run_in_test_session(_run)
+
+
+def test_cannot_suspend_last_active_super_admin(client: TestClient) -> None:
+    _seed_member_identity(
+        student_id="solo-suspend",
+        password="solo-pass",
+        roles="super_admin,admin,member",
+    )
+    solo_id = _member_id_by_student_id("solo-suspend")
+
+    async def _run(session: AsyncSession) -> None:
+        others = (
+            await session.execute(
+                select(models.Member).where(models.Member.id != solo_id)
+            )
+        ).scalars().all()
+        for other in others:
+            tokens = [
+                token
+                for token in str(other.roles).split(",")
+                if token and token != "super_admin"
+            ]
+            setattr(other, "roles", ",".join(tokens) or "member")
+        await session.commit()
+
+        with pytest.raises(ApiError) as exc:
+            await members_service.update_member_profile_admin(
+                session,
+                member_id=solo_id,
+                data=schemas.AdminMemberUpdate(status="suspended"),
+            )
+        assert exc.value.code == "last_super_admin_forbidden"
+
+        member = await session.get(models.Member, solo_id)
+        assert member is not None
+        assert str(member.status) == "active"
+
+    _run_in_test_session(_run)
+
+
+def test_can_suspend_non_last_super_admin(client: TestClient) -> None:
+    _seed_member_identity(
+        student_id="pair-suspend-a",
+        password="solo-pass",
+        roles="super_admin,admin,member",
+    )
+    _seed_member_identity(
+        student_id="pair-suspend-b",
+        password="solo-pass",
+        roles="super_admin,admin,member",
+    )
+    target_id = _member_id_by_student_id("pair-suspend-a")
+
+    async def _run(session: AsyncSession) -> None:
+        updated = await members_service.update_member_profile_admin(
+            session,
+            member_id=target_id,
+            data=schemas.AdminMemberUpdate(status="suspended"),
+        )
+        assert str(updated.status) == "suspended"
 
     _run_in_test_session(_run)

--- a/tests/api/test_d1_auth_role_authority.py
+++ b/tests/api/test_d1_auth_role_authority.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import bcrypt
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api import models
+from apps.api.db import get_db
+from apps.api.errors import ApiError
+from apps.api.main import app
+from apps.api.repositories import members as members_repo
+from apps.api.services import members_service
+
+
+def _run_in_test_session(
+    operation: Callable[[AsyncSession], Awaitable[None]],
+) -> None:
+    override = app.dependency_overrides.get(get_db)
+    if override is None:
+        raise RuntimeError("get_db override not found")
+
+    async def _run() -> None:
+        async for session in override():
+            await operation(session)
+            return
+        raise RuntimeError("test session was not yielded")
+
+    asyncio.run(_run())
+
+
+def _seed_member(
+    *,
+    student_id: str,
+    password: str = "test-pass",
+    roles: str = "member",
+    status: str = "active",
+) -> int:
+    holder = {"member_id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        member = models.Member(
+            student_id=student_id,
+            email=f"{student_id}@example.com",
+            name=student_id,
+            cohort=1,
+            roles=roles,
+            status=status,
+        )
+        session.add(member)
+        await session.flush()
+        session.add(
+            models.MemberAuth(
+                member_id=member.id,
+                student_id=student_id,
+                password_hash=bcrypt.hashpw(
+                    password.encode(), bcrypt.gensalt()
+                ).decode(),
+            )
+        )
+        await session.commit()
+        holder["member_id"] = int(member.id)
+
+    _run_in_test_session(_seed)
+    return holder["member_id"]
+
+
+def _seed_event(*, title: str) -> int:
+    holder = {"event_id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts_at = datetime.now(tz=UTC) + timedelta(days=30)
+        event = models.Event(
+            title=title,
+            starts_at=starts_at,
+            ends_at=starts_at + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        holder["event_id"] = int(event.id)
+
+    _run_in_test_session(_seed)
+    return holder["event_id"]
+
+
+def _login(client: TestClient, *, student_id: str, password: str = "test-pass") -> None:
+    response = client.post(
+        "/auth/login",
+        json={"student_id": student_id, "password": password},
+    )
+    assert response.status_code == HTTPStatus.OK
+
+
+def _update_member(
+    student_id: str,
+    *,
+    roles: str | None = None,
+    status: str | None = None,
+) -> None:
+    async def _update(session: AsyncSession) -> None:
+        result = await session.execute(
+            select(models.Member).where(models.Member.student_id == student_id)
+        )
+        member = result.scalar_one()
+        if roles is not None:
+            setattr(member, "roles", roles)
+        if status is not None:
+            setattr(member, "status", status)
+        await session.commit()
+
+    _run_in_test_session(_update)
+
+
+def test_rsvp_routes_require_authentication(client: TestClient) -> None:
+    requests = (
+        client.get("/rsvps/"),
+        client.get("/rsvps/1/1"),
+        client.post(
+            "/rsvps/",
+            json={"member_id": 1, "event_id": 1, "status": "going"},
+        ),
+        client.post(
+            "/events/1/rsvp",
+            json={"member_id": 1, "status": "going"},
+        ),
+    )
+
+    assert [response.status_code for response in requests] == [
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED,
+    ]
+
+
+def test_rsvp_member_id_is_server_owned(client: TestClient) -> None:
+    actor_id = _seed_member(student_id="rsvp-actor")
+    victim_id = _seed_member(student_id="rsvp-victim")
+    event_id = _seed_event(title="RSVP actor authority")
+    direct_event_id = _seed_event(title="Direct RSVP actor authority")
+    victim_event_id = _seed_event(title="Victim RSVP isolation")
+    _login(client, student_id="rsvp-actor")
+
+    event_response = client.post(
+        f"/events/{event_id}/rsvp",
+        json={"member_id": victim_id, "status": "going"},
+    )
+    assert event_response.status_code == HTTPStatus.CREATED
+    assert event_response.json()["member_id"] == actor_id
+
+    forbidden = client.get(f"/rsvps/{victim_id}/{event_id}")
+    assert forbidden.status_code == HTTPStatus.FORBIDDEN
+
+    own = client.get(f"/rsvps/{actor_id}/{event_id}")
+    assert own.status_code == HTTPStatus.OK
+
+    direct_response = client.post(
+        "/rsvps/",
+        json={
+            "member_id": victim_id,
+            "event_id": direct_event_id,
+            "status": "going",
+        },
+    )
+    assert direct_response.status_code == HTTPStatus.CREATED
+    assert direct_response.json()["member_id"] == actor_id
+
+    admin_path = client.post(
+        f"/admin/events/{event_id}/rsvps/{victim_id}",
+        json={"status": "going"},
+    )
+    assert admin_path.status_code == HTTPStatus.FORBIDDEN
+
+    client.post("/auth/logout")
+    _login(client, student_id="rsvp-victim")
+    victim_response = client.post(
+        f"/events/{victim_event_id}/rsvp",
+        json={"status": "going"},
+    )
+    assert victim_response.status_code == HTTPStatus.CREATED
+    client.post("/auth/logout")
+    _login(client, student_id="rsvp-actor")
+
+    listed = client.get("/rsvps/")
+    assert listed.status_code == HTTPStatus.OK
+    assert {row["member_id"] for row in listed.json()} == {actor_id}
+
+
+def test_existing_session_uses_current_roles_and_status(client: TestClient) -> None:
+    member_id = _seed_member(
+        student_id="stale-admin",
+        roles="super_admin,admin,member,admin_roles",
+    )
+    _seed_member(student_id="role-target")
+    _login(client, student_id="stale-admin")
+
+    _update_member("stale-admin", roles="member")
+    demoted = client.patch(
+        f"/admin/members/{member_id}/roles",
+        json={"roles": ["member"]},
+    )
+    assert demoted.status_code == HTTPStatus.FORBIDDEN
+    assert demoted.json()["detail"] == "super_admin_required"
+
+    event_write = client.post(
+        "/events/",
+        json={
+            "title": "stale role must not write",
+            "starts_at": "2030-01-01T09:00:00Z",
+            "ends_at": "2030-01-01T10:00:00Z",
+            "location": "Seoul",
+            "capacity": 10,
+        },
+    )
+    assert event_write.status_code == HTTPStatus.FORBIDDEN
+
+    _update_member("stale-admin", status="suspended")
+    suspended = client.get("/members/?limit=1")
+    assert suspended.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_existing_session_is_invalid_after_member_deletion(client: TestClient) -> None:
+    _seed_member(student_id="deleted-session")
+    _login(client, student_id="deleted-session")
+
+    async def _delete(session: AsyncSession) -> None:
+        result = await session.execute(
+            select(models.Member).where(
+                models.Member.student_id == "deleted-session"
+            )
+        )
+        member = result.scalar_one()
+        await session.delete(member)
+        await session.commit()
+
+    _run_in_test_session(_delete)
+
+    response = client.get("/members/?limit=1")
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_super_admin_count_uses_exact_active_role_tokens(client: TestClient) -> None:
+    _seed_member(student_id="exact-super", roles="member,super_admin")
+    _seed_member(student_id="substring-super", roles="member,super_admin_helper")
+    _seed_member(
+        student_id="suspended-super",
+        roles="member,super_admin",
+        status="suspended",
+    )
+    holder = {"count": 0}
+
+    async def _count(session: AsyncSession) -> None:
+        holder["count"] = await members_repo.count_active_members_with_role(
+            session,
+            role="super_admin",
+        )
+
+    _run_in_test_session(_count)
+    assert holder["count"] == 1
+
+
+def test_concurrent_demotions_preserve_one_super_admin(client: TestClient) -> None:
+    first_id = _seed_member(
+        student_id="concurrent-super-1",
+        roles="member,admin,super_admin",
+    )
+    second_id = _seed_member(
+        student_id="concurrent-super-2",
+        roles="member,admin,super_admin",
+    )
+    _seed_member(student_id="concurrent-actor")
+    override = app.dependency_overrides.get(get_db)
+    if override is None:
+        raise RuntimeError("get_db override not found")
+
+    async def _demote(member_id: int) -> str:
+        async for session in override():
+            try:
+                await members_service.update_member_roles(
+                    session,
+                    member_id=member_id,
+                    actor_student_id="concurrent-actor",
+                    roles=["member", "admin"],
+                )
+            except ApiError as exc:
+                return exc.code
+            return "updated"
+        raise RuntimeError("test session was not yielded")
+
+    async def _run_demotions() -> list[str]:
+        return list(await asyncio.gather(_demote(first_id), _demote(second_id)))
+
+    outcomes = asyncio.run(_run_demotions())
+
+    assert sorted(outcomes) == ["last_super_admin_forbidden", "updated"]
+
+    holder = {"count": 0}
+
+    async def _count(session: AsyncSession) -> None:
+        holder["count"] = await members_repo.count_active_members_with_role(
+            session,
+            role="super_admin",
+        )
+
+    _run_in_test_session(_count)
+    assert holder["count"] == 1

--- a/tests/api/test_d1_auth_role_authority.py
+++ b/tests/api/test_d1_auth_role_authority.py
@@ -249,6 +249,7 @@ def test_existing_session_is_invalid_after_member_deletion(client: TestClient) -
 def test_super_admin_count_uses_exact_active_role_tokens(client: TestClient) -> None:
     _seed_member(student_id="exact-super", roles="member,super_admin")
     _seed_member(student_id="substring-super", roles="member,super_admin_helper")
+    _seed_member(student_id="wildcard-super", roles="member,superXadmin")
     _seed_member(
         student_id="suspended-super",
         roles="member,super_admin",

--- a/tests/api/test_directory.py
+++ b/tests/api/test_directory.py
@@ -246,24 +246,27 @@ def test_directory_routes_do_not_preread_viewer(
         return await original_execute(session, *args, **kwargs)
 
     monkeypatch.setattr(AsyncSession, "execute", _counting_execute)
+    # 요청마다 현재 계정 상태·역할을 확인하는 인증 쿼리 1개와, viewer
+    # scope를 scalar subquery로 포함한 디렉터리 본 쿼리 1개만 허용한다.
+    expected_queries_with_auth_refresh = 2
 
     before = query_count
     listing = admin_login.get("/members/?q=__seed__admin")
     assert listing.status_code == HTTPStatus.OK
     assert [row["id"] for row in listing.json()] == [viewer_id]
-    assert query_count - before == 1
+    assert query_count - before == expected_queries_with_auth_refresh
 
     before = query_count
     count = admin_login.get("/members/count?q=__seed__admin")
     assert count.status_code == HTTPStatus.OK
     assert count.json() == {"count": 1}
-    assert query_count - before == 1
+    assert query_count - before == expected_queries_with_auth_refresh
 
     before = query_count
     detail = admin_login.get(f"/members/{viewer_id}")
     assert detail.status_code == HTTPStatus.OK
     assert detail.json()["id"] == viewer_id
-    assert query_count - before == 1
+    assert query_count - before == expected_queries_with_auth_refresh
 
 
 def test_directory_scope_uses_latest_viewer_cohort(

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -132,14 +132,7 @@ def test_event_not_found_returns_problem_details(client: TestClient) -> None:
 
 def test_rsvp_not_found_returns_problem_details(admin_login: TestClient) -> None:
     client = admin_login
-    # 선행: 회원/이벤트 생성
-    m = _create_member(
-        client,
-        student_id="rsvp001",
-        email="rsvp@example.com",
-        name="RSVP",
-        cohort=2025,
-    )
+    # 선행: 이벤트 생성
     e = client.post(
         "/events/",
         json={
@@ -151,7 +144,8 @@ def test_rsvp_not_found_returns_problem_details(admin_login: TestClient) -> None
         },
     ).json()
 
-    res = client.get(f"/rsvps/{m['id']}/{e['id']}")
+    current_member_id = client.get("/auth/session").json()["id"]
+    res = client.get(f"/rsvps/{current_member_id}/{e['id']}")
     assert res.status_code == HTTPStatus.NOT_FOUND
     data = res.json()
     assert data["status"] == HTTPStatus.NOT_FOUND
@@ -160,14 +154,7 @@ def test_rsvp_not_found_returns_problem_details(admin_login: TestClient) -> None
 
 def test_rsvp_create_conflict_code(admin_login: TestClient) -> None:
     client = admin_login
-    # 선행: 회원/이벤트 생성
-    m = _create_member(
-        client,
-        student_id="dup001",
-        email="dup@example.com",
-        name="Dup",
-        cohort=2025,
-    )
+    # 선행: 이벤트 생성
     e = client.post(
         "/events/",
         json={
@@ -179,7 +166,7 @@ def test_rsvp_create_conflict_code(admin_login: TestClient) -> None:
         },
     ).json()
 
-    payload = {"member_id": m["id"], "event_id": e["id"], "status": "going"}
+    payload = {"event_id": e["id"], "status": "going"}
     res1 = client.post("/rsvps/", json=payload)
     assert res1.status_code == HTTPStatus.CREATED
 
@@ -192,14 +179,7 @@ def test_rsvp_create_conflict_code(admin_login: TestClient) -> None:
 
 def test_events_rsvp_upsert_create_and_update(admin_login: TestClient) -> None:
     client = admin_login
-    # 선행: 회원/이벤트 생성
-    m = _create_member(
-        client,
-        student_id="upsert001",
-        email="upsert@example.com",
-        name="Up Ser",
-        cohort=2025,
-    )
+    # 선행: 이벤트 생성
     e = client.post(
         "/events/",
         json={
@@ -213,14 +193,14 @@ def test_events_rsvp_upsert_create_and_update(admin_login: TestClient) -> None:
 
     # 생성(create)
     res_create = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m["id"], "status": "going"}
+        f"/events/{e['id']}/rsvp", json={"status": "going"}
     )
     assert res_create.status_code == HTTPStatus.CREATED
     assert res_create.json()["status"] == "going"
 
     # 갱신(update)
     res_update = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m["id"], "status": "waitlist"}
+        f"/events/{e['id']}/rsvp", json={"status": "waitlist"}
     )
     assert res_update.status_code == HTTPStatus.CREATED  # 라우터가 201로 고정 반환
     assert res_update.json()["status"] == "waitlist"
@@ -228,14 +208,7 @@ def test_events_rsvp_upsert_create_and_update(admin_login: TestClient) -> None:
 
 def test_events_rsvp_invalid_enum_422(admin_login: TestClient) -> None:
     client = admin_login
-    # 선행: 회원/이벤트 생성
-    m = _create_member(
-        client,
-        student_id="enum001",
-        email="enum@example.com",
-        name="Enum",
-        cohort=2025,
-    )
+    # 선행: 이벤트 생성
     e = client.post(
         "/events/",
         json={
@@ -248,6 +221,6 @@ def test_events_rsvp_invalid_enum_422(admin_login: TestClient) -> None:
     ).json()
 
     res = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m["id"], "status": "invalid"}
+        f"/events/{e['id']}/rsvp", json={"status": "invalid"}
     )
     assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/api/test_events_admin.py
+++ b/tests/api/test_events_admin.py
@@ -157,22 +157,22 @@ class TestAdminEventList:
 
         assert (
             admin_login.post(
-                f"/events/{e_id}/rsvp",
-                json={"member_id": m1["id"], "status": "going"},
+                f"/admin/events/{e_id}/rsvps/{m1['id']}",
+                json={"status": "going"},
             ).status_code
             == HTTPStatus.CREATED
         )
         assert (
             admin_login.post(
-                f"/events/{e_id}/rsvp",
-                json={"member_id": m2["id"], "status": "waitlist"},
+                f"/admin/events/{e_id}/rsvps/{m2['id']}",
+                json={"status": "waitlist"},
             ).status_code
             == HTTPStatus.CREATED
         )
         assert (
             admin_login.post(
-                f"/events/{e_id}/rsvp",
-                json={"member_id": m3["id"], "status": "cancel"},
+                f"/admin/events/{e_id}/rsvps/{m3['id']}",
+                json={"status": "cancel"},
             ).status_code
             == HTTPStatus.CREATED
         )

--- a/tests/api/test_success.py
+++ b/tests/api/test_success.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from http import HTTPStatus
 
+import bcrypt
 from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from apps.api import models
+from apps.api.db import get_db
+from apps.api.main import app
 
 
 def _create_member(
@@ -108,6 +115,65 @@ def test_rsvp_capacity_v1_enforces_waitlist(admin_login: TestClient) -> None:
     )
     assert r2.status_code == HTTPStatus.CREATED
     assert r2.json()["status"] == "waitlist"
+
+
+def test_rsvp_create_path_enforces_waitlist_capacity(admin_login: TestClient) -> None:
+    client = admin_login
+    e = client.post(
+        "/events/",
+        json={
+            "title": "Cap1-CreatePath",
+            "starts_at": "2030-04-02T09:00:00Z",
+            "ends_at": "2030-04-02T10:00:00Z",
+            "location": "Seoul",
+            "capacity": 1,
+        },
+    ).json()
+    first = client.post("/rsvps/", json={"event_id": e["id"], "status": "going"})
+    assert first.status_code == HTTPStatus.CREATED
+    assert first.json()["status"] == "going"
+
+    m2 = _create_member(
+        client,
+        student_id="m1003",
+        email="c@example.com",
+        name="C",
+        cohort=2025,
+    )
+    override = app.dependency_overrides.get(get_db)
+    assert override is not None
+
+    async def _activate_second() -> None:
+        async for session in override():
+            member = (
+                await session.execute(
+                    select(models.Member).where(models.Member.student_id == "m1003")
+                )
+            ).scalar_one()
+            setattr(member, "status", "active")
+            session.add(
+                models.MemberAuth(
+                    member_id=member.id,
+                    student_id="m1003",
+                    password_hash=bcrypt.hashpw(
+                        b"pass-1003", bcrypt.gensalt()
+                    ).decode(),
+                )
+            )
+            await session.commit()
+            return
+        raise RuntimeError("test session was not yielded")
+
+    asyncio.run(_activate_second())
+    client.post("/auth/logout")
+    login = client.post(
+        "/auth/login", json={"student_id": "m1003", "password": "pass-1003"}
+    )
+    assert login.status_code == HTTPStatus.OK
+    second = client.post("/rsvps/", json={"event_id": e["id"], "status": "going"})
+    assert second.status_code == HTTPStatus.CREATED
+    assert second.json()["status"] == "waitlist"
+    assert second.json()["member_id"] == m2["id"]
 
 
 def test_rsvp_going_reassertion_keeps_status(admin_login: TestClient) -> None:

--- a/tests/api/test_success.py
+++ b/tests/api/test_success.py
@@ -98,13 +98,13 @@ def test_rsvp_capacity_v1_enforces_waitlist(admin_login: TestClient) -> None:
     )
 
     r1 = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m1['id']}", json={"status": "going"}
     )
     assert r1.status_code == HTTPStatus.CREATED
     assert r1.json()["status"] == "going"
 
     r2 = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m2["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m2['id']}", json={"status": "going"}
     )
     assert r2.status_code == HTTPStatus.CREATED
     assert r2.json()["status"] == "waitlist"
@@ -132,14 +132,14 @@ def test_rsvp_going_reassertion_keeps_status(admin_login: TestClient) -> None:
     )
 
     r1 = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m1['id']}", json={"status": "going"}
     )
     assert r1.status_code == HTTPStatus.CREATED
     assert r1.json()["status"] == "going"
 
     # 동일 회원이 다시 going 요청
     r_again = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m1['id']}", json={"status": "going"}
     )
     assert r_again.status_code == HTTPStatus.CREATED
     assert r_again.json()["status"] == "going"
@@ -154,13 +154,6 @@ def test_list_endpoints_ok(member_login: TestClient) -> None:
 
 def test_rsvp_create_success(admin_login: TestClient) -> None:
     client = admin_login
-    m = _create_member(
-        client,
-        student_id="c001",
-        email="c@example.com",
-        name="C",
-        cohort=2025,
-    )
     e = client.post(
         "/events/",
         json={
@@ -173,7 +166,7 @@ def test_rsvp_create_success(admin_login: TestClient) -> None:
     ).json()
     res = client.post(
         "/rsvps/",
-        json={"member_id": m["id"], "event_id": e["id"], "status": "going"},
+        json={"event_id": e["id"], "status": "going"},
     )
     assert res.status_code == HTTPStatus.CREATED
 
@@ -207,19 +200,19 @@ def test_rsvp_waitlist_promoted_on_cancel(admin_login: TestClient) -> None:
     ).json()
 
     r1 = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m1['id']}", json={"status": "going"}
     )
     assert r1.status_code == HTTPStatus.CREATED
     r2 = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m2["id"], "status": "going"}
+        f"/admin/events/{e['id']}/rsvps/{m2['id']}", json={"status": "going"}
     )
     assert r2.status_code == HTTPStatus.CREATED and r2.json()["status"] == "waitlist"
 
     # m1 cancel → m2 going 승급
     rc = client.post(
-        f"/events/{e['id']}/rsvp", json={"member_id": m1["id"], "status": "cancel"}
+        f"/admin/events/{e['id']}/rsvps/{m1['id']}", json={"status": "cancel"}
     )
     assert rc.status_code == HTTPStatus.CREATED
-    promoted = client.get(f"/rsvps/{m2['id']}/{e['id']}")
+    promoted = client.get(f"/admin/events/{e['id']}/rsvps/{m2['id']}")
     assert promoted.status_code == HTTPStatus.OK
     assert promoted.json()["status"] == "going"


### PR DESCRIPTION
## 결과

D1 인증·역할 authority bundle을 구현한다. 일반 회원은 본인 RSVP만 조회·변경할 수 있고, 세션에 저장된 과거 역할로 보호 경로를 계속 사용하는 문제를 차단한다. 마지막 super_admin 판정도 전체 ORM 로딩과 동시 강등 경쟁을 제거한다.

## 근본 원인

- `/rsvps`와 `/events/{event_id}/rsvp`가 인증 actor 없이 client-owned `member_id`를 신뢰했다.
- `require_admin`, `require_super_admin`, `require_member`, 선택적 관리자 판정이 최대 7일간 세션의 역할을 그대로 사용했다.
- 마지막 활성 super_admin 검사가 모든 Member 객체를 로드한 뒤 `len()`으로 판단했고 동시 강등을 직렬화하지 않았다.

## 변경 내용

- 모든 일반 RSVP 경로에 활성 회원 인증을 적용하고 owner를 현재 DB에서 재검증한 세션 회원 ID로 강제
- 일반 RSVP 목록은 본인 행만 반환하고 타인 상세는 403으로 거부
- 타 회원 RSVP 조회·변경을 `admin_events` 전용 `/admin/events/{event_id}/rsvps/{member_id}` 경로로 분리
- 모든 주요 인증·권한 dependency와 optional admin 판정을 현재 `Member.status`·`roles` DB readback 기반으로 통일
- 삭제·정지 계정 세션을 401로 무효화하고 역할 회수는 기존 세션에 즉시 반영
- 마지막 super_admin 판정을 정확한 역할 토큰 COUNT와 PostgreSQL transaction advisory lock으로 직렬화
- RSVP request DTO에서 `member_id`를 제거하고 OpenAPI, TypeScript DTO, Web 요청을 동기화
- 인증·RSVP 운영 계약과 개발 로그 갱신

## 사용자·운영 영향

- 회원의 기존 본인 행사 신청·취소·조회 흐름은 유지된다.
- client가 타 회원 ID를 보내도 그 회원 명의 RSVP가 생성되지 않는다.
- 관리자 강등과 회원 정지·삭제가 재로그인 대기 없이 즉시 적용된다.
- 사무국의 타 회원 RSVP 운영은 명시적인 관리자 API에서 계속 가능하다.

## 검증

Head: `a391a5670f81d193a57445cfbbd1806272d4e7df`

- `.venv/bin/pytest -q` — 209 passed
- D1 회귀 테스트 — 6 passed; 구현 전 3 failures로 원 취약 경로 재현
- `.venv/bin/ruff check apps/api tests/api` — PASS
- `.venv/bin/python -m pyright --project pyrightconfig.json` — 0 errors, 기존 warning 2건
- `pnpm -C apps/web test` — 239 passed
- RSVP Web 전송 계약 집중 테스트 — 8 passed
- `pnpm -C apps/web lint` — PASS
- `pnpm -C apps/web build` — PASS
- repository guards, version lock, Git hook 통합 테스트 — PASS
- OpenAPI/DTO 재생성 후 SHA-256 동일 — deterministic
- 동시 두 super_admin 강등을 독립 DB 세션으로 실행해 하나만 성공하고 마지막 한 명이 남는 것을 확인

## 테스트 영향

동문 수첩 테스트가 요청당 SQL 1회를 절대값으로 강제해 필수 세션 재검증 쿼리를 막고 있었다. 이는 `TEST DRIFT`로 판정하고, 인증 readback 1회 + viewer scope를 포함한 본 쿼리 1회만 허용하도록 수정했다. 별도 viewer 사전 조회는 여전히 금지된다.

## Ready 전 남은 검증

- [ ] 실제 브라우저에서 로그인 → 행사 상세 → 본인 신청 → 상태 조회 → 취소 흐름 확인
- [ ] 관리자 강등/회원 정지 후 기존 브라우저 세션의 접근 거부 확인
- [ ] GitHub CI required checks 확인

Closes #246
Closes #249
Closes #265