### PR TITLE
fix(api): 푸시 구독 소유권·암호화·배치 성능 (D3)

### DIFF
--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 from functools import lru_cache
 from ipaddress import ip_address, ip_network
 
@@ -200,6 +202,25 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "IMAGE_MAX_PIXELS exceeds cap "
                     f"({_IMAGE_MAX_PIXELS_CAP}) when APP_ENV={self.app_env}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_push_encryption(self) -> "Settings":
+        # PUSH_ENCRYPT_AT_REST=true 이면 KEK는 기동 시 반드시 유효해야 한다.
+        if self.push_encrypt_at_rest:
+            try:
+                key = base64.b64decode((self.push_kek or "").strip())
+            except (binascii.Error, ValueError) as exc:
+                raise ValueError(
+                    "PUSH_KEK must be valid base64 AES key "
+                    "(16/24/32 bytes) when PUSH_ENCRYPT_AT_REST=true"
+                ) from exc
+            if len(key) not in (16, 24, 32):
+                raise ValueError(
+                    "PUSH_KEK must be valid base64 AES key "
+                    f"(16/24/32 bytes) when PUSH_ENCRYPT_AT_REST=true "
+                    f"(got {len(key)} bytes)"
                 )
         return self
 

--- a/apps/api/crypto_utils.py
+++ b/apps/api/crypto_utils.py
@@ -9,15 +9,46 @@ from typing import Final
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-from .config import get_settings
+from .config import Settings, get_settings
 
 PREFIX: Final = "enc:v1:"
+_AES_KEY_LENS: Final = frozenset({16, 24, 32})
 
 
-@dataclass
+class CryptoError(Exception):
+    """at-rest 암·복호화 실패 (평문 위장 반환 금지)."""
+
+
+@dataclass(frozen=True)
 class CryptoConfig:
     enabled: bool
     key: bytes | None
+
+
+def decode_push_kek(raw: str) -> bytes:
+    """PUSH_KEK base64 → AES 키 바이트. 형식이 틀리면 ValueError."""
+    try:
+        key = base64.b64decode((raw or "").strip())
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("PUSH_KEK must be valid base64") from exc
+    if len(key) not in _AES_KEY_LENS:
+        raise ValueError(
+            "PUSH_KEK decoded length must be 16, 24, or 32 bytes "
+            f"(got {len(key)})"
+        )
+    return key
+
+
+def is_push_encryption_effective(settings: Settings | None = None) -> bool:
+    """PUSH_ENCRYPT_AT_REST가 켜져 있고 KEK가 유효한지."""
+    s = settings if settings is not None else get_settings()
+    if not s.push_encrypt_at_rest:
+        return False
+    try:
+        decode_push_kek(s.push_kek)
+    except ValueError:
+        return False
+    return True
 
 
 def _cfg() -> CryptoConfig:
@@ -25,18 +56,18 @@ def _cfg() -> CryptoConfig:
     if not s.push_encrypt_at_rest:
         return CryptoConfig(False, None)
     try:
-        key = base64.b64decode(s.push_kek)
-    except (binascii.Error, ValueError):
-        key = b""
-    if len(key) not in (16, 24, 32):  # AES-128/192/256
-        return CryptoConfig(False, None)
+        key = decode_push_kek(s.push_kek)
+    except ValueError as exc:
+        raise CryptoError("push encryption enabled but PUSH_KEK is invalid") from exc
     return CryptoConfig(True, key)
 
 
 def encrypt_str(p: str) -> str:
     cfg = _cfg()
-    if not cfg.enabled or cfg.key is None:
+    if not cfg.enabled:
         return p
+    if cfg.key is None:
+        raise CryptoError("push encryption enabled but key is missing")
     aes = AESGCM(cfg.key)
     nonce = os.urandom(12)
     ct = aes.encrypt(nonce, p.encode("utf-8"), None)
@@ -46,18 +77,24 @@ def encrypt_str(p: str) -> str:
 
 def decrypt_str(c: str) -> str:
     if not c.startswith(PREFIX):
+        # 접두 없음 = 평문(기존 데이터 호환)
         return c
     cfg = _cfg()
     if not cfg.enabled or cfg.key is None:
-        # cannot decrypt; treat as plaintext to fail fast downstream
-        return c
+        raise CryptoError(
+            "encrypted value present but push encryption is not effective"
+        )
     try:
         data = base64.b64decode(c[len(PREFIX) :])
         nonce, ct = data[:12], data[12:]
         aes = AESGCM(cfg.key)
         pt = aes.decrypt(nonce, ct, None)
         return pt.decode("utf-8")
-    except (InvalidTag, ValueError, binascii.Error, TypeError, UnicodeDecodeError):
-        # 키 불일치/손상 등으로 복호화 실패: 원문 그대로 반환하여
-        # 상위 로직이 안전하게 실패하도록 함(크래시 방지)
-        return c
+    except (
+        InvalidTag,
+        ValueError,
+        binascii.Error,
+        TypeError,
+        UnicodeDecodeError,
+    ) as exc:
+        raise CryptoError("failed to decrypt push subscription field") from exc

--- a/apps/api/repositories/notifications.py
+++ b/apps/api/repositories/notifications.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import TypedDict, cast
 
 from sqlalchemy import CursorResult, delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
@@ -32,59 +33,66 @@ def hash_endpoint(endpoint: str) -> str:
     return _hash_endpoint(endpoint)
 
 
-async def upsert_subscription(
-    db: AsyncSession,
-    data: SubscriptionData,
-    *,
-    actor_member_id: int,
-) -> models.PushSubscription:
-    endpoint_plain = str(data.get("endpoint"))
-    endpoint_hash = _hash_endpoint(endpoint_plain)
-    endpoint = encrypt_str(endpoint_plain)
-    p256dh = encrypt_str(str(data.get("p256dh")))
-    auth = encrypt_str(str(data.get("auth")))
-
-    stmt = select(models.PushSubscription).where(
-        models.PushSubscription.endpoint_hash == endpoint_hash
-    )
-    result = await db.execute(stmt)
-    sub = result.scalars().first()
-
-    if sub is None:
-        sub = models.PushSubscription(
-            endpoint=endpoint,
-            p256dh=p256dh,
-            auth=auth,
-            ua=(data.get("ua") if data.get("ua") is not None else None),
-            member_id=int(actor_member_id),
-            endpoint_hash=endpoint_hash,
-        )
-        db.add(sub)
-        await db.commit()
-        await db.refresh(sub)
-        return sub
-
-    owner = _as_member_id(sub.member_id)
-    if owner is not None and owner != int(actor_member_id):
-        raise SubscriptionOwnershipError()
-
-    setattr(sub, "p256dh", p256dh)
-    setattr(sub, "auth", auth)
-    setattr(sub, "ua", (data.get("ua") if data.get("ua") is not None else None))
-    setattr(sub, "member_id", int(actor_member_id))
-    setattr(sub, "endpoint", endpoint)
-    setattr(sub, "endpoint_hash", endpoint_hash)
-    await db.commit()
-    await db.refresh(sub)
-    return sub
-
-
 def _as_member_id(raw: object) -> int | None:
     if raw is None:
         return None
     if isinstance(raw, int):
         return raw
     return int(str(raw))
