### PR TITLE
fix(api): 프록시·운영 설정 신뢰 경계 (D2)

### DIFF
--- a/.env.api.example
+++ b/.env.api.example
@@ -29,9 +29,11 @@ DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
 # 도메인 예시: sogangeconomics.com
 CORS_ORIGINS=["https://sogangeconomics.com","https://www.sogangeconomics.com"]
 
-# 4) 세션/JWT(staging/prod에서는 32자 이상·placeholder 금지)
+# 4) 세션/JWT
+# staging/prod: 32자 이상, change-me*/replace_me*/replace-me*/빈 값 금지(기동 실패).
 # 예: openssl rand -base64 48
-JWT_SECRET=REPLACE_ME_WITH_OPENSSL_RAND_BASE64_32B_MIN
+# 아래는 의도적으로 비워 둠 — 복사 후 반드시 실제 시크릿으로 채울 것.
+JWT_SECRET=
 
 # 5) 레이트리밋(기본값 OK; 필요 시만 조정)
 RATE_LIMIT_DEFAULT=120/minute

--- a/.env.api.example
+++ b/.env.api.example
@@ -3,9 +3,13 @@
 # - 레포에 커밋하지 마세요(.gitignore 규칙 적용). Docker 빌드 컨텍스트에도 포함되지 않습니다.
 
 # 1) 런타임/환경
+# 허용값: dev | test | staging | prod (그 외는 기동 실패)
 APP_ENV=prod
 # 배포 버전 태그(옵션; CI/스크립트에서 주입하는 값을 우선 사용)
 # RELEASE=
+# Nginx→API hop(또는 docker 네트워크 CIDR). Uvicorn --forwarded-allow-ips와 동일 목록.
+# 비어 있으면 127.0.0.1만 허용. '*' 금지.
+TRUSTED_PROXY_IPS=
 
 # 1-1) 관리자 bootstrap 시드(선택)
 # - 배포 시 `ops/cloud-seed-admin.sh` 또는 deploy workflow `seed_admin=true`로 실행할 때 사용
@@ -25,8 +29,9 @@ DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5432/appdb
 # 도메인 예시: sogangeconomics.com
 CORS_ORIGINS=["https://sogangeconomics.com","https://www.sogangeconomics.com"]
 
-# 4) 세션/JWT(운영에서는 32자 이상 강력한 시크릿 필수)
-JWT_SECRET=change-me-to-a-strong-secret
+# 4) 세션/JWT(staging/prod에서는 32자 이상·placeholder 금지)
+# 예: openssl rand -base64 48
+JWT_SECRET=REPLACE_ME_WITH_OPENSSL_RAND_BASE64_32B_MIN
 
 # 5) 레이트리밋(기본값 OK; 필요 시만 조정)
 RATE_LIMIT_DEFAULT=120/minute
@@ -54,6 +59,9 @@ MEDIA_URL_BASE=/media
 AVATAR_MAX_BYTES=100000
 AVATAR_MAX_UPLOAD_BYTES=2000000
 AVATAR_MAX_PIXELS=512
+# 게시글 커버 등 일반 이미지 업로드 한도
+IMAGE_MAX_UPLOAD_BYTES=5000000
+IMAGE_MAX_PIXELS=1920
 
 # 8) 관측/로그(Sentry — 선택)
 SENTRY_DSN=

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -106,10 +106,21 @@ class Settings(BaseSettings):
     def _normalize_jwt_secret(cls, v: str) -> str:
         return (v or "").strip()
 
+    @field_validator("app_env")
+    @classmethod
+    def _validate_app_env(cls, v: str) -> str:
+        allowed = {"dev", "test", "staging", "prod"}
+        vv = (v or "dev").lower().strip() or "dev"
+        if vv not in allowed:
+            raise ValueError(
+                "APP_ENV must be one of: " + ", ".join(sorted(allowed))
+            )
+        return vv
+
     @model_validator(mode="after")
-    def _validate_prod_only(self) -> "Settings":
-        # Enforce strong JWT secret only in prod deployments.
-        if (self.app_env or "dev").lower().strip() == "prod":
+    def _validate_production_like_jwt(self) -> "Settings":
+        # staging/prod는 약한 JWT_SECRET을 거부한다 (fail-closed).
+        if self.app_env in {"staging", "prod"}:
             MIN_LEN = 32
             if (
                 self.jwt_secret in {"change-me", "change-me-to-a-strong-secret", ""}
@@ -117,7 +128,8 @@ class Settings(BaseSettings):
             ):
                 msg = (
                     "JWT_SECRET must be strong ("
-                    f"{MIN_LEN}+ chars) and not a placeholder"
+                    f"{MIN_LEN}+ chars) and not a placeholder "
+                    f"when APP_ENV={self.app_env}"
                 )
                 raise ValueError(msg)
         return self

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -1,7 +1,30 @@
 from functools import lru_cache
+from ipaddress import ip_address, ip_network
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_APP_ENV_ALLOWED = frozenset({"dev", "test", "staging", "prod"})
+_JWT_MIN_LEN = 32
+# staging/prod 이미지 업로드 한도 상한 (오타로 보호 해제 방지)
+_IMAGE_MAX_UPLOAD_BYTES_CAP = 50_000_000  # 50MB
+_IMAGE_MAX_PIXELS_CAP = 10_000
+
+
+def is_jwt_placeholder(secret: str) -> bool:
+    """공개·문서용 placeholder JWT인지 판별.
+
+    change-me* / replace_me* / replace-me* 접두와 빈 값을 포함한다.
+    """
+    s = (secret or "").strip()
+    if not s:
+        return True
+    lower = s.lower()
+    return (
+        lower.startswith("change-me")
+        or lower.startswith("replace_me")
+        or lower.startswith("replace-me")
+    )
 
 
 class Settings(BaseSettings):
@@ -108,30 +131,76 @@ class Settings(BaseSettings):
 
     @field_validator("app_env")
     @classmethod
-    def _validate_app_env(cls, v: str) -> str:
-        allowed = {"dev", "test", "staging", "prod"}
-        vv = (v or "dev").lower().strip() or "dev"
-        if vv not in allowed:
+    def _validate_app_env(cls, v: object) -> str:
+        # 필드 미지정은 Field default("dev")가 들어온다.
+        # APP_ENV= 또는 공백만 넣은 경우는 명시적 오설정으로 거부한다.
+        if not isinstance(v, str) or not v.strip():
             raise ValueError(
-                "APP_ENV must be one of: " + ", ".join(sorted(allowed))
+                "APP_ENV must be one of: "
+                + ", ".join(sorted(_APP_ENV_ALLOWED))
+                + " (empty not allowed)"
+            )
+        vv = v.lower().strip()
+        if vv not in _APP_ENV_ALLOWED:
+            raise ValueError(
+                "APP_ENV must be one of: " + ", ".join(sorted(_APP_ENV_ALLOWED))
             )
         return vv
 
+    @field_validator("trusted_proxy_ips")
+    @classmethod
+    def _validate_trusted_proxy_ips(cls, v: str) -> str:
+        # 잘못된 IP/CIDR·'*'는 조용히 버리지 않고 기동 실패(fail-closed).
+        raw = v or ""
+        for part in raw.split(","):
+            ip_str = part.strip()
+            if not ip_str:
+                continue
+            if ip_str == "*":
+                raise ValueError("TRUSTED_PROXY_IPS must not contain '*'")
+            try:
+                if "/" in ip_str:
+                    ip_network(ip_str, strict=False)
+                else:
+                    ip_address(ip_str)
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid TRUSTED_PROXY_IPS entry: {ip_str}"
+                ) from exc
+        return raw
+
     @model_validator(mode="after")
     def _validate_production_like_jwt(self) -> "Settings":
