### PR TITLE
fix(api): 예약 알림 stale claim·재시도 중복 방지

### DIFF
--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -210,7 +210,7 @@ class Settings(BaseSettings):
         # PUSH_ENCRYPT_AT_REST=true 이면 KEK는 기동 시 반드시 유효해야 한다.
         if self.push_encrypt_at_rest:
             try:
-                key = base64.b64decode((self.push_kek or "").strip())
+                key = base64.b64decode((self.push_kek or "").strip(), validate=True)
             except (binascii.Error, ValueError) as exc:
                 raise ValueError(
                     "PUSH_KEK must be valid base64 AES key "

--- a/apps/api/crypto_utils.py
+++ b/apps/api/crypto_utils.py
@@ -28,13 +28,12 @@ class CryptoConfig:
 def decode_push_kek(raw: str) -> bytes:
     """PUSH_KEK base64 → AES 키 바이트. 형식이 틀리면 ValueError."""
     try:
-        key = base64.b64decode((raw or "").strip())
+        key = base64.b64decode((raw or "").strip(), validate=True)
     except (binascii.Error, ValueError) as exc:
         raise ValueError("PUSH_KEK must be valid base64") from exc
     if len(key) not in _AES_KEY_LENS:
         raise ValueError(
-            "PUSH_KEK decoded length must be 16, 24, or 32 bytes "
-            f"(got {len(key)})"
+            f"PUSH_KEK decoded length must be 16, 24, or 32 bytes (got {len(key)})"
         )
     return key
 

--- a/apps/api/migrations/versions/c8a7f3d1e2b4_add_scheduled_notification_delivery_state.py
+++ b/apps/api/migrations/versions/c8a7f3d1e2b4_add_scheduled_notification_delivery_state.py
@@ -1,0 +1,86 @@
+"""add scheduled notification delivery state
+
+Revision ID: c8a7f3d1e2b4
+Revises: b8e6d1f4a2c7
+Create Date: 2026-08-01 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c8a7f3d1e2b4"
+down_revision = "b8e6d1f4a2c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_notification_logs",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_table(
+        "scheduled_notification_deliveries",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("scheduled_log_id", sa.Integer(), nullable=False),
+        sa.Column("endpoint_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("status_code", sa.Integer(), nullable=True),
+        sa.Column("attempts", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["scheduled_log_id"],
+            ["scheduled_notification_logs.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scheduled_log_id",
+            "endpoint_hash",
+            name="uq_scheduled_notification_delivery_log_endpoint",
+        ),
+    )
+    op.create_index(
+        "ix_scheduled_notification_deliveries_scheduled_log_id",
+        "scheduled_notification_deliveries",
+        ["scheduled_log_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_scheduled_notification_delivery_log_status",
+        "scheduled_notification_deliveries",
+        ["scheduled_log_id", "status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_scheduled_notification_delivery_log_status",
+        table_name="scheduled_notification_deliveries",
+    )
+    op.drop_index(
+        "ix_scheduled_notification_deliveries_scheduled_log_id",
+        table_name="scheduled_notification_deliveries",
+    )
+    op.drop_table("scheduled_notification_deliveries")
+    op.drop_column("scheduled_notification_logs", "updated_at")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -492,6 +493,9 @@ class ScheduledNotificationLog(Base):
     created_at = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
 
     __table_args__ = (
         Index(
@@ -499,6 +503,49 @@ class ScheduledNotificationLog(Base):
             "event_id",
             "d_type",
             unique=True,
+        ),
+    )
+
+
+class ScheduledNotificationDelivery(Base):
+    """예약 발송의 구독별 영속 상태.
+
+    ``in_progress``는 외부 Push 호출 직전에 커밋되는 claim이다. 프로세스가
+    외부 호출 뒤 중단되면 결과를 알 수 없으므로 자동 재전송하지 않고
+    ``unknown``으로 보존해 중복 발송을 막는다.
+    """
+
+    __tablename__ = "scheduled_notification_deliveries"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    scheduled_log_id = Column(
+        Integer,
+        ForeignKey("scheduled_notification_logs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    endpoint_hash = Column(String(64), nullable=False)
+    status = Column(
+        String(16), nullable=False, default="pending", server_default="pending"
+    )  # pending | in_progress | completed | failed | unknown
+    status_code = Column(Integer, nullable=True)
+    attempts = Column(Integer, nullable=False, default=0, server_default="0")
+    claimed_at = Column(DateTime(timezone=True), nullable=True)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "scheduled_log_id",
+            "endpoint_hash",
+            name="uq_scheduled_notification_delivery_log_endpoint",
+        ),
+        Index(
+            "ix_scheduled_notification_delivery_log_status",
+            "scheduled_log_id",
+            "status",
         ),
     )
 
@@ -516,4 +563,3 @@ class MemberAuth(Base):
     created_at = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -527,7 +527,7 @@ class ScheduledNotificationDelivery(Base):
     endpoint_hash = Column(String(64), nullable=False)
     status = Column(
         String(16), nullable=False, default="pending", server_default="pending"
-    )  # pending | in_progress | completed | failed | unknown
+    )  # pending | in_progress | completed | failed | unknown | abandoned
     status_code = Column(Integer, nullable=True)
     attempts = Column(Integer, nullable=False, default=0, server_default="0")
     claimed_at = Column(DateTime(timezone=True), nullable=True)

--- a/apps/api/repositories/scheduled_notifications.py
+++ b/apps/api/repositories/scheduled_notifications.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
+
+from sqlalchemy import case, func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import ScheduledNotificationDelivery, ScheduledNotificationLog
+
+
+@dataclass(frozen=True)
+class DeliveryClaim:
+    """외부 Push 호출 전에 커밋된 구독별 claim."""
+
+    id: int
+    endpoint_hash: str
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    """구독별 외부 호출 결과."""
+
+    claim: DeliveryClaim
+    ok: bool
+    status_code: int | None
+
+
+@dataclass(frozen=True)
+class DeliveryCounts:
+    accepted: int
+    failed: int
+
+
+def _clean_hashes(endpoint_hashes: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in endpoint_hashes if value))
+
+
+async def ensure_deliveries(
+    db: AsyncSession,
+    *,
+    scheduled_log_id: int,
+    endpoint_hashes: Sequence[str],
+) -> None:
+    """예약 로그에 구독별 delivery 행을 멱등적으로 준비한다."""
+    hashes = _clean_hashes(endpoint_hashes)
+    if not hashes:
+        return
+
+    values = [
+        {
+            "scheduled_log_id": scheduled_log_id,
+            "endpoint_hash": endpoint_hash,
+            "status": "pending",
+            "attempts": 0,
+        }
+        for endpoint_hash in hashes
+    ]
+    stmt = pg_insert(ScheduledNotificationDelivery).values(values)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["scheduled_log_id", "endpoint_hash"]
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+
+async def get_delivery_states(
+    db: AsyncSession,
+    *,
+    scheduled_log_id: int,
+    endpoint_hashes: Sequence[str],
+) -> dict[str, str]:
+    """요청한 endpoint의 현재 delivery 상태를 반환한다."""
+    hashes = _clean_hashes(endpoint_hashes)
+    if not hashes:
+        return {}
+
+    stmt = select(
+        ScheduledNotificationDelivery.endpoint_hash,
+        ScheduledNotificationDelivery.status,
+    ).where(
+        ScheduledNotificationDelivery.scheduled_log_id == scheduled_log_id,
+        ScheduledNotificationDelivery.endpoint_hash.in_(hashes),
+    )
+    result = await db.execute(stmt)
+    return {
+        cast(str, row[0]): cast(str, row[1])
+        for row in result.all()
+        if row[0] is not None and row[1] is not None
+    }
+
+
+async def claim_deliveries(
+    db: AsyncSession,
+    *,
+    scheduled_log_id: int,
+    endpoint_hashes: Sequence[str],
+) -> list[DeliveryClaim]:
+    """pending/failed delivery를 잠그고 in_progress claim을 커밋한다."""
+    hashes = _clean_hashes(endpoint_hashes)
+    if not hashes:
+        await db.commit()
+        return []
+
+    stmt = (
+        select(ScheduledNotificationDelivery)
+        .where(
+            ScheduledNotificationDelivery.scheduled_log_id == scheduled_log_id,
+            ScheduledNotificationDelivery.endpoint_hash.in_(hashes),
+            ScheduledNotificationDelivery.status.in_(["pending", "failed"]),
+        )
+        .order_by(ScheduledNotificationDelivery.id)
+        .with_for_update(skip_locked=True)
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+    claims = [
+        DeliveryClaim(
+            id=cast(int, row.id),
+            endpoint_hash=cast(str, row.endpoint_hash),
+        )
+        for row in rows
+    ]
+    for row in rows:
+        setattr(row, "status", "in_progress")
+        setattr(row, "attempts", cast(int, row.attempts or 0) + 1)
+        setattr(row, "claimed_at", func.now())
+        setattr(row, "finished_at", None)
+        setattr(row, "status_code", None)
+    await db.commit()
+    return claims
+
+
+async def record_delivery_results(
+    db: AsyncSession,
+    *,
+    results: Sequence[DeliveryResult],
+) -> None:
+    """구독별 결과를 한 번의 트랜잭션으로 저장한다."""
+    for result in results:
+        stmt = (
+            update(ScheduledNotificationDelivery)
+            .where(ScheduledNotificationDelivery.id == result.claim.id)
+            .values(
+                status="completed" if result.ok else "failed",
+                status_code=result.status_code,
+                finished_at=func.now(),
+            )
+        )
+        await db.execute(stmt)
+    await db.commit()
+
+
+async def get_delivery_counts(
+    db: AsyncSession,
+    *,
+    scheduled_log_id: int,
+) -> DeliveryCounts:
+    """예약 로그의 구독별 결과를 DB에서 집계한다."""
+    status = ScheduledNotificationDelivery.status
+    stmt = select(
+        func.coalesce(func.sum(case((status == "completed", 1), else_=0)), 0),
+        func.coalesce(func.sum(case((status != "completed", 1), else_=0)), 0),
+    ).where(ScheduledNotificationDelivery.scheduled_log_id == scheduled_log_id)
+    result = await db.execute(stmt)
+    row = result.one()
+    return DeliveryCounts(
+        accepted=int(row[0] or 0),
+        failed=int(row[1] or 0),
+    )
+
+
+async def reclaim_stale_log(
+    db: AsyncSession,
+    *,
+    event_id: int,
+    d_type: str,
+    cutoff: datetime,
+) -> int | None:
+    """오래 멈춘 로그를 실패로 회수하고 claim을 unknown으로 고정한다."""
+    stmt = (
+        update(ScheduledNotificationLog)
+        .where(
+            ScheduledNotificationLog.event_id == event_id,
+            ScheduledNotificationLog.d_type == d_type,
+            ScheduledNotificationLog.status.in_(["pending", "in_progress"]),
+            ScheduledNotificationLog.updated_at < cutoff,
+        )
+        .values(status="failed", updated_at=func.now())
+        .returning(ScheduledNotificationLog.id)
+    )
+    result = await db.execute(stmt)
+    log_id = result.scalar_one_or_none()
+    if log_id is None:
+        # SELECT/UPDATE가 연 트랜잭션을 rollback하면 호출자가 이미 로드한
+        # Event가 expire되어 다음 ORM 접근이 불필요하게 깨질 수 있다.
+        await db.commit()
+        return None
+
+    resolved_log_id = int(log_id)
+    await db.execute(
+        update(ScheduledNotificationDelivery)
+        .where(
+            ScheduledNotificationDelivery.scheduled_log_id == resolved_log_id,
+            ScheduledNotificationDelivery.status == "in_progress",
+        )
+        .values(status="unknown", status_code=None, finished_at=func.now())
+    )
+    counts = await get_delivery_counts(db, scheduled_log_id=resolved_log_id)
+    await db.execute(
+        update(ScheduledNotificationLog)
+        .where(ScheduledNotificationLog.id == resolved_log_id)
+        .values(accepted_count=counts.accepted, failed_count=counts.failed)
+    )
+    await db.commit()
+    return resolved_log_id
+
+
+async def mark_log_failed(
+    db: AsyncSession,
+    *,
+    log_id: int,
+    fallback_failed: int,
+) -> DeliveryCounts:
+    """현재 실행의 예약 로그를 실패로 확정한다."""
+    await db.execute(
+        update(ScheduledNotificationDelivery)
+        .where(
+            ScheduledNotificationDelivery.scheduled_log_id == log_id,
+            ScheduledNotificationDelivery.status == "in_progress",
+        )
+        .values(status="unknown", status_code=None, finished_at=func.now())
+    )
+    counts = await get_delivery_counts(db, scheduled_log_id=log_id)
+    if counts.accepted == 0 and counts.failed == 0 and fallback_failed > 0:
+        counts = DeliveryCounts(accepted=0, failed=fallback_failed)
+
+    await db.execute(
+        update(ScheduledNotificationLog)
+        .where(ScheduledNotificationLog.id == log_id)
+        .values(
+            status="failed",
+            accepted_count=counts.accepted,
+            failed_count=counts.failed,
+            sent_at=None,
+            updated_at=func.now(),
+        )
+    )
+    await db.commit()
+    return counts

--- a/apps/api/repositories/scheduled_notifications.py
+++ b/apps/api/repositories/scheduled_notifications.py
@@ -27,6 +27,7 @@ class DeliveryResult:
     claim: DeliveryClaim
     ok: bool
     status_code: int | None
+    uncertain: bool = False
 
 
 @dataclass(frozen=True)
@@ -47,7 +48,19 @@ async def ensure_deliveries(
 ) -> None:
     """예약 로그에 구독별 delivery 행을 멱등적으로 준비한다."""
     hashes = _clean_hashes(endpoint_hashes)
+
+    stale_stmt = update(ScheduledNotificationDelivery).where(
+        ScheduledNotificationDelivery.scheduled_log_id == scheduled_log_id,
+        ScheduledNotificationDelivery.status.in_(["pending", "failed"]),
+    )
+    if hashes:
+        stale_stmt = stale_stmt.where(
+            ~ScheduledNotificationDelivery.endpoint_hash.in_(hashes)
+        )
+    await db.execute(stale_stmt.values(status="abandoned", finished_at=func.now()))
+
     if not hashes:
+        await db.commit()
         return
 
     values = [
@@ -145,7 +158,11 @@ async def record_delivery_results(
             update(ScheduledNotificationDelivery)
             .where(ScheduledNotificationDelivery.id == result.claim.id)
             .values(
-                status="completed" if result.ok else "failed",
+                status=(
+                    "unknown"
+                    if result.uncertain
+                    else ("completed" if result.ok else "failed")
+                ),
                 status_code=result.status_code,
                 finished_at=func.now(),
             )
@@ -161,9 +178,10 @@ async def get_delivery_counts(
 ) -> DeliveryCounts:
     """예약 로그의 구독별 결과를 DB에서 집계한다."""
     status = ScheduledNotificationDelivery.status
+    unresolved = status.in_(["pending", "in_progress", "failed", "unknown"])
     stmt = select(
         func.coalesce(func.sum(case((status == "completed", 1), else_=0)), 0),
-        func.coalesce(func.sum(case((status != "completed", 1), else_=0)), 0),
+        func.coalesce(func.sum(case((unresolved, 1), else_=0)), 0),
     ).where(ScheduledNotificationDelivery.scheduled_log_id == scheduled_log_id)
     result = await db.execute(stmt)
     row = result.one()
@@ -171,6 +189,34 @@ async def get_delivery_counts(
         accepted=int(row[0] or 0),
         failed=int(row[1] or 0),
     )
+
+
+async def _finalize_stale_log(
+    db: AsyncSession,
+    *,
+    log_id: int,
+) -> DeliveryCounts:
+    await db.execute(
+        update(ScheduledNotificationDelivery)
+        .where(
+            ScheduledNotificationDelivery.scheduled_log_id == log_id,
+            ScheduledNotificationDelivery.status == "in_progress",
+        )
+        .values(status="unknown", status_code=None, finished_at=func.now())
+    )
+    counts = await get_delivery_counts(db, scheduled_log_id=log_id)
+    await db.execute(
+        update(ScheduledNotificationLog)
+        .where(ScheduledNotificationLog.id == log_id)
+        .values(
+            status="failed",
+            accepted_count=counts.accepted,
+            failed_count=counts.failed,
+            sent_at=None,
+            updated_at=func.now(),
+        )
+    )
+    return counts
 
 
 async def reclaim_stale_log(
@@ -201,22 +247,36 @@ async def reclaim_stale_log(
         return None
 
     resolved_log_id = int(log_id)
-    await db.execute(
-        update(ScheduledNotificationDelivery)
-        .where(
-            ScheduledNotificationDelivery.scheduled_log_id == resolved_log_id,
-            ScheduledNotificationDelivery.status == "in_progress",
-        )
-        .values(status="unknown", status_code=None, finished_at=func.now())
-    )
-    counts = await get_delivery_counts(db, scheduled_log_id=resolved_log_id)
-    await db.execute(
-        update(ScheduledNotificationLog)
-        .where(ScheduledNotificationLog.id == resolved_log_id)
-        .values(accepted_count=counts.accepted, failed_count=counts.failed)
-    )
+    await _finalize_stale_log(db, log_id=resolved_log_id)
     await db.commit()
     return resolved_log_id
+
+
+async def reclaim_stale_logs(
+    db: AsyncSession,
+    *,
+    cutoff: datetime,
+) -> int:
+    """due 이벤트와 무관하게 오래된 예약 로그를 일괄 회수한다."""
+    stmt = (
+        select(ScheduledNotificationLog.id)
+        .where(
+            ScheduledNotificationLog.status.in_(["pending", "in_progress"]),
+            ScheduledNotificationLog.updated_at < cutoff,
+        )
+        .order_by(ScheduledNotificationLog.id)
+        .with_for_update(skip_locked=True)
+    )
+    result = await db.execute(stmt)
+    log_ids = [int(log_id) for log_id in result.scalars().all()]
+    if not log_ids:
+        await db.commit()
+        return 0
+
+    for log_id in log_ids:
+        await _finalize_stale_log(db, log_id=log_id)
+    await db.commit()
+    return len(log_ids)
 
 
 async def mark_log_failed(

--- a/apps/api/reset_data.py
+++ b/apps/api/reset_data.py
@@ -56,6 +56,7 @@ ALLOWED_DELETE_TABLES: Final[frozenset[str]] = frozenset(
 
 PRESERVED_TABLES: Final[tuple[str, ...]] = (
     "notification_send_logs",
+    "scheduled_notification_deliveries",
     "scheduled_notification_logs",
     "support_tickets",
     "events",

--- a/apps/api/scheduler.py
+++ b/apps/api/scheduler.py
@@ -17,6 +17,7 @@ from datetime import timedelta, timezone
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 
 from .config import get_settings
 from .db import AsyncSessionLocal
@@ -44,6 +45,14 @@ async def process_scheduled_notifications() -> None:
             f"processed={result.processed}, skipped={result.skipped}, "
             f"accepted={result.total_accepted}, failed={result.total_failed}"
         )
+
+
+async def reclaim_stale_scheduled_notifications() -> None:
+    """due 날짜와 무관하게 멈춘 예약 로그를 주기적으로 회수한다."""
+    async with AsyncSessionLocal() as db:
+        reclaimed = await sched_svc.reclaim_stale_scheduled_logs(db)
+        if reclaimed:
+            logger.info("stale 예약 로그 sweep 완료: count=%s", reclaimed)
 
 
 def start_scheduler() -> None:
@@ -76,10 +85,17 @@ def start_scheduler() -> None:
         name="D-3/D-1 이벤트 알림 발송",
         replace_existing=True,
     )
+    scheduler.add_job(
+        reclaim_stale_scheduled_notifications,
+        trigger=IntervalTrigger(minutes=5),
+        id="scheduled_notification_stale_sweep",
+        name="예약 알림 stale 로그 sweep",
+        replace_existing=True,
+    )
 
     scheduler.start()
     _state["scheduler"] = scheduler
-    logger.info("스케줄러 시작됨 (매일 09:00 KST)")
+    logger.info("스케줄러 시작됨 (매일 09:00 KST + 5분 stale sweep)")
 
 
 def shutdown_scheduler() -> None:

--- a/apps/api/services/scheduled_delivery_service.py
+++ b/apps/api/services/scheduled_delivery_service.py
@@ -21,56 +21,71 @@ class DeliveryBatchConfig:
     scheduled_log_id: int | None = None
 
 
+@dataclass(frozen=True)
+class _DeliveryAttempt:
+    ok: bool
+    status_code: int | None
+    uncertain: bool = False
+
+
 async def _send_with_retry(
     provider: PushProvider,
     sub: PushSubscription,
     payload: dict[str, str],
     *,
     max_retries: int,
-) -> tuple[bool, int | None]:
+) -> _DeliveryAttempt:
     """지수 백오프로 일시적 Push 실패를 재시도한다."""
     status: int | None = None
     for attempt in range(max_retries + 1):
         ok, status = await provider.send_async(sub, payload)
-        if ok or status in (400, 404, 410):
-            return ok, status
+        if ok:
+            return _DeliveryAttempt(ok=True, status_code=status)
+        if status is None:
+            # 요청이 Push provider에 도달했는지 알 수 없으므로 재시도하면
+            # 중복 발송이 될 수 있다.
+            return _DeliveryAttempt(
+                ok=False,
+                status_code=None,
+                uncertain=True,
+            )
+        if status in (400, 404, 410):
+            return _DeliveryAttempt(ok=False, status_code=status)
         if attempt < max_retries:
             await asyncio.sleep((2**attempt) * 0.5)
-    return False, status
+    return _DeliveryAttempt(ok=False, status_code=status)
 
 
-async def _prepare_scheduled_batch(
+def _decrypt_subscription(sub: PushSubscription) -> str:
+    """외부 호출 전 암호화 필드가 유효한지 확인하고 endpoint를 반환한다."""
+    endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+    decrypt_str(cast(str, sub.p256dh))
+    decrypt_str(cast(str, sub.auth))
+    return endpoint_plain
+
+
+async def _prepare_scheduled_delivery(
     db: AsyncSession,
-    batch: Sequence[PushSubscription],
+    endpoint_hash: str,
     *,
     scheduled_log_id: int,
-) -> tuple[dict[str, scheduled_repo.DeliveryClaim], list[send_logs.SendLogItem], int]:
-    """이미 처리된 endpoint를 제외하고 이번 배치의 claim을 준비한다."""
-    hashes = [cast(str, sub.endpoint_hash) for sub in batch]
+) -> tuple[scheduled_repo.DeliveryClaim | None, str | None]:
+    """실제 한 번의 외부 호출에 해당하는 endpoint 하나만 claim한다."""
     states = await scheduled_repo.get_delivery_states(
         db,
         scheduled_log_id=scheduled_log_id,
-        endpoint_hashes=hashes,
+        endpoint_hashes=[endpoint_hash],
     )
+    state = states.get(endpoint_hash)
+    if state in {"completed", "unknown", "abandoned", "in_progress"}:
+        return None, state
+
     claims = await scheduled_repo.claim_deliveries(
         db,
         scheduled_log_id=scheduled_log_id,
-        endpoint_hashes=hashes,
+        endpoint_hashes=[endpoint_hash],
     )
-    claim_by_hash = {claim.endpoint_hash: claim for claim in claims}
-    skipped_logs: list[send_logs.SendLogItem] = []
-    skipped_failed = 0
-    for endpoint_hash, state in states.items():
-        if state == "unknown":
-            skipped_logs.append(
-                send_logs.SendLogItem(
-                    ok=False,
-                    status_code=None,
-                    stored_endpoint_hash=endpoint_hash,
-                )
-            )
-            skipped_failed += 1
-    return claim_by_hash, skipped_logs, skipped_failed
+    return (claims[0], None) if claims else (None, state)
 
 
 async def _send_untracked_batch(
@@ -88,7 +103,7 @@ async def _send_untracked_batch(
 
     for sub in batch:
         try:
-            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+            endpoint_plain = _decrypt_subscription(sub)
         except CryptoError:
             failed += 1
             log_items.append(
@@ -100,17 +115,21 @@ async def _send_untracked_batch(
             )
             continue
 
-        ok, status = await _send_with_retry(
+        attempt = await _send_with_retry(
             provider, sub, payload, max_retries=max_retries
         )
-        if ok:
+        if attempt.ok:
             accepted += 1
         else:
             failed += 1
-            if status in (404, 410):
+            if attempt.status_code in (404, 410):
                 expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
         log_items.append(
-            send_logs.SendLogItem(endpoint=endpoint_plain, ok=ok, status_code=status)
+            send_logs.SendLogItem(
+                endpoint=endpoint_plain,
+                ok=attempt.ok,
+                status_code=attempt.status_code,
+            )
         )
 
     await send_logs.create_logs_batch(db, log_items)
@@ -136,51 +155,65 @@ async def send_batch_chunk(
             max_retries=config.max_retries,
         )
 
-    claim_by_hash, log_items, failed = await _prepare_scheduled_batch(
-        db,
-        batch,
-        scheduled_log_id=scheduled_log_id,
-    )
     accepted = 0
-    delivery_results: list[scheduled_repo.DeliveryResult] = []
+    failed = 0
+    log_items: list[send_logs.SendLogItem] = []
     expired_hashes: list[str] = []
 
     for sub in batch:
         endpoint_hash = cast(str, sub.endpoint_hash)
-        claim = claim_by_hash.get(endpoint_hash)
+        claim, state = await _prepare_scheduled_delivery(
+            db,
+            endpoint_hash,
+            scheduled_log_id=scheduled_log_id,
+        )
         if claim is None:
-            # completed/unknown 또는 다른 워커가 잠근 행이다.
+            if state == "unknown":
+                failed += 1
+                log_items.append(
+                    send_logs.SendLogItem(
+                        ok=False,
+                        status_code=None,
+                        stored_endpoint_hash=endpoint_hash,
+                    )
+                )
+            # completed/abandoned/in_progress 또는 다른 워커가 잠근 행이다.
             continue
 
         try:
-            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+            endpoint_plain = _decrypt_subscription(sub)
         except CryptoError:
-            ok = False
-            status = None
+            attempt = _DeliveryAttempt(ok=False, status_code=None)
             endpoint_plain = None
         else:
-            ok, status = await _send_with_retry(
+            attempt = await _send_with_retry(
                 provider, sub, payload, max_retries=config.max_retries
             )
 
-        delivery_results.append(
-            scheduled_repo.DeliveryResult(
-                claim=claim,
-                ok=ok,
-                status_code=status,
-            )
+        # claim 단위와 실제 외부 호출 단위를 일치시켜, 배치 후반의 미송신
+        # endpoint가 프로세스 중단 때문에 unknown으로 같이 탈락하지 않게 한다.
+        await scheduled_repo.record_delivery_results(
+            db,
+            results=[
+                scheduled_repo.DeliveryResult(
+                    claim=claim,
+                    ok=attempt.ok,
+                    status_code=attempt.status_code,
+                    uncertain=attempt.uncertain,
+                )
+            ],
         )
-        if ok:
+        if attempt.ok:
             accepted += 1
         else:
             failed += 1
-            if endpoint_plain is not None and status in (404, 410):
+            if endpoint_plain is not None and attempt.status_code in (404, 410):
                 expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
         if endpoint_plain is None:
             log_items.append(
                 send_logs.SendLogItem(
-                    ok=ok,
-                    status_code=status,
+                    ok=attempt.ok,
+                    status_code=attempt.status_code,
                     stored_endpoint_hash=endpoint_hash,
                 )
             )
@@ -188,14 +221,13 @@ async def send_batch_chunk(
             log_items.append(
                 send_logs.SendLogItem(
                     endpoint=endpoint_plain,
-                    ok=ok,
-                    status_code=status,
+                    ok=attempt.ok,
+                    status_code=attempt.status_code,
                 )
             )
 
-    # 외부 호출 결과를 먼저 영속화한다. 이후 일반 발송 로그 저장이 실패해도
-    # 다음 예약 실행은 완료/실패/불확실 상태를 기준으로 중복을 방지한다.
-    await scheduled_repo.record_delivery_results(db, results=delivery_results)
+    # 일반 발송 로그 저장이 실패해도 delivery 결과는 이미 endpoint별로
+    # 커밋되어 다음 예약 실행의 재시도 경계를 보존한다.
     await send_logs.create_logs_batch(db, log_items)
     await subs_repo.remove_by_endpoint_hashes(db, expired_hashes)
     return accepted, failed

--- a/apps/api/services/scheduled_delivery_service.py
+++ b/apps/api/services/scheduled_delivery_service.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..crypto_utils import CryptoError, decrypt_str
+from ..models import PushSubscription
+from ..repositories import notifications as subs_repo
+from ..repositories import scheduled_notifications as scheduled_repo
+from ..repositories import send_logs
+from .notifications_service import PushProvider
+
+
+@dataclass(frozen=True)
+class DeliveryBatchConfig:
+    max_retries: int = 3
+    scheduled_log_id: int | None = None
+
+
+async def _send_with_retry(
+    provider: PushProvider,
+    sub: PushSubscription,
+    payload: dict[str, str],
+    *,
+    max_retries: int,
+) -> tuple[bool, int | None]:
+    """지수 백오프로 일시적 Push 실패를 재시도한다."""
+    status: int | None = None
+    for attempt in range(max_retries + 1):
+        ok, status = await provider.send_async(sub, payload)
+        if ok or status in (400, 404, 410):
+            return ok, status
+        if attempt < max_retries:
+            await asyncio.sleep((2**attempt) * 0.5)
+    return False, status
+
+
+async def _prepare_scheduled_batch(
+    db: AsyncSession,
+    batch: Sequence[PushSubscription],
+    *,
+    scheduled_log_id: int,
+) -> tuple[dict[str, scheduled_repo.DeliveryClaim], list[send_logs.SendLogItem], int]:
+    """이미 처리된 endpoint를 제외하고 이번 배치의 claim을 준비한다."""
+    hashes = [cast(str, sub.endpoint_hash) for sub in batch]
+    states = await scheduled_repo.get_delivery_states(
+        db,
+        scheduled_log_id=scheduled_log_id,
+        endpoint_hashes=hashes,
+    )
+    claims = await scheduled_repo.claim_deliveries(
+        db,
+        scheduled_log_id=scheduled_log_id,
+        endpoint_hashes=hashes,
+    )
+    claim_by_hash = {claim.endpoint_hash: claim for claim in claims}
+    skipped_logs: list[send_logs.SendLogItem] = []
+    skipped_failed = 0
+    for endpoint_hash, state in states.items():
+        if state == "unknown":
+            skipped_logs.append(
+                send_logs.SendLogItem(
+                    ok=False,
+                    status_code=None,
+                    stored_endpoint_hash=endpoint_hash,
+                )
+            )
+            skipped_failed += 1
+    return claim_by_hash, skipped_logs, skipped_failed
+
+
+async def _send_untracked_batch(
+    db: AsyncSession,
+    provider: PushProvider,
+    batch: Sequence[PushSubscription],
+    payload: dict[str, str],
+    *,
+    max_retries: int,
+) -> tuple[int, int]:
+    accepted = 0
+    failed = 0
+    log_items: list[send_logs.SendLogItem] = []
+    expired_hashes: list[str] = []
+
+    for sub in batch:
+        try:
+            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+        except CryptoError:
+            failed += 1
+            log_items.append(
+                send_logs.SendLogItem(
+                    ok=False,
+                    status_code=None,
+                    stored_endpoint_hash=cast(str, sub.endpoint_hash),
+                )
+            )
+            continue
+
+        ok, status = await _send_with_retry(
+            provider, sub, payload, max_retries=max_retries
+        )
+        if ok:
+            accepted += 1
+        else:
+            failed += 1
+            if status in (404, 410):
+                expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
+        log_items.append(
+            send_logs.SendLogItem(endpoint=endpoint_plain, ok=ok, status_code=status)
+        )
+
+    await send_logs.create_logs_batch(db, log_items)
+    await subs_repo.remove_by_endpoint_hashes(db, expired_hashes)
+    return accepted, failed
+
+
+async def send_batch_chunk(
+    db: AsyncSession,
+    provider: PushProvider,
+    batch: Sequence[PushSubscription],
+    payload: dict[str, str],
+    config: DeliveryBatchConfig,
+) -> tuple[int, int]:
+    """일반 또는 예약 발송 배치 한 덩어리를 처리한다."""
+    scheduled_log_id = config.scheduled_log_id
+    if scheduled_log_id is None:
+        return await _send_untracked_batch(
+            db,
+            provider,
+            batch,
+            payload,
+            max_retries=config.max_retries,
+        )
+
+    claim_by_hash, log_items, failed = await _prepare_scheduled_batch(
+        db,
+        batch,
+        scheduled_log_id=scheduled_log_id,
+    )
+    accepted = 0
+    delivery_results: list[scheduled_repo.DeliveryResult] = []
+    expired_hashes: list[str] = []
+
+    for sub in batch:
+        endpoint_hash = cast(str, sub.endpoint_hash)
+        claim = claim_by_hash.get(endpoint_hash)
+        if claim is None:
+            # completed/unknown 또는 다른 워커가 잠근 행이다.
+            continue
+
+        try:
+            endpoint_plain = decrypt_str(cast(str, sub.endpoint))
+        except CryptoError:
+            ok = False
+            status = None
+            endpoint_plain = None
+        else:
+            ok, status = await _send_with_retry(
+                provider, sub, payload, max_retries=config.max_retries
+            )
+
+        delivery_results.append(
+            scheduled_repo.DeliveryResult(
+                claim=claim,
+                ok=ok,
+                status_code=status,
+            )
+        )
+        if ok:
+            accepted += 1
+        else:
+            failed += 1
+            if endpoint_plain is not None and status in (404, 410):
+                expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
+        if endpoint_plain is None:
+            log_items.append(
+                send_logs.SendLogItem(
+                    ok=ok,
+                    status_code=status,
+                    stored_endpoint_hash=endpoint_hash,
+                )
+            )
+        else:
+            log_items.append(
+                send_logs.SendLogItem(
+                    endpoint=endpoint_plain,
+                    ok=ok,
+                    status_code=status,
+                )
+            )
+
+    # 외부 호출 결과를 먼저 영속화한다. 이후 일반 발송 로그 저장이 실패해도
+    # 다음 예약 실행은 완료/실패/불확실 상태를 기준으로 중복을 방지한다.
+    await scheduled_repo.record_delivery_results(db, results=delivery_results)
+    await send_logs.create_logs_batch(db, log_items)
+    await subs_repo.remove_by_endpoint_hashes(db, expired_hashes)
+    return accepted, failed

--- a/apps/api/services/scheduled_notifications_service.py
+++ b/apps/api/services/scheduled_notifications_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Literal, cast
 
 from requests.exceptions import RequestException
@@ -14,12 +14,12 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..crypto_utils import CryptoError, decrypt_str
 from ..models import Event, PushSubscription, ScheduledNotificationLog
 from ..repositories import notification_preferences as pref_repo
 from ..repositories import notifications as subs_repo
-from ..repositories import send_logs
+from ..repositories import scheduled_notifications as scheduled_repo
 from .notifications_service import PushProvider, SendResult
+from .scheduled_delivery_service import DeliveryBatchConfig, send_batch_chunk
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 KST = timezone(timedelta(hours=9))
 
 DType = Literal["d-3", "d-1"]
+SCHEDULED_LOG_STALE_AFTER = timedelta(minutes=15)
 
 
 @dataclass
@@ -38,6 +39,7 @@ class BatchConfig:
     batch_size: int = 50
     batch_delay_seconds: float = 1.0
     max_retries: int = 3
+    scheduled_log_id: int | None = None
 
 
 async def find_events_due_for_notification(
@@ -118,79 +120,50 @@ async def send_batch_notifications(
     payload: dict[str, str],
     config: BatchConfig | None = None,
 ) -> SendResult:
-    """배치 단위로 알림 발송 (레이트리밋 준수)."""
+    """배치 단위로 알림 발송 (레이트리밋 준수).
+
+    예약 발송은 구독별 claim을 외부 호출 전에 커밋한다. 외부 호출 뒤
+    프로세스가 중단되어 결과가 불확실해져도 다음 실행에서 해당 endpoint를
+    다시 보내지 않도록 하는 at-most-once 경계다.
+    """
     cfg = config or BatchConfig()
     accepted = 0
     failed = 0
+    scheduled_log_id = cfg.scheduled_log_id
 
     subs_list = list(subscriptions)
+    if scheduled_log_id is not None:
+        await scheduled_repo.ensure_deliveries(
+            db,
+            scheduled_log_id=scheduled_log_id,
+            endpoint_hashes=[cast(str, sub.endpoint_hash) for sub in subs_list],
+        )
+
     for i in range(0, len(subs_list), cfg.batch_size):
         batch = subs_list[i : i + cfg.batch_size]
-        log_items: list[send_logs.SendLogItem] = []
-        expired_hashes: list[str] = []
-
-        for sub in batch:
-            try:
-                endpoint_plain = decrypt_str(cast(str, sub.endpoint))
-            except CryptoError:
-                failed += 1
-                log_items.append(
-                    send_logs.SendLogItem(
-                        ok=False,
-                        status_code=None,
-                        stored_endpoint_hash=cast(str, sub.endpoint_hash),
-                    )
-                )
-                continue
-
-            ok, status = await _send_with_retry(
-                provider, sub, payload, max_retries=cfg.max_retries
-            )
-
-            if ok:
-                accepted += 1
-            else:
-                failed += 1
-                if status in (404, 410):
-                    expired_hashes.append(subs_repo.hash_endpoint(endpoint_plain))
-
-            log_items.append(
-                send_logs.SendLogItem(
-                    endpoint=endpoint_plain, ok=ok, status_code=status
-                )
-            )
-
-        await send_logs.create_logs_batch(db, log_items)
-        await subs_repo.remove_by_endpoint_hashes(db, expired_hashes)
+        chunk_accepted, chunk_failed = await send_batch_chunk(
+            db,
+            provider,
+            batch,
+            payload,
+            DeliveryBatchConfig(
+                max_retries=cfg.max_retries,
+                scheduled_log_id=scheduled_log_id,
+            ),
+        )
+        accepted += chunk_accepted
+        failed += chunk_failed
 
         # 배치 간 딜레이 (레이트리밋 준수)
         if i + cfg.batch_size < len(subs_list):
             await asyncio.sleep(cfg.batch_delay_seconds)
 
+    if scheduled_log_id is not None:
+        counts = await scheduled_repo.get_delivery_counts(
+            db, scheduled_log_id=scheduled_log_id
+        )
+        return SendResult(accepted=counts.accepted, failed=counts.failed)
     return SendResult(accepted=accepted, failed=failed)
-
-
-async def _send_with_retry(
-    provider: PushProvider,
-    sub: PushSubscription,
-    payload: dict[str, str],
-    *,
-    max_retries: int = 3,
-) -> tuple[bool, int | None]:
-    """지수 백오프로 재시도."""
-    status: int | None = None
-    for attempt in range(max_retries + 1):
-        ok, status = await provider.send_async(sub, payload)
-
-        if ok or status in (400, 404, 410):
-            # 성공 또는 복구 불가능한 에러
-            return ok, status
-
-        if attempt < max_retries:
-            delay = (2**attempt) * 0.5  # 0.5s, 1s, 2s
-            await asyncio.sleep(delay)
-
-    return False, status
 
 
 async def create_notification_log(
@@ -223,6 +196,7 @@ async def create_notification_log(
                 "accepted_count": 0,
                 "failed_count": 0,
                 "sent_at": None,
+                "updated_at": func.now(),
             },
             where=(ScheduledNotificationLog.status == "failed"),
         )
@@ -254,7 +228,30 @@ async def update_notification_log(
         setattr(log, "failed_count", failed_count)
         if status == "completed":
             setattr(log, "sent_at", func.now())
+        setattr(log, "updated_at", func.now())
         await db.commit()
+
+
+async def _finalize_failed_notification(
+    db: AsyncSession,
+    *,
+    log_id: int,
+    fallback_failed: int,
+) -> scheduled_repo.DeliveryCounts:
+    """실패 세션을 rollback한 뒤 예약 로그를 실패로 마감한다."""
+    await db.rollback()
+    try:
+        return await scheduled_repo.mark_log_failed(
+            db,
+            log_id=log_id,
+            fallback_failed=fallback_failed,
+        )
+    except SQLAlchemyError:
+        # 원래 예외를 가리지 않으면서, 다음 스케줄 실행의 stale 회수에
+        # 맡길 수 있도록 세션을 다시 깨끗한 상태로 돌린다.
+        await db.rollback()
+        logger.exception("예약 발송 실패 로그 마감도 실패: log_id=%s", log_id)
+        return scheduled_repo.DeliveryCounts(accepted=0, failed=max(fallback_failed, 0))
 
 
 async def list_scheduled_logs(
@@ -291,6 +288,16 @@ async def process_single_event(
 ) -> ProcessResult:
     """단일 이벤트 알림 처리 (스케줄러/수동 트리거 공용)."""
     event_id = cast(int, event.id)
+    event_title = cast(str, event.title)
+    raw_location = cast("str | None", event.location)
+    event_location = raw_location if raw_location else ""
+
+    await scheduled_repo.reclaim_stale_log(
+        db,
+        event_id=event_id,
+        d_type=d_type,
+        cutoff=datetime.now(UTC) - SCHEDULED_LOG_STALE_AFTER,
+    )
 
     # 중복 발송 확인
     if await is_already_sent(db, event_id=event_id, d_type=d_type):
@@ -300,7 +307,7 @@ async def process_single_event(
         )
 
     # 발송 로그 생성 (in_progress 상태)
-    # ON CONFLICT DO NOTHING으로 동시 삽입 시 None 반환 (다른 워커가 처리 중)
+    # 신규 삽입 또는 failed stale 행 회수. pending/in_progress 충돌은 None이다.
     log = await create_notification_log(
         db,
         event_id=event_id,
@@ -313,34 +320,44 @@ async def process_single_event(
             event_id=event_id, d_type=d_type, skipped=True, accepted=0, failed=0
         )
     log_id = cast(int, log.id)
-    await update_notification_log(db, log_id, status="in_progress")
+    subs: Sequence[PushSubscription] = []
 
-    # 대상 구독자 조회
-    subs = await get_eligible_subscriptions(db, topic="event")
-
-    if not subs:
-        logger.info(f"발송 대상 없음: event_id={event_id}")
-        await update_notification_log(db, log_id, status="completed")
-        return ProcessResult(
-            event_id=event_id, d_type=d_type, skipped=False, accepted=0, failed=0
-        )
-
-    # 알림 페이로드 생성
-    days_label = "3일" if d_type == "d-3" else "1일"
-    event_title = cast(str, event.title)
-    raw_location = cast("str | None", event.location)
-    event_location = raw_location if raw_location else ""
-    payload = {
-        "title": f"[행사 알림] {event_title}",
-        "body": f"{days_label} 후 행사가 있습니다. {event_location}",
-        "url": f"/events/{event_id}",
-    }
-
-    # 배치 발송 — 예외 시 failed로 마감해 in_progress 고착·재시도 불가 방지
     try:
+        await update_notification_log(db, log_id, status="in_progress")
+
+        # 대상 구독자 조회
+        subs = await get_eligible_subscriptions(db, topic="event")
+
+        if not subs:
+            logger.info(f"발송 대상 없음: event_id={event_id}")
+            await update_notification_log(db, log_id, status="completed")
+            return ProcessResult(
+                event_id=event_id, d_type=d_type, skipped=False, accepted=0, failed=0
+            )
+
+        # 알림 페이로드 생성
+        days_label = "3일" if d_type == "d-3" else "1일"
+        payload = {
+            "title": f"[행사 알림] {event_title}",
+            "body": f"{days_label} 후 행사가 있습니다. {event_location}",
+            "url": f"/events/{event_id}",
+        }
+
+        # 예약 delivery claim은 외부 호출 전에 영속화된다. DB/provider 예외가
+        # 나도 아래 실패 마감 경로에서 in_progress를 unknown으로 고정한다.
         result = await send_batch_notifications(
-            db, provider, subscriptions=subs, payload=payload
+            db,
+            provider,
+            subscriptions=subs,
+            payload=payload,
+            config=BatchConfig(scheduled_log_id=log_id),
         )
+    except asyncio.CancelledError:
+        logger.exception("예약 발송 실패: event_id=%s, d_type=%s", event_id, d_type)
+        await asyncio.shield(
+            _finalize_failed_notification(db, log_id=log_id, fallback_failed=len(subs))
+        )
+        raise
     except (
         RuntimeError,
         TypeError,
@@ -349,34 +366,29 @@ async def process_single_event(
         RequestException,
         SQLAlchemyError,
     ):
-        logger.exception(
-            "예약 발송 실패: event_id=%s, d_type=%s", event_id, d_type
-        )
-        await update_notification_log(
-            db,
-            log_id,
-            status="failed",
-            accepted_count=0,
-            failed_count=len(subs),
+        logger.exception("예약 발송 실패: event_id=%s, d_type=%s", event_id, d_type)
+        counts = await _finalize_failed_notification(
+            db, log_id=log_id, fallback_failed=len(subs)
         )
         return ProcessResult(
             event_id=event_id,
             d_type=d_type,
             skipped=False,
-            accepted=0,
-            failed=len(subs),
+            accepted=counts.accepted,
+            failed=counts.failed,
         )
 
+    final_status = "failed" if result.failed else "completed"
     await update_notification_log(
         db,
         log_id,
-        status="completed",
+        status=final_status,
         accepted_count=result.accepted,
         failed_count=result.failed,
     )
 
     logger.info(
-        f"발송 완료: event_id={event_id}, d_type={d_type}, "
+        f"발송 종료: event_id={event_id}, d_type={d_type}, status={final_status}, "
         f"accepted={result.accepted}, failed={result.failed}"
     )
 

--- a/apps/api/services/scheduled_notifications_service.py
+++ b/apps/api/services/scheduled_notifications_service.py
@@ -379,13 +379,30 @@ async def process_single_event(
         )
 
     final_status = "failed" if result.failed else "completed"
-    await update_notification_log(
-        db,
-        log_id,
-        status=final_status,
-        accepted_count=result.accepted,
-        failed_count=result.failed,
-    )
+    try:
+        await update_notification_log(
+            db,
+            log_id,
+            status=final_status,
+            accepted_count=result.accepted,
+            failed_count=result.failed,
+        )
+    except SQLAlchemyError:
+        logger.exception(
+            "예약 발송 최종 로그 마감 실패: event_id=%s, d_type=%s",
+            event_id,
+            d_type,
+        )
+        counts = await _finalize_failed_notification(
+            db, log_id=log_id, fallback_failed=result.failed
+        )
+        return ProcessResult(
+            event_id=event_id,
+            d_type=d_type,
+            skipped=False,
+            accepted=counts.accepted,
+            failed=counts.failed,
+        )
 
     logger.info(
         f"발송 종료: event_id={event_id}, d_type={d_type}, status={final_status}, "
@@ -419,6 +436,10 @@ async def trigger_scheduled_notifications(
     target_date: date | None = None,
 ) -> TriggerResult:
     """예약 알림 트리거 (스케줄러/수동 공용)."""
+    reclaimed = await reclaim_stale_scheduled_logs(db)
+    if reclaimed:
+        logger.info("stale 예약 로그 회수: count=%s", reclaimed)
+
     events_by_dtype = await find_events_due_for_notification(
         db, target_date=target_date
     )
@@ -445,4 +466,17 @@ async def trigger_scheduled_notifications(
         skipped=skipped,
         total_accepted=total_accepted,
         total_failed=total_failed,
+    )
+
+
+async def reclaim_stale_scheduled_logs(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """due 이벤트와 무관하게 오래된 예약 로그를 회수한다."""
+    current = now or datetime.now(UTC)
+    return await scheduled_repo.reclaim_stale_logs(
+        db,
+        cutoff=current - SCHEDULED_LOG_STALE_AFTER,
     )

--- a/apps/api/stubs/apscheduler/triggers/interval.pyi
+++ b/apps/api/stubs/apscheduler/triggers/interval.pyi
@@ -1,0 +1,8 @@
+"""APScheduler IntervalTrigger 타입 스텁."""
+
+from typing import Any
+
+from .base import BaseTrigger
+
+class IntervalTrigger(BaseTrigger):
+    def __init__(self, **kwargs: Any) -> None: ...

--- a/docs/dev_log_260801.md
+++ b/docs/dev_log_260801.md
@@ -15,3 +15,10 @@
 - 예약 발송의 DB/provider 예외는 세션 rollback 후 `failed`로 마감하고, 예외 처리 중에도 delivery 상태를 보존한다. 배치 로그·delivery 결과는 구독별이 아니라 배치 단위 commit을 유지한다.
 - `PUSH_KEK` 설정과 공통 디코더 모두 `base64.b64decode(validate=True)`를 사용해 유효 문자 외 입력을 fail-closed로 거부한다.
 - 회귀 테스트는 stale 회수, 부분 발송 후 재시도 중복 방지, DB 예외 뒤 failed readback, strict base64 검증을 포함한다.
+
+## PR #285 리뷰 후속 — 예약 delivery 복구 경계 보완
+
+- claim 범위를 실제 외부 Push 1회로 줄이고 endpoint별 결과를 즉시 commit해, 배치 중단 시 아직 보내지 않은 뒤쪽 endpoint가 `unknown`으로 함께 탈락하지 않게 했다.
+- provider의 `(False, None)`처럼 결과가 불확실한 응답은 재시도하지 않고 `unknown`으로 고정한다. 외부 호출 전 복호화 검증 실패만 재시도 가능한 `failed`로 남긴다.
+- due 이벤트 처리와 독립적인 5분 stale sweep을 scheduler에 추가하고, 최종 예약 로그 commit 실패도 rollback 후 `failed` finalize 경계에서 처리한다.
+- 현재 대상에서 빠진 pending/failed delivery는 `abandoned`로 정리해 완료 집계에 남지 않도록 했다.

--- a/docs/dev_log_260801.md
+++ b/docs/dev_log_260801.md
@@ -8,3 +8,10 @@
 - Review follow-up: 발송 경로에서 `CryptoError`를 구독별 실패로 격리(평문 전송 금지). 예약 발송 예외는 `failed` 마감 + failed 행 재시도 회수. 관리자 `send_to_all`은 손상 구독 하나로 전체 중단하지 않음.
 - Tests: `tests/api/test_d3_push_authority.py`, `test_crypto_utils.py` TEST DRIFT(암호문 그대로 반환) 제거.
 - Docs: `docs/pwa_push.md` 소유권·fail-closed·배치 계약 반영.
+
+## PR #284 후속 — 예약 발송 복구 경계와 KEK 검증
+
+- 예약 로그에 `updated_at`과 구독별 `scheduled_notification_deliveries`를 추가해 `pending/in_progress` stale claim을 회수하고, 외부 Push 전에 claim을 커밋하도록 했다. 완료된 구독은 재시도에서 건너뛰며, 프로세스 중단으로 결과가 불확실한 claim은 `unknown`으로 보존해 중복 재전송을 막는다.
+- 예약 발송의 DB/provider 예외는 세션 rollback 후 `failed`로 마감하고, 예외 처리 중에도 delivery 상태를 보존한다. 배치 로그·delivery 결과는 구독별이 아니라 배치 단위 commit을 유지한다.
+- `PUSH_KEK` 설정과 공통 디코더 모두 `base64.b64decode(validate=True)`를 사용해 유효 문자 외 입력을 fail-closed로 거부한다.
+- 회귀 테스트는 stale 회수, 부분 발송 후 재시도 중복 방지, DB 예외 뒤 failed readback, strict base64 검증을 포함한다.

--- a/docs/pwa_push.md
+++ b/docs/pwa_push.md
@@ -113,8 +113,9 @@ at-rest 암호화용 `PUSH_KEK`가 필요한 경우: `openssl rand -base64 32`
    - `enc:v1:` 접두 값의 복호화 실패는 예외(평문처럼 반환하지 않음). 접두 없는 값은 평문 호환.
    - stats의 `encryption_enabled`는 플래그만이 아니라 유효 KEK까지 포함한 effective 상태.
    - 기존 평문 구독의 자동 일괄 재암호화는 하지 않는다. KEK 교체는 `ops/rekey_push_kek.py` 운영 절차를 사용한다.
-   - 예약 발송은 `scheduled_notification_deliveries`에 endpoint hash별 claim/result를 저장한다. 외부 Push 호출 전에 `in_progress`를 커밋하고, 완료된 대상은 재시도에서 건너뛴다.
-   - 프로세스 중단으로 결과가 불확실한 `in_progress`는 stale 회수 시 `unknown`으로 고정해 자동 중복 발송하지 않는다. 이는 외부 Push를 롤백할 수 없는 at-most-once 복구 경계다.
+   - 예약 발송은 `scheduled_notification_deliveries`에 endpoint hash별 claim/result를 저장한다. 실제 외부 Push 1회와 claim 단위를 맞춰 `in_progress`를 커밋하고, 완료된 대상은 재시도에서 건너뛴다.
+   - provider가 요청 결과를 알 수 없게 반환한 경우는 `unknown`으로 즉시 고정해 재시도하지 않는다. 외부 호출 전 암호화 필드 검증 실패처럼 호출이 시작되지 않은 경우만 `failed`로 재시도한다.
+   - 프로세스 중단으로 결과가 불확실한 `in_progress`는 stale sweep 시 `unknown`으로 고정해 자동 중복 발송하지 않는다. stale sweep은 due 이벤트와 무관하게 5분마다 실행되며, 대상에서 빠진 pending/failed delivery는 `abandoned`로 정리한다.
 7. 발송/통계 성능: stats는 DB aggregate(`COUNT`/`FILTER`), `send_to_all`은 로그 batch insert + 만료 endpoint_hash bounded batch DELETE(커밋 수 bounded). 푸시 자체는 롤백 불가.
 
 ## 권한·UX 원칙

--- a/docs/pwa_push.md
+++ b/docs/pwa_push.md
@@ -113,6 +113,8 @@ at-rest 암호화용 `PUSH_KEK`가 필요한 경우: `openssl rand -base64 32`
    - `enc:v1:` 접두 값의 복호화 실패는 예외(평문처럼 반환하지 않음). 접두 없는 값은 평문 호환.
    - stats의 `encryption_enabled`는 플래그만이 아니라 유효 KEK까지 포함한 effective 상태.
    - 기존 평문 구독의 자동 일괄 재암호화는 하지 않는다. KEK 교체는 `ops/rekey_push_kek.py` 운영 절차를 사용한다.
+   - 예약 발송은 `scheduled_notification_deliveries`에 endpoint hash별 claim/result를 저장한다. 외부 Push 호출 전에 `in_progress`를 커밋하고, 완료된 대상은 재시도에서 건너뛴다.
+   - 프로세스 중단으로 결과가 불확실한 `in_progress`는 stale 회수 시 `unknown`으로 고정해 자동 중복 발송하지 않는다. 이는 외부 Push를 롤백할 수 없는 at-most-once 복구 경계다.
 7. 발송/통계 성능: stats는 DB aggregate(`COUNT`/`FILTER`), `send_to_all`은 로그 batch insert + 만료 endpoint_hash bounded batch DELETE(커밋 수 bounded). 푸시 자체는 롤백 불가.
 
 ## 권한·UX 원칙

--- a/tests/api/test_crypto_utils.py
+++ b/tests/api/test_crypto_utils.py
@@ -65,6 +65,11 @@ def test_settings_reject_encrypt_without_valid_kek(
     with pytest.raises(ValidationError):
         Settings()
 
+    valid_key_with_invalid_character = base64.b64encode(os.urandom(32)).decode() + "!"
+    monkeypatch.setenv("PUSH_KEK", valid_key_with_invalid_character)
+    with pytest.raises(ValidationError):
+        Settings()
+
     monkeypatch.setenv("PUSH_KEK", "")
     with pytest.raises(ValidationError):
         Settings()

--- a/tests/api/test_d3_push_authority.py
+++ b/tests/api/test_d3_push_authority.py
@@ -10,6 +10,7 @@ import bcrypt
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api import models
@@ -21,6 +22,7 @@ from apps.api.repositories import notifications as subs_repo
 from apps.api.repositories import send_logs as logs_repo
 from apps.api.routers import notifications as router_mod
 from apps.api.services import notifications_service as notif_svc
+from apps.api.services import scheduled_delivery_service as delivery_svc
 from apps.api.services import scheduled_notifications_service as sched
 from apps.api.services.notifications_service import PushProvider
 
@@ -84,6 +86,40 @@ def _login_member(
         json={"student_id": student_id, "password": password},
     )
     assert response.status_code == HTTPStatus.OK
+
+
+class _PartialBoomProvider(PushProvider):
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def send(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        self.calls.append(str(sub.endpoint_hash))
+        if len(self.calls) == 1:
+            return (True, 201)
+        raise RuntimeError("provider stopped after first send")
+
+    async def send_async(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        return self.send(sub, payload)
+
+
+class _NoCallProvider(PushProvider):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def send(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        self.calls += 1
+        return (True, 201)
+
+    async def send_async(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        return self.send(sub, payload)
 
 
 def test_subscription_ownership_upsert_and_delete(client: TestClient) -> None:
@@ -232,9 +268,7 @@ def test_stats_aggregate_matches_list_counts(admin_login: TestClient) -> None:
             if int(r.ok) == 0 and r.status_code == int(HTTPStatus.NOT_FOUND)
         )
         f410 = sum(
-            1
-            for r in logs
-            if int(r.ok) == 0 and r.status_code == int(HTTPStatus.GONE)
+            1 for r in logs if int(r.ok) == 0 and r.status_code == int(HTTPStatus.GONE)
         )
         assert agg.accepted == accepted
         assert agg.failed == failed
@@ -463,14 +497,15 @@ def test_process_single_event_marks_failed_on_batch_exception(
     async def _run(session: AsyncSession) -> None:
         event = await session.get(models.Event, event_holder["id"])
         assert event is not None
-        result = await sched.process_single_event(
-            session, _Boom(), event, "d-3"
-        )
+        result = await sched.process_single_event(session, _Boom(), event, "d-3")
         assert result.skipped is False
         assert result.failed >= 1
-        assert await sched.is_already_sent(
-            session, event_id=event_holder["id"], d_type="d-3"
-        ) is False
+        assert (
+            await sched.is_already_sent(
+                session, event_id=event_holder["id"], d_type="d-3"
+            )
+            is False
+        )
         logs = await sched.list_scheduled_logs(session, limit=10)
         match = [
             log
@@ -516,5 +551,273 @@ def test_upsert_same_actor_idempotent_other_forbidden(client: TestClient) -> Non
                 {"endpoint": endpoint, "p256dh": "p3", "auth": "a3"},
                 actor_member_id=other_id,
             )
+
+    _run_in_test_session(_run)
+
+
+@pytest.mark.parametrize("stale_status", ["pending", "in_progress"])
+def test_stale_scheduled_log_is_reclaimed(
+    client: TestClient, stale_status: str
+) -> None:
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title=f"stale-{stale_status}",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+
+    _run_in_test_session(_seed)
+
+    async def _create_stale(session: AsyncSession) -> None:
+        log = await sched.create_notification_log(
+            session,
+            event_id=event_holder["id"],
+            d_type="d-3",
+            scheduled_at=datetime.now(tz=UTC),
+        )
+        assert log is not None
+        setattr(log, "status", stale_status)
+        setattr(
+            log,
+            "updated_at",
+            datetime.now(tz=UTC)
+            - sched.SCHEDULED_LOG_STALE_AFTER
+            - timedelta(minutes=1),
+        )
+        await session.commit()
+
+    _run_in_test_session(_create_stale)
+
+    class _Noop(PushProvider):
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return (True, 201)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    async def _run(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, _Noop(), event, "d-3")
+        assert result.skipped is False
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "completed"
+
+    _run_in_test_session(_run)
+
+
+def test_scheduled_trigger_entrypoint_persists_delivery_state(
+    admin_login: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    owner_id = _seed_member(student_id="d3-trigger-owner")
+    target_date = datetime.now(tz=sched.KST).date()
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.combine(
+            target_date + timedelta(days=3),
+            datetime.min.time(),
+            tzinfo=sched.KST,
+        ) + timedelta(hours=10)
+        event = models.Event(
+            title="scheduled-entrypoint",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/trigger-entrypoint",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    provider = _NoCallProvider()
+    app.dependency_overrides[router_mod.get_push_provider] = lambda: provider
+    try:
+        response = admin_login.post(
+            "/notifications/admin/notifications/trigger-scheduled",
+            json={"target_date": target_date.isoformat()},
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED
+        body = response.json()
+        assert body["processed"] == 1
+        assert body["accepted"] == 1
+        assert body["failed"] == 0
+        assert provider.calls == 1
+    finally:
+        app.dependency_overrides.pop(router_mod.get_push_provider, None)
+
+    async def _verify(session: AsyncSession) -> None:
+        result = await session.execute(
+            select(models.ScheduledNotificationDelivery)
+            .join(
+                models.ScheduledNotificationLog,
+                models.ScheduledNotificationDelivery.scheduled_log_id
+                == models.ScheduledNotificationLog.id,
+            )
+            .where(models.ScheduledNotificationLog.event_id == event_holder["id"])
+        )
+        deliveries = result.scalars().all()
+        assert len(deliveries) == 1
+        assert str(deliveries[0].status) == "completed"
+
+    _run_in_test_session(_verify)
+
+
+def test_scheduled_retry_does_not_resend_uncertain_delivery(
+    client: TestClient,
+) -> None:
+    owner_id = _seed_member(student_id="d3-delivery-owner")
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="delivery-idempotency",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        for suffix in ("first", "second"):
+            await subs_repo.upsert_subscription(
+                session,
+                {
+                    "endpoint": f"https://example.com/push/{suffix}",
+                    "p256dh": "p",
+                    "auth": "a",
+                },
+                actor_member_id=owner_id,
+            )
+
+    _run_in_test_session(_seed)
+
+    first_provider = _PartialBoomProvider()
+
+    async def _first_attempt(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, first_provider, event, "d-3")
+        assert result.skipped is False
+        assert result.failed == 2
+        assert len(first_provider.calls) == 2
+
+    _run_in_test_session(_first_attempt)
+
+    retry_provider = _NoCallProvider()
+
+    async def _retry(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, retry_provider, event, "d-3")
+        assert result.skipped is False
+        assert result.failed == 2
+        assert retry_provider.calls == 0
+        delivery_result = await session.execute(
+            select(models.ScheduledNotificationDelivery).order_by(
+                models.ScheduledNotificationDelivery.id
+            )
+        )
+        deliveries = delivery_result.scalars().all()
+        assert len(deliveries) == 2
+        assert {str(row.status) for row in deliveries} == {"unknown"}
+
+    _run_in_test_session(_retry)
+
+
+def test_scheduled_db_failure_rolls_back_before_failed_readback(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    owner_id = _seed_member(student_id="d3-db-fail")
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="db-fail",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/db-fail",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    async def _raise_db_error(_db: AsyncSession, _items: Any) -> int:
+        raise SQLAlchemyError("notification log commit failed")
+
+    monkeypatch.setattr(delivery_svc.send_logs, "create_logs_batch", _raise_db_error)
+
+    class _Good(PushProvider):
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return (True, 201)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    async def _run(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, _Good(), event, "d-3")
+        assert result.skipped is False
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "failed"
 
     _run_in_test_session(_run)

--- a/tests/api/test_d3_push_authority.py
+++ b/tests/api/test_d3_push_authority.py
@@ -122,6 +122,22 @@ class _NoCallProvider(PushProvider):
         return self.send(sub, payload)
 
 
+class _UnknownProvider(PushProvider):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def send(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        self.calls += 1
+        return (False, None)
+
+    async def send_async(
+        self, sub: models.PushSubscription, payload: dict[str, object]
+    ) -> tuple[bool, int | None]:
+        return self.send(sub, payload)
+
+
 def test_subscription_ownership_upsert_and_delete(client: TestClient) -> None:
     owner_id = _seed_member(student_id="d3-owner")
     _seed_member(student_id="d3-other")
@@ -625,6 +641,60 @@ def test_stale_scheduled_log_is_reclaimed(
     _run_in_test_session(_run)
 
 
+def test_stale_sweeper_reclaims_log_without_due_event(client: TestClient) -> None:
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=30)
+        event = models.Event(
+            title="stale-sweeper",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+
+        log = await sched.create_notification_log(
+            session,
+            event_id=event_holder["id"],
+            d_type="d-3",
+            scheduled_at=datetime.now(tz=UTC),
+        )
+        assert log is not None
+        setattr(log, "status", "in_progress")
+        setattr(
+            log,
+            "updated_at",
+            datetime.now(tz=UTC)
+            - sched.SCHEDULED_LOG_STALE_AFTER
+            - timedelta(minutes=1),
+        )
+        await session.commit()
+
+    _run_in_test_session(_seed)
+
+    async def _run(session: AsyncSession) -> None:
+        reclaimed = await sched.reclaim_stale_scheduled_logs(
+            session,
+            now=datetime.now(tz=UTC),
+        )
+        assert reclaimed == 1
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "failed"
+
+    _run_in_test_session(_run)
+
+
 def test_scheduled_trigger_entrypoint_persists_delivery_state(
     admin_login: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -713,7 +783,7 @@ def test_scheduled_retry_does_not_resend_uncertain_delivery(
         await session.commit()
         await session.refresh(event)
         event_holder["id"] = int(event.id)
-        for suffix in ("first", "second"):
+        for suffix in ("first", "second", "third"):
             await subs_repo.upsert_subscription(
                 session,
                 {
@@ -745,16 +815,171 @@ def test_scheduled_retry_does_not_resend_uncertain_delivery(
         assert event is not None
         result = await sched.process_single_event(session, retry_provider, event, "d-3")
         assert result.skipped is False
-        assert result.failed == 2
-        assert retry_provider.calls == 0
+        assert result.failed == 1
+        assert retry_provider.calls == 1
         delivery_result = await session.execute(
             select(models.ScheduledNotificationDelivery).order_by(
                 models.ScheduledNotificationDelivery.id
             )
         )
         deliveries = delivery_result.scalars().all()
-        assert len(deliveries) == 2
-        assert {str(row.status) for row in deliveries} == {"unknown"}
+        assert len(deliveries) == 3
+        assert [str(row.status) for row in deliveries] == [
+            "completed",
+            "unknown",
+            "completed",
+        ]
+
+    _run_in_test_session(_retry)
+
+
+def test_scheduled_unknown_provider_result_is_not_retried(
+    client: TestClient,
+) -> None:
+    owner_id = _seed_member(student_id="d3-unknown-provider")
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="unknown-provider",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/unknown-provider",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    first_provider = _UnknownProvider()
+
+    async def _first_attempt(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, first_provider, event, "d-3")
+        assert result.failed == 1
+        assert first_provider.calls == 1
+
+        delivery_result = await session.execute(
+            select(models.ScheduledNotificationDelivery)
+        )
+        deliveries = delivery_result.scalars().all()
+        assert len(deliveries) == 1
+        assert str(deliveries[0].status) == "unknown"
+
+    _run_in_test_session(_first_attempt)
+
+    retry_provider = _NoCallProvider()
+
+    async def _retry(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, retry_provider, event, "d-3")
+        assert result.failed == 1
+        assert retry_provider.calls == 0
+
+    _run_in_test_session(_retry)
+
+
+def test_removed_subscription_delivery_is_abandoned_on_retry(
+    client: TestClient,
+) -> None:
+    owner_id = _seed_member(student_id="d3-abandoned")
+    event_holder = {"id": 0}
+    removed_endpoint = "https://example.com/push/removed-after-failure"
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="abandoned-delivery",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        for endpoint in (
+            "https://example.com/push/kept-after-failure",
+            removed_endpoint,
+        ):
+            await subs_repo.upsert_subscription(
+                session,
+                {"endpoint": endpoint, "p256dh": "p", "auth": "a"},
+                actor_member_id=owner_id,
+            )
+
+    _run_in_test_session(_seed)
+
+    class _OneSuccessOneBad(PushProvider):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            self.calls += 1
+            return (True, 201) if self.calls == 1 else (False, 400)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    first_provider = _OneSuccessOneBad()
+
+    async def _first_attempt(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, first_provider, event, "d-3")
+        assert result.failed == 1
+        await subs_repo.remove_by_endpoint_hashes(
+            session, [subs_repo.hash_endpoint(removed_endpoint)]
+        )
+
+    _run_in_test_session(_first_attempt)
+
+    retry_provider = _NoCallProvider()
+
+    async def _retry(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, retry_provider, event, "d-3")
+        assert result.failed == 0
+        assert retry_provider.calls == 0
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "completed"
+        delivery_result = await session.execute(
+            select(models.ScheduledNotificationDelivery).order_by(
+                models.ScheduledNotificationDelivery.id
+            )
+        )
+        deliveries = delivery_result.scalars().all()
+        assert {str(row.status) for row in deliveries} == {
+            "completed",
+            "abandoned",
+        }
 
     _run_in_test_session(_retry)
 
@@ -811,6 +1036,88 @@ def test_scheduled_db_failure_rolls_back_before_failed_readback(
         assert event is not None
         result = await sched.process_single_event(session, _Good(), event, "d-3")
         assert result.skipped is False
+        logs = await sched.list_scheduled_logs(session, limit=10)
+        match = [
+            log
+            for log in logs
+            if int(log.event_id) == event_holder["id"] and str(log.d_type) == "d-3"
+        ]
+        assert match
+        assert str(match[0].status) == "failed"
+
+    _run_in_test_session(_run)
+
+
+def test_final_scheduled_log_failure_is_finalized(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    owner_id = _seed_member(student_id="d3-final-log-fail")
+    event_holder = {"id": 0}
+
+    async def _seed(session: AsyncSession) -> None:
+        starts = datetime.now(tz=UTC) + timedelta(days=3)
+        event = models.Event(
+            title="final-log-fail",
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=2),
+            location="Seoul",
+            capacity=10,
+        )
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+        event_holder["id"] = int(event.id)
+        await subs_repo.upsert_subscription(
+            session,
+            {
+                "endpoint": "https://example.com/push/final-log-fail",
+                "p256dh": "p",
+                "auth": "a",
+            },
+            actor_member_id=owner_id,
+        )
+
+    _run_in_test_session(_seed)
+
+    real_update = sched.update_notification_log
+
+    async def _fail_final_update(
+        db: AsyncSession,
+        log_id: int,
+        *,
+        status: str,
+        accepted_count: int = 0,
+        failed_count: int = 0,
+    ) -> None:
+        if status == "completed":
+            raise SQLAlchemyError("final scheduled log commit failed")
+        await real_update(
+            db,
+            log_id,
+            status=status,
+            accepted_count=accepted_count,
+            failed_count=failed_count,
+        )
+
+    monkeypatch.setattr(sched, "update_notification_log", _fail_final_update)
+
+    class _Good(PushProvider):
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return (True, 201)
+
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
+
+    async def _run(session: AsyncSession) -> None:
+        event = await session.get(models.Event, event_holder["id"])
+        assert event is not None
+        result = await sched.process_single_event(session, _Good(), event, "d-3")
+        assert result.skipped is False
+        assert result.accepted == 1
         logs = await sched.list_scheduled_logs(session, limit=10)
         match = [
             log


### PR DESCRIPTION
## Summary

PR #284에서 닫힌 채 남아 있던 예약 알림 복구 경계를 #285에서 보완했고, 리뷰의 P2 4건과 P3 1건을 반영했어.

- 외부 Push 1회 단위로 delivery를 claim하고 결과를 즉시 commit해, 배치 중단 시 아직 호출하지 않은 뒤쪽 endpoint는 `pending`으로 남아 재시도되도록 수정
- provider가 `(False, None)`을 반환하면 요청 도달 여부가 불확실하므로 즉시 `unknown`으로 고정하고 재시도하지 않도록 수정
- due 이벤트 처리와 독립적인 5분 stale sweep을 추가해, D-3/D-1 실행 시점과 무관하게 멈춘 로그를 회수
- 최종 예약 로그 commit 실패도 rollback 후 `failed`로 finalize해 로그가 `in_progress`에 고착되거나 후속 이벤트 처리가 중단되지 않도록 수정
- 재시도 대상에서 빠진 `pending/failed` delivery를 `abandoned`로 정리해 완료/실패 집계와 재시도 노이즈에서 제외
- 운영 문서, dev log, 회귀 테스트를 함께 갱신

## Root cause

기존 구현은 배치 전체를 먼저 `in_progress`로 claim한 뒤 모든 외부 호출 결과를 한 번에 기록해서, 중간 프로세스 중단 시 아직 보내지 않은 endpoint까지 `unknown`으로 탈락시켰어. stale 회수도 due 이벤트 처리에만 묶여 있었고, provider의 응답 소실과 최종 로그 commit 실패를 각각 별도의 복구 경계로 처리하지 못했어.

## Verification

- `.venv/bin/pytest -q` — **269 passed**, 1 warning
- `.venv/bin/pytest -q tests/api/test_d3_push_authority.py` — **18 passed**, 1 warning
- `.venv/bin/ruff check apps/api` — passed
- `.venv/bin/ruff format --check ...` — passed
- `.venv/bin/python -m pyright --project pyrightconfig.json` — 0 errors, 기존 경고 2개
- `.venv/bin/python ops/ci/guards.py` — passed
- `.venv/bin/python ops/ci/check_versions.py` — passed
- `bash ops/ci/test_githooks.sh` — passed
- pre-push hook — pyright, bandit, OpenAPI/DTO sync passed; CI pytest는 hook 정책에 따라 생략
- 전용 PostgreSQL test DB `alembic upgrade head` + schema readback — `c8a7f3d1e2b4 (head)`, delivery table/columns/indexes 확인
- `alembic check`에는 이번 변경과 무관한 기존 index drift 7건만 남음

Related: #284