+
+
+async def upsert_subscription(
+    db: AsyncSession,
+    data: SubscriptionData,
+    *,
+    actor_member_id: int,
+) -> models.PushSubscription:
+    """endpoint_hash 기준 원자적 upsert.
+
+    동시 INSERT는 ON CONFLICT로 직렬화한다. 충돌 후 WHERE로
+    NULL/본인 소유만 갱신하고, 타인 소유면 OwnershipError.
+    """
+    endpoint_plain = str(data.get("endpoint"))
+    endpoint_hash = _hash_endpoint(endpoint_plain)
+    endpoint = encrypt_str(endpoint_plain)
+    p256dh = encrypt_str(str(data.get("p256dh")))
+    auth = encrypt_str(str(data.get("auth")))
+    ua_val = data.get("ua") if data.get("ua") is not None else None
+    actor = int(actor_member_id)
+
+    insert_stmt = pg_insert(models.PushSubscription).values(
+        endpoint=endpoint,
+        p256dh=p256dh,
+        auth=auth,
+        ua=ua_val,
+        member_id=actor,
+        endpoint_hash=endpoint_hash,
+    )
+    stmt = insert_stmt.on_conflict_do_update(
+        index_elements=["endpoint_hash"],
+        set_={
+            "endpoint": insert_stmt.excluded.endpoint,
+            "p256dh": insert_stmt.excluded.p256dh,
+            "auth": insert_stmt.excluded.auth,
+            "ua": insert_stmt.excluded.ua,
+            "member_id": insert_stmt.excluded.member_id,
+        },
+        where=(
+            (models.PushSubscription.member_id.is_(None))
+            | (models.PushSubscription.member_id == actor)
+        ),
+    ).returning(models.PushSubscription)
+
+    result = await db.execute(stmt)
+    sub = result.scalars().first()
+    if sub is None:
+        # 타인 소유로 UPDATE WHERE가 매칭되지 않음
+        await db.rollback()
+        raise SubscriptionOwnershipError()
+
+    await db.commit()
+    await db.refresh(sub)
+    return sub
 
 
 async def delete_subscription(

--- a/apps/api/repositories/notifications.py
+++ b/apps/api/repositories/notifications.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Sequence
-from typing import TypedDict
+from typing import TypedDict, cast
 
-from sqlalchemy import select
+from sqlalchemy import CursorResult, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
@@ -19,12 +19,24 @@ class SubscriptionData(TypedDict, total=False):
     member_id: int | None
 
 
+class SubscriptionOwnershipError(Exception):
+    """구독 행이 다른 회원 소유일 때 발생."""
+
+
 def _hash_endpoint(endpoint: str) -> str:
     return hashlib.sha256(endpoint.encode()).hexdigest()
 
 
+def hash_endpoint(endpoint: str) -> str:
+    """공개 해시 헬퍼 (배치 삭제 등)."""
+    return _hash_endpoint(endpoint)
+
+
 async def upsert_subscription(
-    db: AsyncSession, data: SubscriptionData
+    db: AsyncSession,
+    data: SubscriptionData,
+    *,
+    actor_member_id: int,
 ) -> models.PushSubscription:
     endpoint_plain = str(data.get("endpoint"))
     endpoint_hash = _hash_endpoint(endpoint_plain)
@@ -39,13 +51,12 @@ async def upsert_subscription(
     sub = result.scalars().first()
 
     if sub is None:
-        member_val = data.get("member_id")
         sub = models.PushSubscription(
             endpoint=endpoint,
             p256dh=p256dh,
             auth=auth,
             ua=(data.get("ua") if data.get("ua") is not None else None),
-            member_id=(int(member_val) if member_val is not None else None),
+            member_id=int(actor_member_id),
             endpoint_hash=endpoint_hash,
         )
         db.add(sub)
@@ -53,13 +64,14 @@ async def upsert_subscription(
         await db.refresh(sub)
         return sub
 
-    # update
+    owner = _as_member_id(sub.member_id)
+    if owner is not None and owner != int(actor_member_id):
+        raise SubscriptionOwnershipError()
+
     setattr(sub, "p256dh", p256dh)
     setattr(sub, "auth", auth)
     setattr(sub, "ua", (data.get("ua") if data.get("ua") is not None else None))
-    member_val2 = data.get("member_id")
-    if member_val2 is not None:
-        setattr(sub, "member_id", int(member_val2))
+    setattr(sub, "member_id", int(actor_member_id))
     setattr(sub, "endpoint", endpoint)
     setattr(sub, "endpoint_hash", endpoint_hash)
     await db.commit()
@@ -67,7 +79,17 @@ async def upsert_subscription(
     return sub
 
 
-async def delete_subscription(db: AsyncSession, *, endpoint: str) -> None:
+def _as_member_id(raw: object) -> int | None:
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    return int(str(raw))
+
+
+async def delete_subscription(
+    db: AsyncSession, *, endpoint: str, actor_member_id: int
+) -> None:
     h = _hash_endpoint(endpoint)
     stmt = select(models.PushSubscription).where(
         models.PushSubscription.endpoint_hash == h
@@ -76,6 +98,9 @@ async def delete_subscription(db: AsyncSession, *, endpoint: str) -> None:
     sub = result.scalars().first()
     if sub is None:
         return
+    owner = _as_member_id(sub.member_id)
+    if owner is not None and owner != int(actor_member_id):
+        raise SubscriptionOwnershipError()
     await db.delete(sub)
     await db.commit()
 
@@ -90,13 +115,37 @@ async def list_active_subscriptions(
     return result.scalars().all()
 
 
-async def remove_by_endpoint(db: AsyncSession, *, endpoint: str) -> None:
-    h = _hash_endpoint(endpoint)
-    stmt = select(models.PushSubscription).where(
-        models.PushSubscription.endpoint_hash == h
+async def count_active_subscriptions(db: AsyncSession) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(models.PushSubscription)
+        .where(models.PushSubscription.revoked_at.is_(None))
     )
     result = await db.execute(stmt)
-    sub = result.scalars().first()
-    if sub:
-        await db.delete(sub)
+    return int(result.scalar() or 0)
+
+
+async def remove_by_endpoint(db: AsyncSession, *, endpoint: str) -> None:
+    """시스템(404/410) 정리용 — 소유권 검사 없음."""
+    h = _hash_endpoint(endpoint)
+    await remove_by_endpoint_hashes(db, [h])
+
+
+async def remove_by_endpoint_hashes(
+    db: AsyncSession, hashes: Sequence[str], *, batch_size: int = 100
+) -> int:
+    """endpoint_hash 목록으로 구독 행을 bounded batch DELETE."""
+    cleaned = [h for h in hashes if h]
+    if not cleaned:
+        return 0
+    total = 0
+    for i in range(0, len(cleaned), batch_size):
+        chunk = list(cleaned[i : i + batch_size])
+        stmt = delete(models.PushSubscription).where(
+            models.PushSubscription.endpoint_hash.in_(chunk)
+        )
+        result = await db.execute(stmt)
+        cursor = cast(CursorResult[object], result)
+        total += int(cursor.rowcount or 0)
         await db.commit()
+    return total

--- a/apps/api/repositories/send_logs.py
+++ b/apps/api/repositories/send_logs.py
@@ -33,9 +33,12 @@ class LogAggregates:
 
 @dataclass(frozen=True)
 class SendLogItem:
-    endpoint: str
     ok: bool
     status_code: int | None
+    # 평문 endpoint. 복호화 실패 시 None이고 stored_endpoint_hash를 쓴다.
+    endpoint: str | None = None
+    # 복호화 불가 시 DB에 저장된 endpoint_hash로 로그.
+    stored_endpoint_hash: str | None = None
 
 
 async def create_log(
@@ -62,7 +65,13 @@ async def create_logs_batch(
         return 0
     rows: list[models.NotificationSendLog] = []
     for item in items:
-        endpoint_hash, endpoint_tail = hash_endpoint(item.endpoint)
+        if item.stored_endpoint_hash:
+            endpoint_hash = item.stored_endpoint_hash
+            endpoint_tail = endpoint_hash[-16:]
+        elif item.endpoint:
+            endpoint_hash, endpoint_tail = hash_endpoint(item.endpoint)
+        else:
+            continue
         rows.append(
             models.NotificationSendLog(
                 ok=1 if item.ok else 0,
@@ -71,6 +80,8 @@ async def create_logs_batch(
                 endpoint_tail=endpoint_tail,
             )
         )
+    if not rows:
+        return 0
     db.add_all(rows)
     await db.commit()
     return len(rows)

--- a/apps/api/repositories/send_logs.py
+++ b/apps/api/repositories/send_logs.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime
+from http import HTTPStatus
 
 from sqlalchemy import delete, desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql import func
+from sqlalchemy.sql import case, func
 
 from .. import models
 
@@ -15,6 +17,25 @@ def hash_endpoint(endpoint: str) -> tuple[str, str]:
     h = hashlib.sha256(endpoint.encode()).hexdigest()
     tail = endpoint[-16:]
     return h, tail
+
+
+@dataclass(frozen=True)
+class LogAggregates:
+    accepted: int
+    failed: int
+    failed_404: int
+    failed_410: int
+
+    @property
+    def failed_other(self) -> int:
+        return self.failed - (self.failed_404 + self.failed_410)
+
+
+@dataclass(frozen=True)
+class SendLogItem:
+    endpoint: str
+    ok: bool
+    status_code: int | None
 
 
 async def create_log(
@@ -31,6 +52,28 @@ async def create_log(
     await db.commit()
     await db.refresh(row)
     return row
+
+
+async def create_logs_batch(
+    db: AsyncSession, items: Sequence[SendLogItem]
+) -> int:
+    """발송 로그를 한 트랜잭션에 batch insert."""
+    if not items:
+        return 0
+    rows: list[models.NotificationSendLog] = []
+    for item in items:
+        endpoint_hash, endpoint_tail = hash_endpoint(item.endpoint)
+        rows.append(
+            models.NotificationSendLog(
+                ok=1 if item.ok else 0,
+                status_code=item.status_code,
+                endpoint_hash=endpoint_hash,
+                endpoint_tail=endpoint_tail,
+            )
+        )
+    db.add_all(rows)
+    await db.commit()
+    return len(rows)
 
 
 async def list_recent(
@@ -59,6 +102,48 @@ async def list_since(
     )
     result = await db.execute(stmt)
     return result.scalars().all()
+
+
+async def aggregate_since(db: AsyncSession, *, cutoff: datetime) -> LogAggregates:
+    """기간 내 발송 로그를 DB aggregate로 집계 (전건 ORM 로드 없음)."""
+    ok_col = models.NotificationSendLog.ok
+    sc_col = models.NotificationSendLog.status_code
+    stmt = select(
+        func.coalesce(func.sum(case((ok_col != 0, 1), else_=0)), 0),
+        func.coalesce(func.sum(case((ok_col == 0, 1), else_=0)), 0),
+        func.coalesce(
+            func.sum(
+                case(
+                    (
+                        (ok_col == 0) & (sc_col == int(HTTPStatus.NOT_FOUND)),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ),
+            0,
+        ),
+        func.coalesce(
+            func.sum(
+                case(
+                    (
+                        (ok_col == 0) & (sc_col == int(HTTPStatus.GONE)),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ),
+            0,
+        ),
+    ).where(models.NotificationSendLog.created_at >= cutoff)
+    result = await db.execute(stmt)
+    row = result.one()
+    return LogAggregates(
+        accepted=int(row[0] or 0),
+        failed=int(row[1] or 0),
+        failed_404=int(row[2] or 0),
+        failed_410=int(row[3] or 0),
+    )
 
 
 async def prune_older_than_days(db: AsyncSession, *, days: int) -> int:

--- a/apps/api/routers/notifications.py
+++ b/apps/api/routers/notifications.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
-from http import HTTPStatus
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -10,6 +9,7 @@ from slowapi import Limiter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.config import get_settings
+from apps.api.crypto_utils import is_push_encryption_effective
 from apps.api.db import get_db
 from apps.api.ratelimit import consume_limit, get_client_ip_for_rate_limit
 from apps.api.repositories import notifications as subs_repo
@@ -65,8 +65,9 @@ async def save_subscription(
             "p256dh": payload.p256dh,
             "auth": payload.auth,
             "ua": payload.ua,
-            "member_id": _member.id,
+            "member_id": cast(int, _member.id),
         },
+        actor_member_id=cast(int, _member.id),
     )
 
 
@@ -87,7 +88,9 @@ async def delete_subscription(
         request,
         settings.rate_limit_subscribe,
     )
-    await notif_svc.delete_subscription(db, endpoint=str(payload.endpoint))
+    await notif_svc.delete_subscription(
+        db, endpoint=str(payload.endpoint), actor_member_id=cast(int, _member.id)
+    )
 
 
 class SendPushPayload(BaseModel):
@@ -181,34 +184,19 @@ async def get_stats(
     )
     cutoff = datetime.now(UTC_TZ) - delta
 
-    subs = await subs_repo.list_active_subscriptions(db)
-    logs = await logs_repo.list_since(db, cutoff=cutoff)
-    accepted = 0
-    failed = 0
-    f404 = 0
-    f410 = 0
-    for rlog in logs:
-        ok_v = int(cast(int, getattr(rlog, "ok", 0)))
-        sc = cast(int | None, getattr(rlog, "status_code", None))
-        if ok_v != 0:
-            accepted += 1
-        else:
-            failed += 1
-            if sc == int(HTTPStatus.NOT_FOUND):
-                f404 += 1
-            elif sc == int(HTTPStatus.GONE):
-                f410 += 1
-    fother = failed - (f404 + f410)
+    active = await subs_repo.count_active_subscriptions(db)
+    agg = await logs_repo.aggregate_since(db, cutoff=cutoff)
     settings = get_settings()
+
     return NotificationStats(
-        active_subscriptions=len(subs),
-        recent_accepted=accepted,
-        recent_failed=failed,
-        encryption_enabled=bool(settings.push_encrypt_at_rest),
+        active_subscriptions=active,
+        recent_accepted=agg.accepted,
+        recent_failed=agg.failed,
+        encryption_enabled=is_push_encryption_effective(settings),
         range=r,
-        failed_404=f404,
-        failed_410=f410,
-        failed_other=fother,
+        failed_404=agg.failed_404,
+        failed_410=agg.failed_410,
+        failed_other=agg.failed_other,
     )
 
 

--- a/apps/api/services/notifications_service.py
+++ b/apps/api/services/notifications_service.py
@@ -11,7 +11,7 @@ from requests.exceptions import RequestException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
-from ..crypto_utils import decrypt_str
+from ..crypto_utils import CryptoError, decrypt_str
 from ..errors import ApiError
 from ..models import PushSubscription
 from ..repositories import notifications as repo
@@ -42,9 +42,13 @@ class PyWebPushProvider:
     def send(
         self, sub: PushSubscription, payload: dict[str, Any]
     ) -> tuple[bool, int | None]:
-        endpoint = decrypt_str(cast(str, sub.endpoint))
-        p256dh = decrypt_str(cast(str, sub.p256dh))
-        auth = decrypt_str(cast(str, sub.auth))
+        try:
+            endpoint = decrypt_str(cast(str, sub.endpoint))
+            p256dh = decrypt_str(cast(str, sub.p256dh))
+            auth = decrypt_str(cast(str, sub.auth))
+        except CryptoError:
+            # 손상·키불일치 구독은 평문 전송 없이 실패 처리
+            return (False, None)
         subscription_info = {
             "endpoint": endpoint,
             "keys": {"p256dh": p256dh, "auth": auth},
@@ -125,11 +129,22 @@ async def send_to_all(
     failed = 0
     log_items: list[SendLogItem] = []
     expired_hashes: list[str] = []
+    payload = {"title": title, "body": body, **({"url": url} if url else {})}
     for sub in subs:
-        endpoint_plain = decrypt_str(cast(str, sub.endpoint))
-        ok, status = await provider.send_async(
-            sub, {"title": title, "body": body, **({"url": url} if url else {})}
-        )
+        try:
+            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+        except CryptoError:
+            failed += 1
+            log_items.append(
+                SendLogItem(
+                    ok=False,
+                    status_code=None,
+                    stored_endpoint_hash=cast(str, sub.endpoint_hash),
+                )
+            )
+            continue
+
+        ok, status = await provider.send_async(sub, payload)
         if ok:
             accepted += 1
         else:

--- a/apps/api/services/notifications_service.py
+++ b/apps/api/services/notifications_service.py
@@ -12,10 +12,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
 from ..crypto_utils import decrypt_str
+from ..errors import ApiError
 from ..models import PushSubscription
 from ..repositories import notifications as repo
 from ..repositories import send_logs
-from ..repositories.notifications import SubscriptionData
+from ..repositories.notifications import SubscriptionData, SubscriptionOwnershipError
+from ..repositories.send_logs import SendLogItem
 
 
 class PushProvider(Protocol):
@@ -82,12 +84,32 @@ class SendResult:
     failed: int
 
 
-async def save_subscription(db: AsyncSession, data: SubscriptionData) -> None:
-    await repo.upsert_subscription(db, data)
+def _ownership_error() -> ApiError:
+    return ApiError(
+        code="subscription_forbidden",
+        detail="subscription_forbidden",
+        status=403,
+    )
 
 
-async def delete_subscription(db: AsyncSession, *, endpoint: str) -> None:
-    await repo.delete_subscription(db, endpoint=endpoint)
+async def save_subscription(
+    db: AsyncSession, data: SubscriptionData, *, actor_member_id: int
+) -> None:
+    try:
+        await repo.upsert_subscription(db, data, actor_member_id=actor_member_id)
+    except SubscriptionOwnershipError as exc:
+        raise _ownership_error() from exc
+
+
+async def delete_subscription(
+    db: AsyncSession, *, endpoint: str, actor_member_id: int
+) -> None:
+    try:
+        await repo.delete_subscription(
+            db, endpoint=endpoint, actor_member_id=actor_member_id
+        )
+    except SubscriptionOwnershipError as exc:
+        raise _ownership_error() from exc
 
 
 async def send_to_all(
@@ -101,6 +123,8 @@ async def send_to_all(
     subs = await repo.list_active_subscriptions(db)
     accepted = 0
     failed = 0
+    log_items: list[SendLogItem] = []
+    expired_hashes: list[str] = []
     for sub in subs:
         endpoint_plain = decrypt_str(cast(str, sub.endpoint))
         ok, status = await provider.send_async(
@@ -111,9 +135,11 @@ async def send_to_all(
         else:
             failed += 1
             if status in (404, 410):
-                await repo.remove_by_endpoint(db, endpoint=endpoint_plain)
-        # 발송 로그(민감정보 해시 보관)
-        await send_logs.create_log(
-            db, endpoint=endpoint_plain, ok=ok, status_code=status
+                expired_hashes.append(repo.hash_endpoint(endpoint_plain))
+        log_items.append(
+            SendLogItem(endpoint=endpoint_plain, ok=ok, status_code=status)
         )
+    # DB: 발송 로그·만료 구독 정리는 bounded batch commit
+    await send_logs.create_logs_batch(db, log_items)
+    await repo.remove_by_endpoint_hashes(db, expired_hashes)
     return SendResult(accepted=accepted, failed=failed)

--- a/apps/api/services/scheduled_notifications_service.py
+++ b/apps/api/services/scheduled_notifications_service.py
@@ -8,11 +8,13 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal, cast
 
+from requests.exceptions import RequestException
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..crypto_utils import decrypt_str
+from ..crypto_utils import CryptoError, decrypt_str
 from ..models import Event, PushSubscription, ScheduledNotificationLog
 from ..repositories import notification_preferences as pref_repo
 from ..repositories import notifications as subs_repo
@@ -128,7 +130,19 @@ async def send_batch_notifications(
         expired_hashes: list[str] = []
 
         for sub in batch:
-            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+            try:
+                endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+            except CryptoError:
+                failed += 1
+                log_items.append(
+                    send_logs.SendLogItem(
+                        ok=False,
+                        status_code=None,
+                        stored_endpoint_hash=cast(str, sub.endpoint_hash),
+                    )
+                )
+                continue
+
             ok, status = await _send_with_retry(
                 provider, sub, payload, max_retries=cfg.max_retries
             )
@@ -188,8 +202,8 @@ async def create_notification_log(
 ) -> ScheduledNotificationLog | None:
     """발송 로그 생성 (중복 방지용).
 
-    ON CONFLICT DO NOTHING 사용으로 동시 삽입 시 레이스 컨디션 방지.
-    이미 존재하는 경우 None 반환.
+    신규 INSERT. 이미 completed/in_progress면 None.
+    failed 행은 재시도 가능하도록 pending으로 회수한다.
     """
     stmt = (
         pg_insert(ScheduledNotificationLog)
@@ -198,13 +212,29 @@ async def create_notification_log(
             d_type=d_type,
             scheduled_at=scheduled_at,
             status="pending",
+            accepted_count=0,
+            failed_count=0,
         )
-        .on_conflict_do_nothing(index_elements=["event_id", "d_type"])
+        .on_conflict_do_update(
+            index_elements=["event_id", "d_type"],
+            set_={
+                "status": "pending",
+                "scheduled_at": scheduled_at,
+                "accepted_count": 0,
+                "failed_count": 0,
+                "sent_at": None,
+            },
+            where=(ScheduledNotificationLog.status == "failed"),
+        )
         .returning(ScheduledNotificationLog)
     )
     result = await db.execute(stmt)
+    row = result.scalars().first()
     await db.commit()
-    return result.scalars().first()  # None if conflict
+    if row is not None:
+        # ON CONFLICT UPDATE 시 identity map에 남은 이전 status를 갱신
+        await db.refresh(row)
+    return row
 
 
 async def update_notification_log(
@@ -306,10 +336,36 @@ async def process_single_event(
         "url": f"/events/{event_id}",
     }
 
-    # 배치 발송
-    result = await send_batch_notifications(
-        db, provider, subscriptions=subs, payload=payload
-    )
+    # 배치 발송 — 예외 시 failed로 마감해 in_progress 고착·재시도 불가 방지
+    try:
+        result = await send_batch_notifications(
+            db, provider, subscriptions=subs, payload=payload
+        )
+    except (
+        RuntimeError,
+        TypeError,
+        ValueError,
+        OSError,
+        RequestException,
+        SQLAlchemyError,
+    ):
+        logger.exception(
+            "예약 발송 실패: event_id=%s, d_type=%s", event_id, d_type
+        )
+        await update_notification_log(
+            db,
+            log_id,
+            status="failed",
+            accepted_count=0,
+            failed_count=len(subs),
+        )
+        return ProcessResult(
+            event_id=event_id,
+            d_type=d_type,
+            skipped=False,
+            accepted=0,
+            failed=len(subs),
+        )
 
     await update_notification_log(
         db,

--- a/apps/api/services/scheduled_notifications_service.py
+++ b/apps/api/services/scheduled_notifications_service.py
@@ -124,6 +124,8 @@ async def send_batch_notifications(
     subs_list = list(subscriptions)
     for i in range(0, len(subs_list), cfg.batch_size):
         batch = subs_list[i : i + cfg.batch_size]
+        log_items: list[send_logs.SendLogItem] = []
+        expired_hashes: list[str] = []
 
         for sub in batch:
             endpoint_plain = decrypt_str(cast(str, sub.endpoint))
@@ -136,11 +138,16 @@ async def send_batch_notifications(
             else:
                 failed += 1
                 if status in (404, 410):
-                    await subs_repo.remove_by_endpoint(db, endpoint=endpoint_plain)
+                    expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
 
-            await send_logs.create_log(
-                db, endpoint=endpoint_plain, ok=ok, status_code=status
+            log_items.append(
+                send_logs.SendLogItem(
+                    endpoint=endpoint_plain, ok=ok, status_code=status
+                )
             )
+
+        await send_logs.create_logs_batch(db, log_items)
+        await subs_repo.remove_by_endpoint_hashes(db, expired_hashes)
 
         # 배치 간 딜레이 (레이트리밋 준수)
         if i + cfg.batch_size < len(subs_list):

--- a/docs/dev_log_260801.md
+++ b/docs/dev_log_260801.md
@@ -2,8 +2,9 @@
 
 ## D3 푸시 구독 보안·성능 (#248/#250/#264)
 
-- Ownership (#248): `upsert_subscription`/`delete_subscription`가 actor `member_id`와 행 소유자를 대조. 타인 소유 → `403` `subscription_forbidden`. 없는 delete는 204. NULL `member_id` 레거시는 귀속 허용.
+- Ownership (#248): `upsert_subscription`/`delete_subscription`가 actor `member_id`와 행 소유자를 대조. 타인 소유 → `403` `subscription_forbidden`. 없는 delete는 204. NULL `member_id` 레거시는 귀속 허용. upsert는 `ON CONFLICT (endpoint_hash)`로 동시 재동기화 원자화.
 - Crypto (#250): `PUSH_ENCRYPT_AT_REST=true` 시 Settings 기동에서 `PUSH_KEK` base64·길이(16/24/32) fail-closed. `decrypt_str`는 `enc:v1:` 복호화 실패 시 `CryptoError`. stats `encryption_enabled`는 effective 설정.
 - Perf (#264): stats는 `count_active_subscriptions` + `aggregate_since`. `send_to_all`/예약 발송은 `create_logs_batch` + `remove_by_endpoint_hashes`(100개 단위).
+- Review follow-up: 발송 경로에서 `CryptoError`를 구독별 실패로 격리(평문 전송 금지). 예약 발송 예외는 `failed` 마감 + failed 행 재시도 회수. 관리자 `send_to_all`은 손상 구독 하나로 전체 중단하지 않음.
 - Tests: `tests/api/test_d3_push_authority.py`, `test_crypto_utils.py` TEST DRIFT(암호문 그대로 반환) 제거.
 - Docs: `docs/pwa_push.md` 소유권·fail-closed·배치 계약 반영.

--- a/docs/dev_log_260801.md
+++ b/docs/dev_log_260801.md
@@ -1,0 +1,9 @@
+# Dev Log 2026-08-01
+
+## D3 푸시 구독 보안·성능 (#248/#250/#264)
+
+- Ownership (#248): `upsert_subscription`/`delete_subscription`가 actor `member_id`와 행 소유자를 대조. 타인 소유 → `403` `subscription_forbidden`. 없는 delete는 204. NULL `member_id` 레거시는 귀속 허용.
+- Crypto (#250): `PUSH_ENCRYPT_AT_REST=true` 시 Settings 기동에서 `PUSH_KEK` base64·길이(16/24/32) fail-closed. `decrypt_str`는 `enc:v1:` 복호화 실패 시 `CryptoError`. stats `encryption_enabled`는 effective 설정.
+- Perf (#264): stats는 `count_active_subscriptions` + `aggregate_since`. `send_to_all`/예약 발송은 `create_logs_batch` + `remove_by_endpoint_hashes`(100개 단위).
+- Tests: `tests/api/test_d3_push_authority.py`, `test_crypto_utils.py` TEST DRIFT(암호문 그대로 반환) 제거.
+- Docs: `docs/pwa_push.md` 소유권·fail-closed·배치 계약 반영.

--- a/docs/pwa_push.md
+++ b/docs/pwa_push.md
@@ -78,9 +78,10 @@ at-rest 암호화용 `PUSH_KEK`가 필요한 경우: `openssl rand -base64 32`
 - `POST /notifications/subscriptions`
   - req: `{ endpoint, keys: { p256dh, auth }, ua? }`
   - res: `204 No Content`
+  - 소유권: 동일 `endpoint_hash`가 다른 회원 소유면 `403` `subscription_forbidden`. `member_id`가 NULL인 레거시 행은 요청자 귀속 허용.
 - `DELETE /notifications/subscriptions`
   - req: `{ endpoint }`
-  - res: `204 No Content`
+  - res: `204 No Content` (행 없음도 idempotent 204). 타인 소유면 `403` `subscription_forbidden`.
 - `POST /notifications/admin/notifications/send` (운영자)
   - req: `{ title, body, url? }`
   - res: `{ accepted: number, failed: number }`
@@ -108,6 +109,11 @@ at-rest 암호화용 `PUSH_KEK`가 필요한 경우: `openssl rand -base64 32`
 4. APScheduler(혹은 워커)로 예약 발송(D-3/D-1) 큐 실행. 배치 크기/재시도/백오프 설정.
 5. 운영자 알림 발송 API 제공.
 6. (선택) at-rest 암호화 활성화: `PUSH_ENCRYPT_AT_REST=true`, `PUSH_KEK` 설정. 저장 시 endpoint/p256dh/auth를 AES-GCM으로 암호화하고, 해시(`endpoint_hash`)로 조회·삭제.
+   - **fail-closed:** `PUSH_ENCRYPT_AT_REST=true`이면 기동 시 `PUSH_KEK`가 base64로 디코드되어 길이 16/24/32여야 한다. 아니면 프로세스 기동 실패.
+   - `enc:v1:` 접두 값의 복호화 실패는 예외(평문처럼 반환하지 않음). 접두 없는 값은 평문 호환.
+   - stats의 `encryption_enabled`는 플래그만이 아니라 유효 KEK까지 포함한 effective 상태.
+   - 기존 평문 구독의 자동 일괄 재암호화는 하지 않는다. KEK 교체는 `ops/rekey_push_kek.py` 운영 절차를 사용한다.
+7. 발송/통계 성능: stats는 DB aggregate(`COUNT`/`FILTER`), `send_to_all`은 로그 batch insert + 만료 endpoint_hash bounded batch DELETE(커밋 수 bounded). 푸시 자체는 롤백 불가.
 
 ## 권한·UX 원칙
 - 옵트인: 기본 비활성. 사용자 의식적 동의 후 구독 저장.

--- a/tests/api/test_crypto_utils.py
+++ b/tests/api/test_crypto_utils.py
@@ -3,27 +3,68 @@ from __future__ import annotations
 import base64
 import os
 
-from apps.api.config import reset_settings_cache
-from apps.api.crypto_utils import decrypt_str, encrypt_str
+import pytest
+from pydantic import ValidationError
+
+from apps.api.config import Settings, reset_settings_cache
+from apps.api.crypto_utils import CryptoError, decrypt_str, encrypt_str
+
+_PG = "postgresql+psycopg://app:devpass@localhost:5434/appdb_test"
 
 
-def test_decrypt_returns_ciphertext_on_key_mismatch() -> None:
-    # Enable encryption with KEK-A
+def test_decrypt_raises_on_key_mismatch() -> None:
     os.environ["PUSH_ENCRYPT_AT_REST"] = "true"
     os.environ["PUSH_KEK"] = base64.b64encode(os.urandom(32)).decode()
     reset_settings_cache()
     ct = encrypt_str("hello")
     assert ct.startswith("enc:v1:")
 
-    # Rotate to KEK-B (mismatch)
     os.environ["PUSH_KEK"] = base64.b64encode(os.urandom(32)).decode()
     reset_settings_cache()
 
-    # decrypt_str should not raise; it should return the ciphertext unchanged
-    out = decrypt_str(ct)
-    assert out == ct
+    with pytest.raises(CryptoError):
+        decrypt_str(ct)
 
-    # Cleanup
     os.environ.pop("PUSH_ENCRYPT_AT_REST", None)
     os.environ.pop("PUSH_KEK", None)
     reset_settings_cache()
+
+
+def test_decrypt_plaintext_without_prefix() -> None:
+    os.environ.pop("PUSH_ENCRYPT_AT_REST", None)
+    os.environ.pop("PUSH_KEK", None)
+    reset_settings_cache()
+    assert decrypt_str("plain-endpoint") == "plain-endpoint"
+
+
+def test_encrypt_roundtrip() -> None:
+    os.environ["PUSH_ENCRYPT_AT_REST"] = "true"
+    os.environ["PUSH_KEK"] = base64.b64encode(os.urandom(32)).decode()
+    reset_settings_cache()
+    try:
+        ct = encrypt_str("roundtrip-value")
+        assert ct.startswith("enc:v1:")
+        assert decrypt_str(ct) == "roundtrip-value"
+    finally:
+        os.environ.pop("PUSH_ENCRYPT_AT_REST", None)
+        os.environ.pop("PUSH_KEK", None)
+        reset_settings_cache()
+
+
+def test_settings_reject_encrypt_without_valid_kek(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("DATABASE_URL", _PG)
+    monkeypatch.setenv("PUSH_ENCRYPT_AT_REST", "true")
+    monkeypatch.setenv("PUSH_KEK", "not-valid-base64!!!")
+    with pytest.raises(ValidationError):
+        Settings()
+
+    monkeypatch.setenv("PUSH_KEK", base64.b64encode(b"short").decode())
+    with pytest.raises(ValidationError):
+        Settings()
+
+    monkeypatch.setenv("PUSH_KEK", "")
+    with pytest.raises(ValidationError):
+        Settings()

--- a/tests/api/test_d3_push_authority.py
+++ b/tests/api/test_d3_push_authority.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from typing import Any
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api import models
+from apps.api.config import get_settings, reset_settings_cache
+from apps.api.crypto_utils import is_push_encryption_effective
+from apps.api.db import get_db
+from apps.api.main import app
+from apps.api.repositories import notifications as subs_repo
+from apps.api.repositories import send_logs as logs_repo
+from apps.api.routers import notifications as router_mod
+from apps.api.services import notifications_service as notif_svc
+from apps.api.services.notifications_service import PushProvider
+
+
+def _run_in_test_session(
+    operation: Callable[[AsyncSession], Awaitable[None]],
+) -> None:
+    override = app.dependency_overrides.get(get_db)
+    if override is None:
+        raise RuntimeError("get_db override not found")
+
+    async def _run() -> None:
+        async for session in override():
+            await operation(session)
+            return
+        raise RuntimeError("test session was not yielded")
+
+    asyncio.run(_run())
+
+
+def _seed_member(
+    *,
+    student_id: str,
+    password: str = "test-pass",
+    roles: str = "member",
+) -> int:
+    holder = {"member_id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        member = models.Member(
+            student_id=student_id,
+            email=f"{student_id}@example.com",
+            name=student_id,
+            cohort=1,
+            roles=roles,
+            status="active",
+        )
+        session.add(member)
+        await session.flush()
+        session.add(
+            models.MemberAuth(
+                member_id=member.id,
+                student_id=student_id,
+                password_hash=bcrypt.hashpw(
+                    password.encode(), bcrypt.gensalt()
+                ).decode(),
+            )
+        )
+        await session.commit()
+        holder["member_id"] = int(member.id)
+
+    _run_in_test_session(_seed)
+    return holder["member_id"]
+
+
+def _login_member(
+    client: TestClient, *, student_id: str, password: str = "test-pass"
+) -> None:
+    response = client.post(
+        "/auth/member/login",
+        json={"student_id": student_id, "password": password},
+    )
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_subscription_ownership_upsert_and_delete(client: TestClient) -> None:
+    owner_id = _seed_member(student_id="d3-owner")
+    _seed_member(student_id="d3-other")
+    endpoint = "https://example.com/push/d3-ownership"
+
+    _login_member(client, student_id="d3-owner")
+    ok = client.post(
+        "/notifications/subscriptions",
+        json={"endpoint": endpoint, "p256dh": "k", "auth": "a"},
+    )
+    assert ok.status_code == HTTPStatus.NO_CONTENT
+
+    _login_member(client, student_id="d3-other")
+    takeover = client.post(
+        "/notifications/subscriptions",
+        json={"endpoint": endpoint, "p256dh": "k2", "auth": "a2"},
+    )
+    assert takeover.status_code == HTTPStatus.FORBIDDEN
+    body = takeover.json()
+    assert body["code"] == "subscription_forbidden"
+    assert "endpoint" not in body.get("detail", "").lower()
+
+    steal_delete = client.request(
+        "DELETE",
+        "/notifications/subscriptions",
+        json={"endpoint": endpoint},
+    )
+    assert steal_delete.status_code == HTTPStatus.FORBIDDEN
+    assert steal_delete.json()["code"] == "subscription_forbidden"
+
+    _login_member(client, student_id="d3-owner")
+    own_delete = client.request(
+        "DELETE",
+        "/notifications/subscriptions",
+        json={"endpoint": endpoint},
+    )
+    assert own_delete.status_code == HTTPStatus.NO_CONTENT
+
+    missing = client.request(
+        "DELETE",
+        "/notifications/subscriptions",
+        json={"endpoint": endpoint},
+    )
+    assert missing.status_code == HTTPStatus.NO_CONTENT
+
+    # 레거시 member_id NULL 행은 actor에게 귀속 허용
+    async def _seed_legacy(session: AsyncSession) -> None:
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/d3-legacy",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+        result = await session.execute(
+            select(models.PushSubscription).where(
+                models.PushSubscription.endpoint_hash
+                == subs_repo.hash_endpoint("https://example.com/push/d3-legacy")
+            )
+        )
+        row = result.scalars().first()
+        assert row is not None
+        setattr(row, "member_id", None)
+        await session.commit()
+
+    _run_in_test_session(_seed_legacy)
+
+    _login_member(client, student_id="d3-other")
+    claim = client.post(
+        "/notifications/subscriptions",
+        json={
+            "endpoint": "https://example.com/push/d3-legacy",
+            "p256dh": "p2",
+            "auth": "a2",
+        },
+    )
+    assert claim.status_code == HTTPStatus.NO_CONTENT
+
+
+def test_stats_encryption_enabled_matches_effective(
+    admin_login: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PUSH_ENCRYPT_AT_REST", raising=False)
+    monkeypatch.delenv("PUSH_KEK", raising=False)
+    reset_settings_cache()
+    res = admin_login.get("/notifications/admin/notifications/stats?range=7d")
+    assert res.status_code == HTTPStatus.OK
+    assert res.json()["encryption_enabled"] is False
+    assert is_push_encryption_effective(get_settings()) is False
+
+
+def test_stats_aggregate_matches_list_counts(admin_login: TestClient) -> None:
+    member_id = _seed_member(student_id="d3-stats-owner")
+
+    async def _seed(session: AsyncSession) -> None:
+        now = datetime.now(tz=UTC)
+        await logs_repo.create_log(
+            session, endpoint="https://example.com/a", ok=True, status_code=201
+        )
+        await logs_repo.create_log(
+            session, endpoint="https://example.com/b", ok=False, status_code=404
+        )
+        await logs_repo.create_log(
+            session, endpoint="https://example.com/c", ok=False, status_code=410
+        )
+        await logs_repo.create_log(
+            session, endpoint="https://example.com/d", ok=False, status_code=500
+        )
+        # 범위 밖
+        old = models.NotificationSendLog(
+            ok=1,
+            status_code=201,
+            endpoint_hash="old",
+            endpoint_tail="old-tail",
+            created_at=now - timedelta(days=40),
+        )
+        session.add(old)
+        await session.commit()
+
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/stats-sub",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=member_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    cutoff = datetime.now(tz=UTC) - timedelta(days=7)
+
+    async def _compare(session: AsyncSession) -> None:
+        agg = await logs_repo.aggregate_since(session, cutoff=cutoff)
+        logs = await logs_repo.list_since(session, cutoff=cutoff)
+        accepted = sum(1 for r in logs if int(r.ok) != 0)
+        failed = sum(1 for r in logs if int(r.ok) == 0)
+        f404 = sum(
+            1
+            for r in logs
+            if int(r.ok) == 0 and r.status_code == int(HTTPStatus.NOT_FOUND)
+        )
+        f410 = sum(
+            1
+            for r in logs
+            if int(r.ok) == 0 and r.status_code == int(HTTPStatus.GONE)
+        )
+        assert agg.accepted == accepted
+        assert agg.failed == failed
+        assert agg.failed_404 == f404
+        assert agg.failed_410 == f410
+        active = await subs_repo.count_active_subscriptions(session)
+        listed = await subs_repo.list_active_subscriptions(session)
+        assert active == len(listed)
+
+    _run_in_test_session(_compare)
+
+    res = admin_login.get("/notifications/admin/notifications/stats?range=7d")
+    assert res.status_code == HTTPStatus.OK
+    data = res.json()
+    assert data["recent_accepted"] >= 1
+    assert data["recent_failed"] >= 3
+    assert data["failed_404"] >= 1
+    assert data["failed_410"] >= 1
+    assert data["failed_other"] >= 1
+
+
+def test_send_to_all_batches_logs_and_expired_deletes(
+    admin_login: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    owner_id = _seed_member(student_id="d3-batch-owner")
+    endpoints = [f"https://example.com/push/batch/{i}" for i in range(12)]
+
+    async def _seed(session: AsyncSession) -> None:
+        for ep in endpoints:
+            await subs_repo.upsert_subscription(
+                session,
+                {"endpoint": ep, "p256dh": "p", "auth": "a"},
+                actor_member_id=owner_id,
+            )
+
+    _run_in_test_session(_seed)
+
+    class _Dummy(PushProvider):
+        def __init__(self) -> None:
+            self._n = 0
+
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            self._n += 1
+            if self._n % 2 == 0:
+                return (False, 404)
+            return (True, 201)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    provider = _Dummy()
+
+    batch_calls = {"logs": 0, "removes": 0}
+    real_create = logs_repo.create_logs_batch
+    real_remove = subs_repo.remove_by_endpoint_hashes
+
+    async def _count_logs(db: AsyncSession, items: Any) -> int:
+        batch_calls["logs"] += 1
+        return await real_create(db, items)
+
+    async def _count_remove(db: AsyncSession, hashes: Any, **kwargs: Any) -> int:
+        batch_calls["removes"] += 1
+        return await real_remove(db, hashes, **kwargs)
+
+    monkeypatch.setattr(logs_repo, "create_logs_batch", _count_logs)
+    monkeypatch.setattr(notif_svc.send_logs, "create_logs_batch", _count_logs)
+    monkeypatch.setattr(subs_repo, "remove_by_endpoint_hashes", _count_remove)
+    monkeypatch.setattr(notif_svc.repo, "remove_by_endpoint_hashes", _count_remove)
+
+    app.dependency_overrides[router_mod.get_push_provider] = lambda: provider
+    try:
+        res = admin_login.post(
+            "/notifications/admin/notifications/send",
+            json={"title": "t", "body": "b"},
+        )
+        assert res.status_code in (HTTPStatus.ACCEPTED, HTTPStatus.OK)
+        body = res.json()
+        assert body["accepted"] + body["failed"] == 12
+        assert batch_calls["logs"] == 1
+        assert batch_calls["removes"] == 1
+        assert body["failed"] >= 1
+        assert body["accepted"] >= 1
+    finally:
+        app.dependency_overrides.pop(router_mod.get_push_provider, None)
+
+
+def test_remove_by_endpoint_hashes_bounded_batches() -> None:
+    calls = {"commits": 0}
+
+    class _FakeResult:
+        rowcount = 3
+
+    class _FakeSession:
+        async def execute(self, _stmt: object) -> _FakeResult:
+            return _FakeResult()
+
+        async def commit(self) -> None:
+            calls["commits"] += 1
+
+    hashes = [f"h{i:03d}" for i in range(250)]
+    removed = asyncio.run(
+        subs_repo.remove_by_endpoint_hashes(_FakeSession(), hashes, batch_size=100)
+    )
+    assert removed == 9  # 3 batches * rowcount 3
+    assert calls["commits"] == 3
+
+
+def test_create_logs_batch_single_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = {"n": 0}
+
+    class _FakeSession:
+        def add_all(self, _rows: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            commits["n"] += 1
+
+    items = [
+        logs_repo.SendLogItem(endpoint=f"https://e/{i}", ok=True, status_code=201)
+        for i in range(5)
+    ]
+    n = asyncio.run(logs_repo.create_logs_batch(_FakeSession(), items))
+    assert n == 5
+    assert commits["n"] == 1

--- a/tests/api/test_d3_push_authority.py
+++ b/tests/api/test_d3_push_authority.py
@@ -21,6 +21,7 @@ from apps.api.repositories import notifications as subs_repo
 from apps.api.repositories import send_logs as logs_repo
 from apps.api.routers import notifications as router_mod
 from apps.api.services import notifications_service as notif_svc
+from apps.api.services import scheduled_notifications_service as sched
 from apps.api.services.notifications_service import PushProvider
 
 
@@ -362,3 +363,158 @@ def test_create_logs_batch_single_commit(monkeypatch: pytest.MonkeyPatch) -> Non
     n = asyncio.run(logs_repo.create_logs_batch(_FakeSession(), items))
     assert n == 5
     assert commits["n"] == 1
+
+
+def test_send_to_all_isolates_crypto_failure_per_subscription(
+    admin_login: TestClient,
+) -> None:
+    owner_id = _seed_member(student_id="d3-crypto-iso")
+    good_ep = "https://example.com/push/crypto-good"
+    bad_hash = subs_repo.hash_endpoint("https://example.com/push/crypto-bad")
+
+    async def _seed(session: AsyncSession) -> None:
+        await subs_repo.upsert_subscription(
+            session,
+            {"endpoint": good_ep, "p256dh": "p", "auth": "a"},
+            actor_member_id=owner_id,
+        )
+        session.add(
+            models.PushSubscription(
+                endpoint="enc:v1:not-a-real-ciphertext",
+                p256dh="enc:v1:bad",
+                auth="enc:v1:bad",
+                endpoint_hash=bad_hash,
+                member_id=owner_id,
+            )
+        )
+        await session.commit()
+
+    _run_in_test_session(_seed)
+
+    class _Dummy(PushProvider):
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return (True, 201)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    provider = _Dummy()
+    app.dependency_overrides[router_mod.get_push_provider] = lambda: provider
+    try:
+        res = admin_login.post(
+            "/notifications/admin/notifications/send",
+            json={"title": "t", "body": "b"},
+        )
+        assert res.status_code == HTTPStatus.ACCEPTED
+        body = res.json()
+        assert body["accepted"] >= 1
+        assert body["failed"] >= 1
+        assert body["accepted"] + body["failed"] >= 2
+    finally:
+        app.dependency_overrides.pop(router_mod.get_push_provider, None)
+
+
+def test_process_single_event_marks_failed_on_batch_exception(
+    client: TestClient,
+) -> None:
+    owner_id = _seed_member(student_id="d3-sched-fail")
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="d3-sched",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/sched-fail",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    class _Boom(PushProvider):
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            raise RuntimeError("provider boom")
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    async def _run(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(
+            session, _Boom(), event, "d-3"
+        )
+        assert result.skipped is False
+        assert result.failed >= 1
+        assert await sched.is_already_sent(
+            session, event_id=event_holder["id"], d_type="d-3"
+        ) is False
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "failed"
+
+        # failed 행은 재시도 시 회수 가능해야 함
+        reclaim = await sched.create_notification_log(
+            session,
+            event_id=event_holder["id"],
+            d_type="d-3",
+            scheduled_at=datetime.now(tz=UTC),
+        )
+        assert reclaim is not None
+        assert str(reclaim.status) == "pending"
+
+    _run_in_test_session(_run)
+
+
+def test_upsert_same_actor_idempotent_other_forbidden(client: TestClient) -> None:
+    owner_id = _seed_member(student_id="d3-upsert-a")
+    other_id = _seed_member(student_id="d3-upsert-b")
+    endpoint = "https://example.com/push/upsert-race"
+
+    async def _run(session: AsyncSession) -> None:
+        await subs_repo.upsert_subscription(
+            session,
+            {"endpoint": endpoint, "p256dh": "p1", "auth": "a1"},
+            actor_member_id=owner_id,
+        )
+        again = await subs_repo.upsert_subscription(
+            session,
+            {"endpoint": endpoint, "p256dh": "p2", "auth": "a2"},
+            actor_member_id=owner_id,
+        )
+        assert int(again.member_id) == owner_id
+        with pytest.raises(subs_repo.SubscriptionOwnershipError):
+            await subs_repo.upsert_subscription(
+                session,
+                {"endpoint": endpoint, "p256dh": "p3", "auth": "a3"},
+                actor_member_id=other_id,
+            )
+
+    _run_in_test_session(_run)

--- a/tests/api/test_notifications_encrypt.py
+++ b/tests/api/test_notifications_encrypt.py
@@ -37,6 +37,16 @@ def test_subscription_encrypted_at_rest_and_logged_plain_tail(
 
         async def _seed_subscription() -> None:
             async for db in override():
+                member = models.Member(
+                    student_id="enc-seed-member",
+                    email="enc-seed@example.com",
+                    name="Enc Seed",
+                    cohort=1,
+                    roles="member",
+                    status="active",
+                )
+                db.add(member)
+                await db.flush()
                 await subs_repo.upsert_subscription(
                     db,
                     {
@@ -44,6 +54,7 @@ def test_subscription_encrypted_at_rest_and_logged_plain_tail(
                         "p256dh": "p",
                         "auth": "a",
                     },
+                    actor_member_id=int(member.id),
                 )
                 PS = models.PushSubscription
                 stmt = select(PS)


### PR DESCRIPTION
## Summary
- Closes #248: 구독 upsert/delete 소유권 검사 — 타인 소유 `403` `subscription_forbidden`, 없는 delete는 204, NULL `member_id` 레거시 귀속 허용
- Closes #250: `PUSH_ENCRYPT_AT_REST=true` 시 `PUSH_KEK` 기동 fail-closed, `enc:v1:` decrypt 실패는 예외, stats `encryption_enabled`는 effective
- Closes #264: stats DB aggregate, `send_to_all`/예약 발송 로그 batch insert + endpoint_hash bounded batch DELETE
- Base: `main` @ `4aa3c57`
- Umbrella: #245 (D3)

## Test plan
- [x] `.venv/bin/ruff check apps/api`
- [x] `.venv/bin/python -m pyright --project pyrightconfig.json` (0 errors)
- [x] `.venv/bin/pytest -q` (257 passed)
- [ ] Ready 전: 멤버 A/B 구독 탈취·삭제 거부 readback, encrypt on+valid KEK round-trip, stats/send accepted·failed


Made with [Cursor](https://cursor.com)