-        # staging/prod는 약한 JWT_SECRET을 거부한다 (fail-closed).
+        # staging/prod는 약한·placeholder JWT_SECRET을 거부한다 (fail-closed).
         if self.app_env in {"staging", "prod"}:
-            MIN_LEN = 32
-            if (
-                self.jwt_secret in {"change-me", "change-me-to-a-strong-secret", ""}
-                or len(self.jwt_secret) < MIN_LEN
-            ):
+            weak = is_jwt_placeholder(self.jwt_secret)
+            if weak or len(self.jwt_secret) < _JWT_MIN_LEN:
                 msg = (
                     "JWT_SECRET must be strong ("
-                    f"{MIN_LEN}+ chars) and not a placeholder "
+                    f"{_JWT_MIN_LEN}+ chars) and not a placeholder "
+                    f"(change-me*/replace_me*/replace-me*/empty) "
                     f"when APP_ENV={self.app_env}"
                 )
                 raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_image_limits(self) -> "Settings":
+        if self.image_max_upload_bytes <= 0 or self.image_max_pixels <= 0:
+            raise ValueError(
+                "IMAGE_MAX_UPLOAD_BYTES and IMAGE_MAX_PIXELS must be positive"
+            )
+        if self.app_env in {"staging", "prod"}:
+            if self.image_max_upload_bytes > _IMAGE_MAX_UPLOAD_BYTES_CAP:
+                raise ValueError(
+                    "IMAGE_MAX_UPLOAD_BYTES exceeds cap "
+                    f"({_IMAGE_MAX_UPLOAD_BYTES_CAP}) when APP_ENV={self.app_env}"
+                )
+            if self.image_max_pixels > _IMAGE_MAX_PIXELS_CAP:
+                raise ValueError(
+                    "IMAGE_MAX_PIXELS exceeds cap "
+                    f"({_IMAGE_MAX_PIXELS_CAP}) when APP_ENV={self.app_env}"
+                )
         return self
 
     @model_validator(mode="after")

--- a/apps/api/ratelimit.py
+++ b/apps/api/ratelimit.py
@@ -10,8 +10,13 @@ from slowapi import Limiter
 from .config import Settings, get_settings
 
 
-def parse_trusted_proxies(raw: str) -> list[str]:
-    """신뢰할 프록시 IP/CIDR 목록 파싱."""
+def parse_trusted_proxies(raw: str, *, strict: bool = False) -> list[str]:
+    """신뢰할 프록시 IP/CIDR 목록 파싱.
+
+    strict=True이면 잘못된 항목·'*'에서 ValueError를 일으킨다.
+    strict=False(기본)는 잘못된 항목을 건너뛴다(하위 호환·부분 파싱).
+    Settings 기동 검증은 config 쪽에서 fail-closed로 수행한다.
+    """
     if not raw:
         return []
     result: list[str] = []
@@ -19,14 +24,21 @@ def parse_trusted_proxies(raw: str) -> list[str]:
         ip_str = part.strip()
         if not ip_str:
             continue
+        if ip_str == "*":
+            if strict:
+                raise ValueError("TRUSTED_PROXY_IPS must not contain '*'")
+            continue
         try:
             if "/" in ip_str:
                 ip_network(ip_str, strict=False)
             else:
                 ip_address(ip_str)
             result.append(ip_str)
-        except ValueError:
-            pass
+        except ValueError as exc:
+            if strict:
+                raise ValueError(
+                    f"invalid TRUSTED_PROXY_IPS entry: {ip_str}"
+                ) from exc
     return result
 
 

--- a/apps/api/ratelimit.py
+++ b/apps/api/ratelimit.py
@@ -1,13 +1,105 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from ipaddress import ip_address, ip_network
 from typing import Protocol, cast
 
 from fastapi import Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 
-from .config import Settings
+from .config import Settings, get_settings
+
+
+def parse_trusted_proxies(raw: str) -> list[str]:
+    """신뢰할 프록시 IP/CIDR 목록 파싱."""
+    if not raw:
+        return []
+    result: list[str] = []
+    for part in raw.split(","):
+        ip_str = part.strip()
+        if not ip_str:
+            continue
+        try:
+            if "/" in ip_str:
+                ip_network(ip_str, strict=False)
+            else:
+                ip_address(ip_str)
+            result.append(ip_str)
+        except ValueError:
+            pass
+    return result
+
+
+def forwarded_allow_ips(raw: str | None = None) -> str:
+    """Uvicorn --forwarded-allow-ips 값.
+
+    TRUSTED_PROXY_IPS와 동일한 목록을 쓰고, 비어 있으면 127.0.0.1만 허용한다.
+    '*'는 허용하지 않는다.
+    """
+    value = raw if raw is not None else get_settings().trusted_proxy_ips
+    parsed = parse_trusted_proxies(value)
+    if not parsed:
+        return "127.0.0.1"
+    return ",".join(parsed)
+
+
+def _is_ip_trusted(ip_str: str, trusted_networks: list[str]) -> bool:
+    if not trusted_networks:
+        return False
+    try:
+        client_ip = ip_address(ip_str)
+    except ValueError:
+        return False
+    for net_str in trusted_networks:
+        try:
+            if "/" in net_str:
+                if client_ip in ip_network(net_str, strict=False):
+                    return True
+            elif client_ip == ip_address(net_str):
+                return True
+        except ValueError:
+            pass
+    return False
+
+
+def get_client_ip_for_rate_limit(request: Request) -> str:
+    """레이트리밋용 클라이언트 IP 추출.
+
+    X-Forwarded-For 처리 정책:
+    1. trusted_proxy_ips 설정이 있고, 직접 연결 IP가 신뢰 목록에 있을 때만 XFF 사용.
+    2. XFF가 있으면 우측에서 역순 파싱해 첫 non-trusted hop을 원본 IP로 확정.
+    3. 신뢰 체인을 모두 통과하면 XFF 첫 번째(좌측) IP 사용.
+    4. 그 외에는 request.client.host 사용.
+    """
+    settings = get_settings()
+    trusted = parse_trusted_proxies(settings.trusted_proxy_ips)
+
+    if request.client and request.client.host:
+        direct_ip = request.client.host
+    else:
+        return "unknown"
+
+    if not _is_ip_trusted(direct_ip, trusted):
+        return direct_ip
+
+    xff = request.headers.get("x-forwarded-for", "")
+    if not xff:
+        return direct_ip
+
+    parts = [p.strip() for p in xff.split(",") if p.strip()]
+    if not parts:
+        return direct_ip
+
+    for ip_str in reversed(parts):
+        if not _is_ip_trusted(ip_str, trusted):
+            return ip_str
+
+    return parts[0]
+
+
+def should_skip_rate_limit() -> bool:
+    """테스트 환경에서만 레이트리밋을 건너뛴다."""
+    return (get_settings().app_env or "").lower().strip() == "test"
 
 
 def create_limiter(settings: Settings) -> Limiter:
@@ -16,7 +108,7 @@ def create_limiter(settings: Settings) -> Limiter:
     기본값: `RATE_LIMIT_DEFAULT` 환경변수(예: "120/minute").
     """
     return Limiter(
-        key_func=get_remote_address,
+        key_func=get_client_ip_for_rate_limit,
         default_limits=[settings.rate_limit_default],
     )
 
@@ -33,12 +125,15 @@ _consume_cache: dict[str, Callable[[Request], None]] = {}
 
 
 def consume_limit(limiter: Limiter, request: Request, limit_value: str) -> None:
-    """요청 단위 레이트리밋 토큰 소비(테스트 클라이언트 분기에서 활용).
+    """요청 단위 레이트리밋 토큰 소비.
 
     동일 (limiter id, path, limit_value) 조합에 대해 데코레이트된 함수를
     한 번만 생성·등록하고 이후에는 캐시된 함수를 재사용하여
     _route_limits 누적에 의한 다중 토큰 차감 버그를 방지합니다.
     """
+    if should_skip_rate_limit():
+        return
+
     path_key = request.url.path.strip("/").replace("/", "_") or "root"
     limit_key = (
         limit_value.replace("/", "_").replace(" ", "").replace("-", "_").lower()

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -47,11 +47,6 @@ __all__ = [
     "require_super_admin",
 ]
 
-
-def _is_test_client(request: Request) -> bool:
-    """테스트 클라이언트인지 확인 (레이트리밋 우회용)."""
-    return bool(request.client and request.client.host == "testclient")
-
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 NewPassword = Annotated[str, AfterValidator(validate_password_for_hash)]
@@ -92,8 +87,7 @@ async def login(
     레이트리밋은 이 라우터에서 1회만 차감 (서비스 함수에서는 skip).
     """
     settings = get_settings()
-    if settings.app_env == "prod" and not _is_test_client(request):
-        consume_limit(limiter_login, request, settings.rate_limit_login)
+    consume_limit(limiter_login, request, settings.rate_limit_login)
 
     return await login_member(
         db, request, payload.student_id, payload.password, skip_rate_limit=True

--- a/apps/api/routers/notifications.py
+++ b/apps/api/routers/notifications.py
@@ -7,12 +7,11 @@ from typing import Annotated, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, HttpUrl
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.config import get_settings
 from apps.api.db import get_db
-from apps.api.ratelimit import consume_limit
+from apps.api.ratelimit import consume_limit, get_client_ip_for_rate_limit
 from apps.api.repositories import notifications as subs_repo
 from apps.api.repositories import send_logs as logs_repo
 from apps.api.routers.auth import (
@@ -26,11 +25,7 @@ from apps.api.services import scheduled_notifications_service as sched_svc
 from apps.api.services.scheduled_notifications_service import KST
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
-limiter_notifications = Limiter(key_func=get_remote_address)
-
-
-def _is_test_client(request: Request) -> bool:
-    return bool(request.client and request.client.host == "testclient")
+limiter_notifications = Limiter(key_func=get_client_ip_for_rate_limit)
 
 # pyright/ruff 호환 UTC 타임존 (timezone.utc 대체)
 UTC_TZ = timezone(timedelta(0))
@@ -58,12 +53,11 @@ async def save_subscription(
 ) -> None:
     """Web Push 구독 저장(idempotent). 동일 endpoint는 갱신 처리."""
     settings = get_settings()
-    if not _is_test_client(request):
-        consume_limit(
-            limiter_notifications,
-            request,
-            settings.rate_limit_subscribe,
-        )
+    consume_limit(
+        limiter_notifications,
+        request,
+        settings.rate_limit_subscribe,
+    )
     await notif_svc.save_subscription(
         db,
         {
@@ -88,12 +82,11 @@ async def delete_subscription(
     _member: CurrentMember = Depends(require_member),
 ) -> None:
     settings = get_settings()
-    if not _is_test_client(request):
-        consume_limit(
-            limiter_notifications,
-            request,
-            settings.rate_limit_subscribe,
-        )
+    consume_limit(
+        limiter_notifications,
+        request,
+        settings.rate_limit_subscribe,
+    )
     await notif_svc.delete_subscription(db, endpoint=str(payload.endpoint))
 
 
@@ -114,12 +107,11 @@ async def send_push(
     db: AsyncSession = Depends(get_db),
     provider: notif_svc.PushProvider = Depends(get_push_provider),
 ) -> dict[str, int]:
-    if not _is_test_client(request):
-        consume_limit(
-            limiter_notifications,
-            request,
-            get_settings().rate_limit_notify_send,
-        )
+    consume_limit(
+        limiter_notifications,
+        request,
+        get_settings().rate_limit_notify_send,
+    )
 
     result = await notif_svc.send_to_all(
         db, provider, title=_payload.title, body=_payload.body, url=_payload.url

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import time
 from collections import defaultdict, deque
 from http import HTTPStatus
-from ipaddress import ip_address, ip_network
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -13,6 +12,7 @@ from .. import schemas
 from ..config import get_settings
 from ..db import get_db
 from ..errors import ApiError
+from ..ratelimit import get_client_ip_for_rate_limit, should_skip_rate_limit
 from ..repositories import posts as posts_repo
 from ..services import posts_service
 from ..services.auth_service import is_admin
@@ -21,101 +21,10 @@ from .auth import require_admin, require_member
 router = APIRouter(prefix="/posts", tags=["posts"])
 
 
-def _is_test_client(request: Request) -> bool:
-    return bool(request.client and request.client.host == "testclient")
-
-
-# ---- 레이트리밋 키 추출 (XFF 신뢰 경계 포함) ----
-
 # 멤버 게시글 작성 레이트리밋 (in-memory)
 # 주의: 멀티워커 환경에서는 워커 간 상태가 공유되지 않아 일관성이 깨질 수 있음.
 # 운영 환경에서는 Redis 기반 분산 레이트리밋(slowapi + Redis)으로 전환 권장.
 _MEMBER_RATE_TABLE: dict[str, deque[float]] = defaultdict(deque)
-
-
-def _parse_trusted_proxies(raw: str) -> list[str]:
-    """신뢰할 프록시 IP 목록 파싱 (CIDR 지원)."""
-    if not raw:
-        return []
-    result: list[str] = []
-    for part in raw.split(","):
-        ip_str = part.strip()
-        if not ip_str:
-            continue
-        try:
-            # CIDR 표기법 검증 (예: 10.0.0.0/8, 192.168.1.0/24)
-            if "/" in ip_str:
-                ip_network(ip_str, strict=False)
-            else:
-                ip_address(ip_str)
-            result.append(ip_str)
-        except ValueError:
-            pass  # 잘못된 형식은 무시
-    return result
-
-
-def _is_ip_trusted(ip_str: str, trusted_networks: list[str]) -> bool:
-    """IP가 신뢰하는 프록시 대역에 속하는지 확인."""
-    if not trusted_networks:
-        return False
-    try:
-        client_ip = ip_address(ip_str)
-    except ValueError:
-        return False
-    for net_str in trusted_networks:
-        try:
-            if "/" in net_str:
-                if client_ip in ip_network(net_str, strict=False):
-                    return True
-            elif client_ip == ip_address(net_str):
-                return True
-        except ValueError:
-            pass
-    return False
-
-
-def _get_client_ip_for_rate_limit(request: Request) -> str:
-    """레이트리밋용 클라이언트 IP 추출.
-
-    X-Forwarded-For 처리 정책:
-    1. trusted_proxy_ips 설정이 있고, 직접 연결 IP가 신뢰 목록에 있을 때만 XFF 사용.
-    2. XFF가 있으면 우측에서 역순 파싱해 첫 non-trusted hop을 원본 IP로 확정.
-       (클라이언트가 XFF 좌측에 임의 값을 주입하는 것을 방지)
-    3. 신뢰 체인을 모두 통과하면 XFF 첫 번째(좌측) IP 사용.
-    4. 그 외에는 request.client.host 사용.
-
-    주의: 잘못된 신뢰 경계 설정은 스푸핑 공격에 노출될 수 있음.
-    """
-    settings = get_settings()
-    trusted = _parse_trusted_proxies(settings.trusted_proxy_ips)
-
-    # 직접 연결된 IP
-    if request.client and request.client.host:
-        direct_ip = request.client.host
-    else:
-        return "unknown"
-
-    # 신뢰할 수 있는 프록시를 통한 요청인지 확인
-    if not _is_ip_trusted(direct_ip, trusted):
-        return direct_ip
-
-    # XFF 헤더 파싱
-    xff = request.headers.get("x-forwarded-for", "")
-    if not xff:
-        return direct_ip
-
-    parts = [p.strip() for p in xff.split(",") if p.strip()]
-    if not parts:
-        return direct_ip
-
-    # 우측에서 역순으로 첫 non-trusted IP 찾기
-    # (신뢰하는 프록시 체인을 건너뛰고 실제 클라이언트 IP 확정)
-    for ip_str in reversed(parts):
-        if not _is_ip_trusted(ip_str, trusted):
-            return ip_str
-
-    # 모든 hop이 신뢰하는 프록시인 경우, 가장 좌측(원본) IP 사용
-    return parts[0]
 
 
 def _parse_rate_limit(raw: str) -> tuple[int, float]:
@@ -149,10 +58,10 @@ def _enforce_member_post_limit(request: Request, limit_value: str) -> None:
     주의: 현재 in-memory 구현으로 멀티워커 환경에서 일관성이 보장되지 않음.
     운영 환경에서는 Redis 기반 분산 레이트리밋으로 전환 권장.
     """
-    if _is_test_client(request):
+    if should_skip_rate_limit():
         return
     amount, window = _parse_rate_limit(limit_value)
-    key = _get_client_ip_for_rate_limit(request)
+    key = get_client_ip_for_rate_limit(request)
     now = time.monotonic()
     bucket = _MEMBER_RATE_TABLE[key]
     while bucket and now - bucket[0] > window:

--- a/apps/api/routers/support.py
+++ b/apps/api/routers/support.py
@@ -54,7 +54,7 @@ async def contact(
         return {"status": "accepted"}
 
     # 최근 동일 사용자(또는 세션 IP) 중복/쿨다운 드롭
-    host = request.client.host if request.client else ""
+    host = get_client_ip_for_rate_limit(request)
     email = getattr(_m, "email", "") or ""
     ident = f"{host}|{email}"
     h = f"{payload.subject}\n{payload.body}"
@@ -73,7 +73,7 @@ async def contact(
             "subject": payload.subject,
             "body": payload.body,
             "contact": payload.contact,
-            "client_ip": (request.client.host if request.client else None),
+            "client_ip": host if host != "unknown" else None,
         },
     )
 

--- a/apps/api/routers/support.py
+++ b/apps/api/routers/support.py
@@ -9,12 +9,11 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
 from ..db import get_db
-from ..ratelimit import consume_limit
+from ..ratelimit import consume_limit, get_client_ip_for_rate_limit
 from ..repositories import support_tickets as tickets_repo
 from ..routers.auth import (
     CurrentMember,
@@ -24,11 +23,7 @@ from ..routers.auth import (
 )
 
 router = APIRouter(prefix="/support", tags=["support"])
-limiter = Limiter(key_func=get_remote_address)
-
-
-def _is_test_client(request: Request) -> bool:
-    return bool(request.client and request.client.host == "testclient")
+limiter = Limiter(key_func=get_client_ip_for_rate_limit)
 
 # 최근 중복/쿨다운 체크(간단 메모리)
 _recent: dict[str, tuple[float, str]] = {}
@@ -50,8 +45,7 @@ async def contact(
     _m: CurrentMember = Depends(require_member),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
-    if not _is_test_client(request):
-        consume_limit(limiter, request, get_settings().rate_limit_support)
+    consume_limit(limiter, request, get_settings().rate_limit_support)
 
     # 봇/스팸: honeypot 또는 키워드 차단 → 드롭(accepted)
     if payload.hp or _BLOCKLIST.search(payload.subject) or _BLOCKLIST.search(

--- a/apps/api/services/auth_service.py
+++ b/apps/api/services/auth_service.py
@@ -13,7 +13,6 @@ from typing import Any, cast
 
 from fastapi import Depends, HTTPException, Request
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
@@ -21,7 +20,7 @@ from ..config import get_settings
 from ..db import get_db
 from ..errors import ApiError, NotFoundError
 from ..passwords import hash_password, verify_password
-from ..ratelimit import consume_limit
+from ..ratelimit import consume_limit, get_client_ip_for_rate_limit
 from ..repositories import auth as auth_repo
 from ..repositories import members as members_repo
 from ..repositories import signup_requests as signup_requests_repo
@@ -33,12 +32,7 @@ from .activation_service import (
 from .roles_service import ensure_member_role, has_permission, normalize_roles
 
 # 로그인 레이트리밋 (slowapi)
-limiter_login = Limiter(key_func=get_remote_address)
-
-
-def _is_test_client(request: Request) -> bool:
-    """테스트 클라이언트인지 확인 (레이트리밋 우회용)."""
-    return bool(request.client and request.client.host == "testclient")
+limiter_login = Limiter(key_func=get_client_ip_for_rate_limit)
 
 
 # ---- 세션 데이터 클래스 ----
@@ -278,8 +272,7 @@ async def login_member(
     """
     if not skip_rate_limit:
         settings = get_settings()
-        if settings.app_env == "prod" and not _is_test_client(request):
-            consume_limit(limiter_login, request, settings.rate_limit_login)
+        consume_limit(limiter_login, request, settings.rate_limit_login)
 
     member, creds = await auth_repo.get_member_with_auth_by_student_id(db, student_id)
     if member is None or creds is None:
@@ -323,8 +316,7 @@ async def activate_member(
 ) -> dict[str, str]:
     """멤버 활성화: 승인 기반 토큰 검증 후 비밀번호 설정."""
     settings = get_settings()
-    if settings.app_env == "prod" and not _is_test_client(request):
-        consume_limit(limiter_login, request, settings.rate_limit_login)
+    consume_limit(limiter_login, request, settings.rate_limit_login)
 
     payload = load_activation_payload(token)
     row = await resolve_activation_signup_request(db, payload)
@@ -362,8 +354,7 @@ async def change_member_password(
 ) -> dict[str, str]:
     """멤버 비밀번호 변경."""
     settings = get_settings()
-    if settings.app_env == "prod" and not _is_test_client(request):
-        consume_limit(limiter_login, request, settings.rate_limit_login)
+    consume_limit(limiter_login, request, settings.rate_limit_login)
 
     auth_row = await auth_repo.get_member_auth_by_student_id(db, member.student_id)
 

--- a/docs/dev_log_260731.md
+++ b/docs/dev_log_260731.md
@@ -13,5 +13,6 @@
 - Shared: `apps/api/ratelimit.py`에 trusted-proxy XFF IP SSOT·`should_skip_rate_limit()`(`APP_ENV=test`만 스킵) 승격, 전 Limiter/posts 적용
 - Removed: `host==testclient` 문자열 우회; 로그인 레이트리밋을 prod-only에서 non-test 전 환경으로 정렬
 - Runtime: `infra/api-entrypoint.sh`가 `TRUSTED_PROXY_IPS`→`--forwarded-allow-ips`(빈 값=`127.0.0.1`, `*` 금지, noglob로 `*` pathname expansion 차단)
-- Settings: `APP_ENV` allowlist + staging/prod JWT fail-closed; `.env.api.example`/`ops/deploy_api.md`에 `TRUSTED_PROXY_IPS`·`IMAGE_MAX_*` 문서화
+- Settings: `APP_ENV` allowlist(빈 값 거부) + staging/prod JWT placeholder 패턴(`change-me*`/`replace_me*`/`replace-me*`) fail-closed; `IMAGE_MAX_*` 양수·상한 검증; `.env.api.example` JWT는 빈 값으로 교체 강제
+- Support: cooldown/`client_ip`도 `get_client_ip_for_rate_limit` SSOT 사용
 - Tests: `tests/api/test_d2_proxy_config_authority.py`, root conftest `APP_ENV=test` 고정

--- a/docs/dev_log_260731.md
+++ b/docs/dev_log_260731.md
@@ -7,3 +7,11 @@
 - Fixed: `count_active_members_with_role` LIKE 패턴에서 `_`/`%` 이스케이프해 역할 토큰 오탐 방지
 - Docs: `architecture.md`에 RSVP create 경로 정원 규칙·마지막 super_admin 상태 보호 반영
 - Tests: create 경로 waitlist, 마지막 SA 정지 거부/비마지막 정지 허용, LIKE 와일드카드 회귀 추가
+
+## D2 프록시·운영 설정 신뢰 경계 (#247/#260)
+
+- Shared: `apps/api/ratelimit.py`에 trusted-proxy XFF IP SSOT·`should_skip_rate_limit()`(`APP_ENV=test`만 스킵) 승격, 전 Limiter/posts 적용
+- Removed: `host==testclient` 문자열 우회; 로그인 레이트리밋을 prod-only에서 non-test 전 환경으로 정렬
+- Runtime: `infra/api-entrypoint.sh`가 `TRUSTED_PROXY_IPS`→`--forwarded-allow-ips`(빈 값=`127.0.0.1`, `*` 금지)
+- Settings: `APP_ENV` allowlist + staging/prod JWT fail-closed; `.env.api.example`/`ops/deploy_api.md`에 `TRUSTED_PROXY_IPS`·`IMAGE_MAX_*` 문서화
+- Tests: `tests/api/test_d2_proxy_config_authority.py`, root conftest `APP_ENV=test` 고정

--- a/docs/dev_log_260731.md
+++ b/docs/dev_log_260731.md
@@ -12,6 +12,6 @@
 
 - Shared: `apps/api/ratelimit.py`에 trusted-proxy XFF IP SSOT·`should_skip_rate_limit()`(`APP_ENV=test`만 스킵) 승격, 전 Limiter/posts 적용
 - Removed: `host==testclient` 문자열 우회; 로그인 레이트리밋을 prod-only에서 non-test 전 환경으로 정렬
-- Runtime: `infra/api-entrypoint.sh`가 `TRUSTED_PROXY_IPS`→`--forwarded-allow-ips`(빈 값=`127.0.0.1`, `*` 금지)
+- Runtime: `infra/api-entrypoint.sh`가 `TRUSTED_PROXY_IPS`→`--forwarded-allow-ips`(빈 값=`127.0.0.1`, `*` 금지, noglob로 `*` pathname expansion 차단)
 - Settings: `APP_ENV` allowlist + staging/prod JWT fail-closed; `.env.api.example`/`ops/deploy_api.md`에 `TRUSTED_PROXY_IPS`·`IMAGE_MAX_*` 문서화
 - Tests: `tests/api/test_d2_proxy_config_authority.py`, root conftest `APP_ENV=test` 고정

--- a/infra/api-entrypoint.sh
+++ b/infra/api-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# TRUSTED_PROXY_IPS → uvicorn --forwarded-allow-ips
+# 비어 있으면 127.0.0.1만 허용. '*'는 사용하지 않는다.
+_raw="${TRUSTED_PROXY_IPS:-}"
+_allow=""
+_old_ifs=$IFS
+IFS=,
+for part in ${_raw}; do
+  trimmed=$(printf '%s' "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [ -z "$trimmed" ] && continue
+  [ "$trimmed" = "*" ] && continue
+  if [ -z "$_allow" ]; then
+    _allow="$trimmed"
+  else
+    _allow="${_allow},${trimmed}"
+  fi
+done
+IFS=$_old_ifs
+
+if [ -z "$_allow" ]; then
+  _allow="127.0.0.1"
+fi
+
+exec uvicorn apps.api.main:app \
+  --host 0.0.0.0 \
+  --port 3001 \
+  --proxy-headers \
+  --forwarded-allow-ips "$_allow"

--- a/infra/api-entrypoint.sh
+++ b/infra/api-entrypoint.sh
@@ -5,8 +5,12 @@ set -eu
 # 비어 있으면 127.0.0.1만 허용. '*'는 사용하지 않는다.
 _raw="${TRUSTED_PROXY_IPS:-}"
 _allow=""
+
+# '*' 등이 pathname expansion 되지 않도록 noglob
+set -f
 _old_ifs=$IFS
 IFS=,
+# shellcheck disable=SC2086
 for part in ${_raw}; do
   trimmed=$(printf '%s' "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   [ -z "$trimmed" ] && continue
@@ -18,6 +22,7 @@ for part in ${_raw}; do
   fi
 done
 IFS=$_old_ifs
+set +f
 
 if [ -z "$_allow" ]; then
   _allow="127.0.0.1"

--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -31,12 +31,14 @@ WORKDIR /app
 
 COPY --from=build /install /usr/local
 COPY apps/api ./apps/api
+COPY infra/api-entrypoint.sh /app/infra/api-entrypoint.sh
 
 RUN mkdir -p uploads \
+    && chmod +x /app/infra/api-entrypoint.sh \
     && chown apiuser:apiuser uploads
 
 USER apiuser
 
 EXPOSE 3001
 
-CMD ["uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "3001", "--proxy-headers", "--forwarded-allow-ips", "*"]
+ENTRYPOINT ["/app/infra/api-entrypoint.sh"]

--- a/ops/deploy_api.md
+++ b/ops/deploy_api.md
@@ -5,18 +5,18 @@
 - 데이터베이스는 PostgreSQL 16만 지원한다(루트 `compose.yaml`). 모든 환경에서 `postgresql+psycopg://` 스킴을 사용한다.
 
 ## 2. 필수 환경 변수
-- `APP_ENV`: `dev` / `test` / `staging` / `prod` (그 외 값은 기동 실패)
+- `APP_ENV`: `dev` / `test` / `staging` / `prod` (빈 값·그 외 값은 기동 실패)
 - `DATABASE_URL`: SQLAlchemy 접속 문자열 (예: `postgresql+psycopg://user:pass@host:5432/db`)
-- `JWT_SECRET`: 세션/토큰 서명 키. `staging`/`prod`에서는 32자 이상이며 `change-me*` placeholder 금지
+- `JWT_SECRET`: 세션/토큰 서명 키. `staging`/`prod`에서는 32자 이상이며 `change-me*` / `replace_me*` / `replace-me*` / 빈 값 placeholder 금지
 - `CORS_ORIGINS`: 허용 Origin 목록(JSON 문자열). 예: `[{"origin": "https://sogangeconomics.com"}]`가 아니라 `['https://sogangeconomics.com']` 형태로 보일 수 있으니, 실제 설정은 다음과 같이 JSON 배열 문자열을 권장: `CORS_ORIGINS=["https://sogangeconomics.com"]`
-- `TRUSTED_PROXY_IPS`: Nginx→API hop(또는 docker 네트워크 CIDR). 레이트리밋 XFF 파싱과 Uvicorn `--forwarded-allow-ips`가 동일 목록을 사용. 비어 있으면 `127.0.0.1`만 허용하며 `*`는 금지
+- `TRUSTED_PROXY_IPS`: Nginx→API hop(또는 docker 네트워크 CIDR). 레이트리밋 XFF 파싱과 Uvicorn `--forwarded-allow-ips`가 동일 목록을 사용. 비어 있으면 `127.0.0.1`만 허용하며 `*`와 잘못된 IP/CIDR은 기동 실패
 - `RATE_LIMIT_DEFAULT`: 기본 레이트리밋 (예: `120/minute`)
 - `RATE_LIMIT_POST_CREATE`: 멤버 게시글 작성 레이트리밋 (예: `5/minute`)
 - `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`
 - `PUSH_ENCRYPT_AT_REST`, `PUSH_KEK`: 푸시 구독 암호화 옵션
 - (선택) 관리자 bootstrap 시드: `SEED_PROD_ADMIN001_VALUE`
 - `MEDIA_ROOT`, `MEDIA_URL_BASE`: 업로드 경로 (기본값 사용 가능)
-- `IMAGE_MAX_UPLOAD_BYTES`, `IMAGE_MAX_PIXELS`: 게시글 커버 등 이미지 업로드 한도 (기본 5MB / 1920px)
+- `IMAGE_MAX_UPLOAD_BYTES`, `IMAGE_MAX_PIXELS`: 게시글 커버 등 이미지 업로드 한도 (양수 필수; staging/prod는 각각 50MB·10000px 상한)
 - Sentry/관측: `SENTRY_DSN`, `RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`(기본 0.05), `SENTRY_PROFILES_SAMPLE_RATE`(기본 0.0), `SENTRY_SEND_DEFAULT_PII`(필요 시 `true`)
 - CI/CD 시크릿 스토리지에 위 값을 저장하고 배포 시 주입한다.
 

--- a/ops/deploy_api.md
+++ b/ops/deploy_api.md
@@ -5,18 +5,22 @@
 - 데이터베이스는 PostgreSQL 16만 지원한다(루트 `compose.yaml`). 모든 환경에서 `postgresql+psycopg://` 스킴을 사용한다.
 
 ## 2. 필수 환경 변수
-- `APP_ENV`: `dev` / `staging` / `prod`
+- `APP_ENV`: `dev` / `test` / `staging` / `prod` (그 외 값은 기동 실패)
 - `DATABASE_URL`: SQLAlchemy 접속 문자열 (예: `postgresql+psycopg://user:pass@host:5432/db`)
-- `JWT_SECRET`: 세션/토큰 서명 키
+- `JWT_SECRET`: 세션/토큰 서명 키. `staging`/`prod`에서는 32자 이상이며 `change-me*` placeholder 금지
 - `CORS_ORIGINS`: 허용 Origin 목록(JSON 문자열). 예: `[{"origin": "https://sogangeconomics.com"}]`가 아니라 `['https://sogangeconomics.com']` 형태로 보일 수 있으니, 실제 설정은 다음과 같이 JSON 배열 문자열을 권장: `CORS_ORIGINS=["https://sogangeconomics.com"]`
+- `TRUSTED_PROXY_IPS`: Nginx→API hop(또는 docker 네트워크 CIDR). 레이트리밋 XFF 파싱과 Uvicorn `--forwarded-allow-ips`가 동일 목록을 사용. 비어 있으면 `127.0.0.1`만 허용하며 `*`는 금지
 - `RATE_LIMIT_DEFAULT`: 기본 레이트리밋 (예: `120/minute`)
 - `RATE_LIMIT_POST_CREATE`: 멤버 게시글 작성 레이트리밋 (예: `5/minute`)
 - `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`
 - `PUSH_ENCRYPT_AT_REST`, `PUSH_KEK`: 푸시 구독 암호화 옵션
 - (선택) 관리자 bootstrap 시드: `SEED_PROD_ADMIN001_VALUE`
 - `MEDIA_ROOT`, `MEDIA_URL_BASE`: 업로드 경로 (기본값 사용 가능)
+- `IMAGE_MAX_UPLOAD_BYTES`, `IMAGE_MAX_PIXELS`: 게시글 커버 등 이미지 업로드 한도 (기본 5MB / 1920px)
 - Sentry/관측: `SENTRY_DSN`, `RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`(기본 0.05), `SENTRY_PROFILES_SAMPLE_RATE`(기본 0.0), `SENTRY_SEND_DEFAULT_PII`(필요 시 `true`)
 - CI/CD 시크릿 스토리지에 위 값을 저장하고 배포 시 주입한다.
+
+> 프록시: Nginx가 `X-Forwarded-For`를 붙이더라도 API는 `TRUSTED_PROXY_IPS`에 등록된 직접 연결 hop에서만 XFF를 신뢰한다. 운영에서는 반드시 Nginx→API(또는 컨테이너 네트워크) IP/CIDR을 `TRUSTED_PROXY_IPS`에 넣는다.
 
 ### 쿠키/세션(도메인 전략에 따른 권장값)
 - 기본(같은 상위도메인의 하위 도메인, 예: `sogangeconomics.com` + `api.sogangeconomics.com`):
@@ -68,12 +72,12 @@
 1) DNS: `sogangeconomics.com`, `www.sogangeconomics.com`, `api.sogangeconomics.com` → VPS IP
 2) API `.env` 혹은 env-file
    - 레포 루트의 `.env.api.example`을 복사해 `.env.api` 생성 후 값 채움
-   - 최소 구성: `APP_ENV=prod`, `CORS_ORIGINS=["https://sogangeconomics.com","https://www.sogangeconomics.com"]`, `JWT_SECRET=...`, `DATABASE_URL=...`
+   - 최소 구성: `APP_ENV=prod`, `CORS_ORIGINS=["https://sogangeconomics.com","https://www.sogangeconomics.com"]`, `JWT_SECRET=...`(32자+), `DATABASE_URL=...`, `TRUSTED_PROXY_IPS=...`(Nginx→API hop)
    - 쿠키: `COOKIE_SAMESITE=lax`(기본), `COOKIE_SECURE=true`
 3) 마이그레이션/기동
    - `API_IMAGE=... ENV_FILE=.env.api ./ops/cloud-migrate.sh`
    - `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web ./ops/cloud-start.sh`
-4) 프록시: `api.sogangeconomics.com` → `127.0.0.1:3001`(예시 Nginx는 `ops/nginx-examples/` 참고)
+4) 프록시: `api.sogangeconomics.com` → `127.0.0.1:3001`(예시 Nginx는 `ops/nginx-examples/` 참고). `TRUSTED_PROXY_IPS`에 해당 hop을 반드시 등록
 5) 헬스체크: `GET https://api.sogangeconomics.com/healthz` → 200
 
 > 추후 별도 도메인(예: `sogecon.app` 등)으로 전환 시:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -15,11 +15,23 @@ from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from apps.api import models
+from apps.api.config import reset_settings_cache
 from apps.api.db import get_db
 from apps.api.main import app
 from apps.api.routers.notifications import limiter_notifications
 from apps.api.routers.support import limiter as limiter_support
 from apps.api.services.auth_service import limiter_login
+
+
+@pytest.fixture()
+def enable_rate_limit(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """레이트리밋 동작 검증용: APP_ENV=test 스킵을 잠시 해제한다."""
+    monkeypatch.setenv("APP_ENV", "dev")
+    reset_settings_cache()
+    try:
+        yield
+    finally:
+        reset_settings_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/api/test_abc_phase1.py
+++ b/tests/api/test_abc_phase1.py
@@ -187,7 +187,9 @@ def test_member_login_inactive_blocked(client: TestClient) -> None:
     assert res.json()["detail"] == "member_not_active"
 
 
-def test_support_contact_rate_limit(admin_login: TestClient) -> None:
+def test_support_contact_rate_limit(
+    admin_login: TestClient, enable_rate_limit: None
+) -> None:
     client = admin_login
     res1 = client.post(
         "/support/contact", json={"subject": "hello", "body": "message long enough"}

--- a/tests/api/test_d2_proxy_config_authority.py
+++ b/tests/api/test_d2_proxy_config_authority.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 from starlette.requests import Request
 
-from apps.api.config import Settings, get_settings, reset_settings_cache
+from apps.api.config import (
+    Settings,
+    get_settings,
+    is_jwt_placeholder,
+    reset_settings_cache,
+)
 from apps.api.ratelimit import (
     forwarded_allow_ips,
     get_client_ip_for_rate_limit,
@@ -15,6 +21,7 @@ from apps.api.ratelimit import (
 
 _PG = "postgresql+psycopg://app:devpass@localhost:5434/appdb_test"
 _STRONG_JWT = "d2-test-strong-jwt-secret-32chars-min"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _request(host: str, xff: str | None = None) -> Request:
@@ -96,10 +103,63 @@ def test_production_like_rejects_weak_jwt(
         Settings()
 
 
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "change-me-to-a-strong-secret",
+        "change-me-extra-long-but-still-placeholder!!",
+        "REPLACE_ME_WITH_OPENSSL_RAND_BASE64_32B_MIN",
+        "replace-me-please-use-openssl-rand-base64",
+        "",
+    ],
+)
+@pytest.mark.parametrize("env", ["staging", "prod"])
+def test_production_like_rejects_placeholder_jwt_patterns(
+    env: str, secret: str, monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    assert is_jwt_placeholder(secret) or len(secret) < 32 or secret == ""
+    monkeypatch.setenv("APP_ENV", env)
+    monkeypatch.setenv("JWT_SECRET", secret)
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_env_api_example_jwt_placeholder_rejected_in_prod(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    """`.env.api.example`의 JWT_SECRET 값은 staging/prod에서 거부되어야 한다."""
+    example = (_REPO_ROOT / ".env.api.example").read_text(encoding="utf-8")
+    jwt_line = next(
+        line for line in example.splitlines() if line.startswith("JWT_SECRET=")
+    )
+    example_secret = jwt_line.split("=", 1)[1]
+    assert is_jwt_placeholder(example_secret)
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("JWT_SECRET", example_secret)
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
 def test_unknown_app_env_fail_closed(
     monkeypatch: pytest.MonkeyPatch, _restore_settings: None
 ) -> None:
     monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("JWT_SECRET", _STRONG_JWT)
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+@pytest.mark.parametrize("empty", ["", "   "])
+def test_empty_app_env_fail_closed(
+    empty: str, monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", empty)
     monkeypatch.setenv("JWT_SECRET", _STRONG_JWT)
     monkeypatch.setenv("DATABASE_URL", _PG)
     reset_settings_cache()
@@ -129,3 +189,55 @@ def test_forwarded_allow_ips_defaults_and_never_star(
     assert forwarded_allow_ips("10.0.0.1, 10.0.0.2") == "10.0.0.1,10.0.0.2"
     # '*' 단독 입력은 파서에서 무시되어 기본값으로 떨어진다
     assert forwarded_allow_ips("*") == "127.0.0.1"
+
+
+def test_invalid_trusted_proxy_ips_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "not-an-ip")
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+@pytest.mark.parametrize("env", ["staging", "prod"])
+@pytest.mark.parametrize(
+    ("upload", "pixels"),
+    [
+        (0, 1920),
+        (-1, 1920),
+        (5_000_000, 0),
+        (5_000_000, -10),
+        (50_000_001, 1920),
+        (5_000_000, 10_001),
+    ],
+)
+def test_production_like_rejects_bad_image_limits(
+    env: str,
+    upload: int,
+    pixels: int,
+    monkeypatch: pytest.MonkeyPatch,
+    _restore_settings: None,
+) -> None:
+    monkeypatch.setenv("APP_ENV", env)
+    monkeypatch.setenv("JWT_SECRET", _STRONG_JWT)
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    monkeypatch.setenv("IMAGE_MAX_UPLOAD_BYTES", str(upload))
+    monkeypatch.setenv("IMAGE_MAX_PIXELS", str(pixels))
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_dev_rejects_non_positive_image_limits(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", "dev")
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    monkeypatch.setenv("IMAGE_MAX_UPLOAD_BYTES", "0")
+    monkeypatch.setenv("IMAGE_MAX_PIXELS", "1920")
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()

--- a/tests/api/test_d2_proxy_config_authority.py
+++ b/tests/api/test_d2_proxy_config_authority.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from pydantic import ValidationError
+from starlette.requests import Request
+
+from apps.api.config import Settings, get_settings, reset_settings_cache
+from apps.api.ratelimit import (
+    forwarded_allow_ips,
+    get_client_ip_for_rate_limit,
+    should_skip_rate_limit,
+)
+
+_PG = "postgresql+psycopg://app:devpass@localhost:5434/appdb_test"
+_STRONG_JWT = "d2-test-strong-jwt-secret-32chars-min"
+
+
+def _request(host: str, xff: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": headers,
+        "client": (host, 12345),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+@pytest.fixture()
+def _restore_settings() -> Generator[None, None, None]:
+    yield
+    reset_settings_cache()
+
+
+def test_untrusted_direct_connection_ignores_spoofed_xff(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "10.0.0.1")
+    reset_settings_cache()
+    req = _request("203.0.113.10", xff="198.51.100.1, 10.0.0.1")
+    assert get_client_ip_for_rate_limit(req) == "203.0.113.10"
+
+
+def test_trusted_proxy_extracts_original_client_ip(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "10.0.0.1")
+    reset_settings_cache()
+    req = _request("10.0.0.1", xff="198.51.100.7")
+    assert get_client_ip_for_rate_limit(req) == "198.51.100.7"
+
+
+def test_testclient_host_does_not_skip_outside_test_env(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    for env in ("dev", "staging", "prod"):
+        monkeypatch.setenv("APP_ENV", env)
+        monkeypatch.setenv("JWT_SECRET", _STRONG_JWT)
+        monkeypatch.setenv("DATABASE_URL", _PG)
+        reset_settings_cache()
+        assert should_skip_rate_limit() is False
+        # host 문자열은 더 이상 스킵 근거가 아니다
+        assert get_client_ip_for_rate_limit(_request("testclient")) == "testclient"
+
+
+def test_should_skip_only_when_app_env_test(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    assert should_skip_rate_limit() is True
+    assert get_settings().app_env == "test"
+
+
+@pytest.mark.parametrize("env", ["staging", "prod"])
+def test_production_like_rejects_weak_jwt(
+    env: str, monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", env)
+    monkeypatch.setenv("JWT_SECRET", "change-me")
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_unknown_app_env_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("JWT_SECRET", _STRONG_JWT)
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    reset_settings_cache()
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_dev_and_test_accept_weak_jwt_fixture(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    for env in ("dev", "test"):
+        monkeypatch.setenv("APP_ENV", env)
+        monkeypatch.setenv("JWT_SECRET", "change-me")
+        monkeypatch.setenv("DATABASE_URL", _PG)
+        reset_settings_cache()
+        settings = Settings()
+        assert settings.app_env == env
+        assert settings.jwt_secret == "change-me"
+
+
+def test_forwarded_allow_ips_defaults_and_never_star(
+    monkeypatch: pytest.MonkeyPatch, _restore_settings: None
+) -> None:
+    monkeypatch.setenv("TRUSTED_PROXY_IPS", "")
+    reset_settings_cache()
+    assert forwarded_allow_ips() == "127.0.0.1"
+    assert forwarded_allow_ips("10.0.0.1, 10.0.0.2") == "10.0.0.1,10.0.0.2"
+    # '*' 단독 입력은 파서에서 무시되어 기본값으로 떨어진다
+    assert forwarded_allow_ips("*") == "127.0.0.1"

--- a/tests/api/test_notifications_auth.py
+++ b/tests/api/test_notifications_auth.py
@@ -46,7 +46,9 @@ def test_subscription_invalid_payload_returns_422(member_login: TestClient) -> N
 
 
 @pytest.mark.anyio
-async def test_admin_send_rate_limit_429(admin_login: TestClient) -> None:
+async def test_admin_send_rate_limit_429(
+    admin_login: TestClient, enable_rate_limit: None
+) -> None:
     class _DummyProvider(PushProvider):
         def send(
             self, sub: models.PushSubscription, payload: dict[str, object]

--- a/tests/api/test_notifications_rate_concurrency.py
+++ b/tests/api/test_notifications_rate_concurrency.py
@@ -31,7 +31,9 @@ class _DummyProvider(PushProvider):
 
 
 @pytest.mark.anyio
-async def test_admin_send_rate_limit_concurrent(admin_login: TestClient) -> None:
+async def test_admin_send_rate_limit_concurrent(
+    admin_login: TestClient, enable_rate_limit: None
+) -> None:
     def _provider_override() -> _DummyProvider:
         return _DummyProvider()
 

--- a/tests/api/test_posts_board.py
+++ b/tests/api/test_posts_board.py
@@ -154,7 +154,9 @@ def test_post_create_requires_auth(client: TestClient) -> None:
 
 
 @pytest.mark.anyio("asyncio")
-async def test_post_create_rate_limit(member_login: TestClient) -> None:
+async def test_post_create_rate_limit(
+    member_login: TestClient, enable_rate_limit: None
+) -> None:
     posts_router.reset_member_post_limit_cache()
 
     transport = httpx.ASGITransport(app=app, client=("10.20.30.40", 8080))

--- a/tests/api/test_support_contact.py
+++ b/tests/api/test_support_contact.py
@@ -20,7 +20,9 @@ def anyio_backend() -> str:
 
 
 @pytest.mark.anyio
-async def test_support_contact_rate_limit_and_validation(client: TestClient) -> None:
+async def test_support_contact_rate_limit_and_validation(
+    client: TestClient, enable_rate_limit: None
+) -> None:
     transport = httpx.ASGITransport(app=app, client=("2.2.2.2", 55555))
     async with httpx.AsyncClient(transport=transport, base_url="http://local") as hc:
         # login as admin to satisfy require_member compatibility

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+# 테스트 기본 환경: 레이트리밋은 APP_ENV=test 일 때만 스킵한다.
+# api conftest가 app을 import하기 전에 고정해야 한다.
+os.environ["APP_ENV"] = "test"
 
 # Ensure repo root on sys.path so the "apps" package
 # is importable during pytest collection.

--- a/tests/test_ratelimit_consume.py
+++ b/tests/test_ratelimit_consume.py
@@ -7,6 +7,7 @@ from slowapi import Limiter
 from starlette.requests import Request
 
 from apps.api import ratelimit
+from apps.api.config import reset_settings_cache
 
 
 def _build_request(path: str) -> Request:
@@ -34,15 +35,23 @@ def clear_consume_cache() -> Generator[None, None, None]:
     ratelimit._consume_cache.clear()
 
 
-def test_consume_limit_reuses_decorated_consumer_per_path_and_limit() -> None:
-    limiter = Limiter(key_func=lambda request: "1.2.3.4")
-    path = "/notifications/admin/notifications/send"
-    limit_value = "6/minute"
-    route_key = "apps.api.ratelimit.consume_notifications_admin_notifications_send_6_minute"
+def test_consume_limit_reuses_decorated_consumer_per_path_and_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "dev")
+    reset_settings_cache()
+    try:
+        limiter = Limiter(key_func=lambda request: "1.2.3.4")
+        path = "/notifications/admin/notifications/send"
+        limit_value = "6/minute"
+        route_key = (
+            "apps.api.ratelimit.consume_notifications_admin_notifications_send_6_minute"
+        )
 
-    for _ in range(6):
-        ratelimit.consume_limit(limiter, _build_request(path), limit_value)
+        for _ in range(6):
+            ratelimit.consume_limit(limiter, _build_request(path), limit_value)
 
-    assert len(limiter._route_limits.get(route_key, [])) == 1
-    assert len(ratelimit._consume_cache) == 1
-
+        assert len(limiter._route_limits.get(route_key, [])) == 1
+        assert len(ratelimit._consume_cache) == 1
+    finally:
+        reset_settings_cache()


### PR DESCRIPTION
## Summary
- Closes #247, Closes #260 (umbrella #245 D2 묶음)
- Base: `main` @ `49097f7`
- Head: `codex/d2-proxy-config-trust` @ `8efd0fe`
- 레이트리밋 클라이언트 IP를 trusted-proxy XFF SSOT로 통일하고 `host==testclient` 우회를 제거한다 (`APP_ENV=test`만 스킵).
- Uvicorn `--forwarded-allow-ips '*'`를 제거하고 `TRUSTED_PROXY_IPS`와 동일 목록으로 제한한다.
- `APP_ENV` allowlist + staging/prod JWT fail-closed, `IMAGE_MAX_*`/`TRUSTED_PROXY_IPS` 문서·예시 보강.

## 완료 기준
- [x] 비신뢰 직접 연결 + 위조 XFF → direct host 키
- [x] 신뢰 프록시 + XFF → 원본 IP
- [x] `testclient` host여도 non-test env에서 레이트리밋 스킵 안 됨
- [x] staging/prod weak JWT·unknown APP_ENV 기동 실패
- [x] Dockerfile/entrypoint `*` 금지

## Test plan
- [x] `.venv/bin/ruff check apps/api`
- [x] `.venv/bin/python -m pyright --project pyrightconfig.json`
- [x] `.venv/bin/pytest -q` (221 passed)
- [x] Settings startup negative/positive (unknown env, staging weak/strong JWT, forwarded-allow-ips)
- [ ] WSL 실기동 + Cursor browser e2e 스모크 (로그인·헬스) — 진행 중, 결과 PR 댓글


Made with [Cursor](https://cursor.com)