### PR TITLE
feat(db): migration gate 및 동문 검색 인덱스 정비 (D5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt
           pip install pip-audit bandit
+      - name: Alembic migration and schema drift gate
+        env:
+          DATABASE_URL: postgresql+psycopg://app:devpass@localhost:5434/appdb_test
+        run: python ops/ci/migration_gate.py --require-empty
       - name: Lint
         run: ruff check apps/api
       - name: Type check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         run: python ops/ci/guards.py
       - name: Git hooks integration tests
         run: bash ops/ci/test_githooks.sh
+      - name: Cloud migration command contract
+        run: bash ops/ci/test_cloud_migrate.sh
       - name: Enforce standardized versions
         run: python ops/ci/check_versions.py
       - name: Validate Dependabot policy

--- a/apps/api/migrations/versions/d5f2a1c9e7b3_add_directory_search_trgm_indexes.py
+++ b/apps/api/migrations/versions/d5f2a1c9e7b3_add_directory_search_trgm_indexes.py
@@ -1,0 +1,48 @@
+"""add selected directory search trigram indexes
+
+Revision ID: d5f2a1c9e7b3
+Revises: c8a7f3d1e2b4
+Create Date: 2026-08-02 00:00:00.000000
+
+검색 workload와 PostgreSQL plan 측정 결과에 따라 부분문자열 검색의
+선택도가 충분한 student_id와 company만 추가한다. major와 industry는
+현실적인 분포에서 선택도가 낮아 GIN 인덱스를 추가하지 않는다.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5f2a1c9e7b3"
+down_revision: str | None = "c8a7f3d1e2b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # pg_trgm은 기존 migration에서 생성되지만, 이 migration만 재적용해도
+    # extension 계약이 명시되도록 유지한다. 운영 계정이 extension을 만들
+    # 권한이 없으면 migration을 진행하지 않고 명시적으로 실패한다.
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # CREATE INDEX CONCURRENTLY는 트랜잭션 밖에서만 가능하다. IF NOT EXISTS는
+    # 재시도 시 이미 성공한 개별 인덱스를 보존하지만, invalid index는 운영자가
+    # catalog에서 확인하고 정리한 뒤 재시도해야 한다.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_members_student_id_trgm "
+            "ON members USING gin (student_id gin_trgm_ops)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_members_company_trgm "
+            "ON members USING gin (company gin_trgm_ops)"
+        )
+
+
+def downgrade() -> None:
+    # 인덱스만 제거하며 pg_trgm extension은 기존 5개 인덱스가 계속 사용하므로
+    # 제거하지 않는다. downgrade도 CONCURRENTLY 제약을 동일하게 지킨다.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_members_company_trgm")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_members_student_id_trgm")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -110,6 +110,23 @@ class Member(Base):
 
 Index("ix_members_updated_at", Member.updated_at)
 Index("ix_members_cohort_name", Member.cohort, Member.name)
+# PostgreSQL 전용 검색 인덱스도 migration과 metadata가 같은 catalog 계약을
+# 표현한다. 실제 생성·삭제는 운영 lock 규칙을 지키는 migration이 담당한다.
+for _index_name, _column, _column_name in (
+    ("idx_members_name_trgm", Member.name, "name"),
+    ("idx_members_email_trgm", Member.email, "email"),
+    ("idx_members_addr_personal_trgm", Member.addr_personal, "addr_personal"),
+    ("idx_members_addr_company_trgm", Member.addr_company, "addr_company"),
+    ("idx_members_job_title_trgm", Member.job_title, "job_title"),
+    ("idx_members_student_id_trgm", Member.student_id, "student_id"),
+    ("idx_members_company_trgm", Member.company, "company"),
+):
+    Index(
+        _index_name,
+        _column,
+        postgresql_using="gin",
+        postgresql_ops={_column_name: "gin_trgm_ops"},
+    )
 
 
 class Post(Base):
@@ -249,6 +266,7 @@ Index(
 
 class RSVP(Base):
     __tablename__ = "rsvps"
+    __table_args__ = (Index("ix_rsvps_event_status", "event_id", "status"),)
 
     member_id = Column(
         Integer,
@@ -420,6 +438,13 @@ class ProfileChangeRequest(Base):
 
 class PushSubscription(Base):
     __tablename__ = "push_subscriptions"
+    __table_args__ = (
+        Index(
+            "ix_push_subs_active",
+            "id",
+            postgresql_where=text("revoked_at IS NULL"),
+        ),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     member_id = Column(

--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -73,6 +73,32 @@ ORDER BY category NULLS FIRST;
 
 조회 결과와 판단을 배포 기록에 남긴 뒤 기존 릴리스 태그를 롤백 대상으로 보존한다.
 
+### D5 Alembic·검색 인덱스 migration 운영 규칙
+
+배포 이미지의 `ops/cloud-migrate.sh`가 기본값으로
+`alembic -c apps/api/alembic.ini upgrade head`를 실행한다. D5 revision
+`d5f2a1c9e7b3`는 `pg_trgm` extension을 확인·생성하고
+`student_id`·`company` GIN index를 `CREATE INDEX CONCURRENTLY`로 만든다.
+따라서 이 migration을 별도 트랜잭션으로 감싸거나 `--sql` 출력만으로 적용하지
+않는다. 인덱스 build 중에는 lock·build 상태를 관찰하고, 실패 시 해당 이름의
+invalid index가 없는지 catalog를 확인한 뒤 운영 승인 하에 재시도한다.
+
+적용 후에는 API 재기동 전 다음처럼 version과 검색 catalog를 readback한다.
+
+```bash
+docker run --rm --network sogecon_net --env-file .env.api \
+  "$API_IMAGE" bash -lc \
+  'alembic -c apps/api/alembic.ini current && \
+   psql "$DATABASE_URL" -c "SELECT extname, extversion FROM pg_extension WHERE extname = '\''pg_trgm'\'';" && \
+   psql "$DATABASE_URL" -c "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = '\''public'\'' AND indexname IN ('\''idx_members_student_id_trgm'\'', '\''idx_members_company_trgm'\'') ORDER BY indexname;"'
+```
+
+D5 rollback은 애플리케이션 릴리스 rollback과 별개로 승인 후
+`alembic -c apps/api/alembic.ini downgrade -1`을 실행한다. 두 GIN index만
+`DROP INDEX CONCURRENTLY`로 제거하고, 기존 검색 index가 사용하므로
+`pg_trgm` extension은 제거하지 않는다. 운영 DB mutation은 이 runbook을
+따르는 운영자만 수행하며, 이번 D5 검증에서는 실행하지 않는다.
+
 ```bash
 cd /srv/sogecon-app
 git pull --ff-only origin main

--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -90,7 +90,8 @@ one-shot migration으로 종료되게 한다. 인덱스 build 중에는 lock·bu
 version과 검색 catalog를 readback한다. `--readback-only`는 upgrade와
 `alembic check`를 건너뛰고 DB를 변경하지 않으며, Alembic current/head,
 `pg_trgm`, 기대 index의 public table·column·access method·operator class와
-`indisvalid`·`indisready`·`indislive`를 PostgreSQL catalog에서 구조적으로
+`pg_index.indpred IS NULL`, `indisvalid`·`indisready`·`indislive`를
+PostgreSQL catalog에서 구조적으로
 확인한다. API 이미지 내부에서 `psql`을 호출하거나 `pg_indexes.indexdef`
 문자열을 파싱하지 않는다.
 

--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -80,24 +80,61 @@ ORDER BY category NULLS FIRST;
 `d5f2a1c9e7b3`는 `pg_trgm` extension을 확인·생성하고
 `student_id`·`company` GIN index를 `CREATE INDEX CONCURRENTLY`로 만든다.
 따라서 이 migration을 별도 트랜잭션으로 감싸거나 `--sql` 출력만으로 적용하지
-않는다. 인덱스 build 중에는 lock·build 상태를 관찰하고, 실패 시 해당 이름의
-invalid index가 없는지 catalog를 확인한 뒤 운영 승인 하에 재시도한다.
+않는다. API 이미지의 고정 uvicorn entrypoint는 운영 API 실행 계약이므로
+전역적으로 바꾸지 않는다. 대신 `cloud-migrate.sh`가 `docker run`에서
+`--entrypoint /bin/sh`를 명시하고 `IMAGE -lc "$ALEMBIC_CMD"`를 실행해
+one-shot migration으로 종료되게 한다. 인덱스 build 중에는 lock·build 상태를
+관찰한다.
 
-적용 후에는 API 재기동 전 다음처럼 version과 검색 catalog를 readback한다.
+적용 후에는 API 재기동 전 같은 API 이미지에 포함된 Python gate를 사용해
+version과 검색 catalog를 readback한다. `--readback-only`는 upgrade와
+`alembic check`를 건너뛰고 DB를 변경하지 않으며, Alembic current/head,
+`pg_trgm`, 기대 index의 public table·column·access method·operator class와
+`indisvalid`·`indisready`·`indislive`를 PostgreSQL catalog에서 구조적으로
+확인한다. API 이미지 내부에서 `psql`을 호출하거나 `pg_indexes.indexdef`
+문자열을 파싱하지 않는다.
 
 ```bash
-docker run --rm --network sogecon_net --env-file .env.api \
-  "$API_IMAGE" bash -lc \
-  'alembic -c apps/api/alembic.ini current && \
-   psql "$DATABASE_URL" -c "SELECT extname, extversion FROM pg_extension WHERE extname = '\''pg_trgm'\'';" && \
-   psql "$DATABASE_URL" -c "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = '\''public'\'' AND indexname IN ('\''idx_members_student_id_trgm'\'', '\''idx_members_company_trgm'\'') ORDER BY indexname;"'
+docker run --rm --entrypoint /bin/sh --network sogecon_net --env-file .env.api \
+  "$API_IMAGE" -lc \
+  'python ops/ci/migration_gate.py --readback-only'
 ```
 
 D5 rollback은 애플리케이션 릴리스 rollback과 별개로 승인 후
-`alembic -c apps/api/alembic.ini downgrade -1`을 실행한다. 두 GIN index만
-`DROP INDEX CONCURRENTLY`로 제거하고, 기존 검색 index가 사용하므로
-`pg_trgm` extension은 제거하지 않는다. 운영 DB mutation은 이 runbook을
-따르는 운영자만 수행하며, 이번 D5 검증에서는 실행하지 않는다.
+`ALEMBIC_CMD='alembic -c apps/api/alembic.ini downgrade -1' \
+  bash ops/cloud-migrate.sh`로 실행한다. 두 GIN index만 `DROP INDEX CONCURRENTLY`로
+역순 제거하고, 기존 검색 index가 사용하므로 `pg_trgm` extension은 제거하지
+않는다. 운영 DB mutation은 이 runbook을 따르는 운영자만 수행하며, 이번 D5
+검증에서는 실행하지 않는다.
+
+실패한 `CREATE INDEX CONCURRENTLY`는 이름이 남은 invalid/not-ready index를
+만들 수 있다. 이 상태에서 `CREATE INDEX CONCURRENTLY IF NOT EXISTS`를 다시
+실행하면 이름 충돌로 실제 재생성이 되지 않을 수 있다. 먼저 위
+`--readback-only` gate로 exact index 이름과 catalog flag를 확인하고, 승인된
+운영 절차에서 해당 invalid index만 `DROP INDEX CONCURRENTLY`로 제거한 뒤
+`cloud-migrate.sh`를 재실행하고 다시 readback한다. 다른 index나 데이터를
+삭제하지 않으며, 여러 pending revision 중 뒤 revision이 실패하면 앞선
+revision이 `autocommit_block()` 때문에 이미 커밋되어 중간 `alembic current`가
+남을 수 있으므로 current를 확인한 후 그 지점부터 재개한다.
+
+`--require-empty`는 CI와 local disposable DB에서만 사용한다. 재실행 전에
+정확한 전용 DB를 drop/create하고, 기존 `appdb`·`appdb_test` 또는 운영 DB를
+대상으로 하지 않는다.
+
+```bash
+# 예시: local disposable PostgreSQL에서만 실행
+docker compose --profile dev exec -T postgres_test \
+  psql -U app -d postgres -c 'DROP DATABASE IF EXISTS d5_migration_gate_local'
+docker compose --profile dev exec -T postgres_test \
+  psql -U app -d postgres -c 'CREATE DATABASE d5_migration_gate_local'
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/d5_migration_gate_local \
+  .venv/bin/python ops/ci/migration_gate.py --require-empty
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/d5_migration_gate_local \
+  .venv/bin/python ops/ci/migration_gate.py --readback-only
+```
+
+마지막으로 전용 DB를 drop하고, migration 실패 시 남은 invalid index와 중간
+`alembic current`를 배포 기록에 남긴다.
 
 ```bash
 cd /srv/sogecon-app

--- a/docs/agent_runbook_vps_en.md
+++ b/docs/agent_runbook_vps_en.md
@@ -87,12 +87,64 @@ API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
   bash ops/cloud-start.sh
 ```
 
-## 4) Cookie/domain switches
+## 4) D5 migration and catalog readback
+
+The Korean runbook is the canonical policy source; the D5 operational details are
+also reproduced here so an English-reading operator does not skip the safety steps:
+[D5 migration/readback procedure](agent_runbook_vps.md).
+
+Run the migration as a one-shot container command before restarting the API. The
+repository script explicitly overrides the image's fixed uvicorn entrypoint with
+`/bin/sh -lc`; do not change the global API entrypoint or run a shell command after
+the image without the override.
+
+```bash
+cd /srv/sogecon-app
+ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net \
+  bash ops/cloud-migrate.sh
+```
+
+After the one-shot migration exits successfully, use the same API image and the
+same `postgresql+psycopg://` `DATABASE_URL` for the non-mutating operational readback
+before restarting the API. This also explicitly bypasses the fixed entrypoint:
+
+```bash
+docker run --rm --network sogecon_net --env-file .env.api \
+  --entrypoint /bin/sh "$API_IMAGE" -lc \
+  'python ops/ci/migration_gate.py --readback-only'
+```
+
+The readback must show a single Alembic head, `pg_trgm`, and each expected
+`members` GIN index with the expected column and `gin_trgm_ops`. Each expected
+index must be a full index (`pg_index.indpred IS NULL`) and must have
+`indisvalid=true`, `indisready=true`, and `indislive=true`. A valid partial index
+with the expected name, table, column, access method, and operator class is not
+acceptable.
+
+If `CREATE INDEX CONCURRENTLY` fails, inspect the exact catalog row before retrying.
+An invalid, not-ready, not-live, wrong-method, or partial index with the expected
+name can cause `CREATE INDEX CONCURRENTLY IF NOT EXISTS` to skip the desired full
+index. Approve only the exact expected full index. Otherwise run the narrow,
+non-destructive recovery sequence: read back the exact index name, run
+`DROP INDEX CONCURRENTLY IF EXISTS public.<exact-index-name>`, retry the migration,
+then run the Python readback again. Do not drop unrelated indexes or use a blanket
+catalog exception.
+
+`autocommit_block()` can commit earlier revisions before a later concurrent
+revision fails. After such a failure, `alembic current` may show an intermediate
+revision and the database may be partially applied. Read back the current revision
+and catalog state first, then resume or roll back according to the exact state.
+
+`--require-empty` is only for a named disposable local database. Drop and recreate
+that exact database before rerunning it; never run it against `appdb`, `appdb_test`,
+production, or a VPS operational database.
+
+## 5) Cookie/domain switches
 - Subdomain stage: `COOKIE_SAMESITE=lax`, `COOKIE_SECURE=true`.
 - Cross‑site domains: `COOKIE_SAMESITE=none`, `COOKIE_SECURE=true` (HTTPS required).
 - Location: `.env.api` → applied by `SessionMiddleware` in `apps/api/main.py`.
 
-## 5) Web without container (Next.js standalone + systemd + Nginx)
+## 6) Web without container (Next.js standalone + systemd + Nginx)
 
 Run the Next.js `standalone` build as a systemd service. DB/API containers remain unchanged.
 
@@ -155,12 +207,12 @@ Notes
 - Alternative (in repo): `RELEASE_BASE=/srv/sogecon-app/.releases/web`
   - How‑to: pass `RELEASE_BASE` to `ops/web-deploy.sh` and update `WorkingDirectory` in `ops/systemd/sogecon-web.service` accordingly
 
-## 6) Troubleshooting
+## 7) Troubleshooting
 - Next public envs not applied: `NEXT_PUBLIC_*` are build‑time only — rebuild required.
 - Uploads permission error: ensure `/var/lib/sogecon/uploads` owner uid 1000.
 - Health check fails: verify Nginx upstream to 127.0.0.1:3000/3001 and TLS cert paths.
 
-## References
+## 8) References
 - Detailed deploy docs: `ops/deploy_api.md`, `ops/deploy_web.md`
 - Nginx examples: `ops/nginx-examples/`
 - CI workflows: `.github/workflows/ci.yml`, `.github/workflows/dto-verify.yml`, `.github/workflows/codeql.yml`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@
 - **라우터 구성**: `routers/` 하위 `members.py`, `posts.py`, `board_posts.py`, `events.py`, `rsvps.py`가 서비스만 호출하도록 리팩터링 완료(초판). `posts.py`의 관리자 mutation과 `board_posts.py`의 회원 owner mutation은 권한 경계를 공유하지 않는다.
 - **DB 세션 관리**: `db.py`의 `get_db()` 의존성을 통해 요청 단위 세션 생성/정리.
 - **마이그레이션**: `migrations/` 하위 Alembic 스크립트로 버전 관리. 새로운 모델 변경 시 `alembic revision --autogenerate` 사용 후 코드 검토한다. PostgreSQL의 실제 catalog가 권위이며, 모델 metadata에도 운영 인덱스 계약을 표현해 `alembic check`가 일반 테이블·컬럼·인덱스 drift를 검출하도록 유지한다.
-- **마이그레이션 필수 게이트**: `ops/ci/migration_gate.py --require-empty`가 빈 PostgreSQL에서 최초 revision부터 `upgrade head`와 `alembic check`를 실행하고, `alembic_version`, `pg_trgm`, 기대 GIN 인덱스를 catalog에서 readback한다. CI의 PostgreSQL 서비스와 로컬 전용 disposable DB에서 같은 명령을 실행한다.
+- **마이그레이션 필수 게이트**: `ops/ci/migration_gate.py --require-empty`가 빈 PostgreSQL에서 최초 revision부터 `upgrade head`와 `alembic check`를 실행하고, `alembic_version`, `pg_trgm`, 기대 GIN 인덱스를 PostgreSQL 구조적 catalog에서 readback한다. `--readback-only`는 같은 Python gate를 운영 readback에 재사용하되 DB를 변경하지 않는다. CI의 PostgreSQL 서비스와 로컬 전용 disposable DB에서 같은 authority를 실행한다.
 - **검색 인덱스 운영 계약**: `d5f2a1c9e7b3`는 `student_id`와 `company`의 부분문자열 검색만 `pg_trgm` GIN으로 보완한다. 기존 `name`·`email`·주소·직함 GIN은 유지하고, 낮은 선택도의 `major`·`industry`에는 인덱스를 추가하지 않는다. `CREATE/DROP INDEX CONCURRENTLY`는 migration의 autocommit block 안에서 수행하며, 운영 migration을 외부 트랜잭션으로 감싸지 않는다.
 - **예정 기능**: 인증(예: OAuth2, SSO), 권한 레이어, 감사 로깅, 웹훅 등은 추후 설계 항목으로 남겨둔다.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@
   - `apps/api/repositories/`: SQLAlchemy를 통한 영속성 접근. 쿼리/정렬/페이징 책임을 가짐.
 - **라우터 구성**: `routers/` 하위 `members.py`, `posts.py`, `board_posts.py`, `events.py`, `rsvps.py`가 서비스만 호출하도록 리팩터링 완료(초판). `posts.py`의 관리자 mutation과 `board_posts.py`의 회원 owner mutation은 권한 경계를 공유하지 않는다.
 - **DB 세션 관리**: `db.py`의 `get_db()` 의존성을 통해 요청 단위 세션 생성/정리.
-- **마이그레이션**: `migrations/` 하위 Alembic 스크립트로 버전 관리. 새로운 모델 변경 시 `alembic revision --autogenerate` 사용 후 코드 검토.
+- **마이그레이션**: `migrations/` 하위 Alembic 스크립트로 버전 관리. 새로운 모델 변경 시 `alembic revision --autogenerate` 사용 후 코드 검토한다. PostgreSQL의 실제 catalog가 권위이며, 모델 metadata에도 운영 인덱스 계약을 표현해 `alembic check`가 일반 테이블·컬럼·인덱스 drift를 검출하도록 유지한다.
+- **마이그레이션 필수 게이트**: `ops/ci/migration_gate.py --require-empty`가 빈 PostgreSQL에서 최초 revision부터 `upgrade head`와 `alembic check`를 실행하고, `alembic_version`, `pg_trgm`, 기대 GIN 인덱스를 catalog에서 readback한다. CI의 PostgreSQL 서비스와 로컬 전용 disposable DB에서 같은 명령을 실행한다.
+- **검색 인덱스 운영 계약**: `d5f2a1c9e7b3`는 `student_id`와 `company`의 부분문자열 검색만 `pg_trgm` GIN으로 보완한다. 기존 `name`·`email`·주소·직함 GIN은 유지하고, 낮은 선택도의 `major`·`industry`에는 인덱스를 추가하지 않는다. `CREATE/DROP INDEX CONCURRENTLY`는 migration의 autocommit block 안에서 수행하며, 운영 migration을 외부 트랜잭션으로 감싸지 않는다.
 - **예정 기능**: 인증(예: OAuth2, SSO), 권한 레이어, 감사 로깅, 웹훅 등은 추후 설계 항목으로 남겨둔다.
 
 ## 프런트엔드 구조
@@ -93,11 +95,12 @@
 - 세션은 남아 있지만 해당 회원 행이 삭제된 비정상 상태에서는 목록·건수는 빈 결과로 닫고 상세는 `member_not_found`를 반환합니다. 어떤 경로에서도 다른 회원 정보는 노출하지 않습니다.
 - `DirectoryMemberRead`는 학번, 역할, 계정 상태를 제외한 동문 수첩 전용 DTO입니다. 관리 화면은 권한이 적용된 `/admin/members` 계약을 사용합니다.
 - 조회자별 건수는 공개 범위 변경을 즉시 반영하기 위해 캐시하지 않습니다.
+- 동문 수첩 검색은 `MemberRepository`의 `ILIKE` 조건과 동일한 결과 계약을 유지한다. D5에서 실제 plan이 인덱스를 선택한 `student_id`·`company`만 GIN을 추가했고, `major`·`industry`는 현실적인 분포에서 순차 스캔이 선택되어 제외했다. 인덱스 전후 exact·partial·case-insensitive 대표 결과 digest는 동일하다.
 
 ## 품질 및 운영 가드레일
 - **정적 검사**: `ruff`, `pyright`, `eslint`, `tsc --noEmit`.
 - **테스트**: `pytest -q`로 API 단위 테스트, 웹 쪽은 `vitest`/`@testing-library/react` 도입 예정.
-- **CI 파이프라인**: PR Ready 전환 시 lint → type check → build 순서. 비밀 검출은 `gitleaks`로 수행.
+- **CI 파이프라인**: PR Ready 전환 시 repository guards와 빈 PostgreSQL migration/schema drift gate를 먼저 통과한 뒤 lint → type check → build 순서로 진행한다. 비밀 검출은 `gitleaks`로 수행한다. API 테스트 fixture가 `create_all()`을 사용하는 경우에도 migration gate가 스키마의 권위 있는 검증 경로다.
 - **로그 정책**: 상세 이력은 커밋/PR 히스토리로 관리하고, 개발 세션 별로 `docs/dev_log_YYMMDD.md`를 업데이트.
 
 ## 배포 및 환경 구성

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -27,6 +27,9 @@ pnpm -C apps/web install
 .venv/bin/python ops/ci/guards.py
 .venv/bin/python ops/ci/check_versions.py
 pnpm exec commitlint --from origin/main --to HEAD --config docs/commitlint.config.cjs
+# 빈 PostgreSQL 서비스에서 최초 revision부터 upgrade/check/catalog readback
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test \
+  .venv/bin/python ops/ci/migration_gate.py --require-empty
 .venv/bin/ruff check apps/api
 .venv/bin/python -m pyright --project pyrightconfig.json
 .venv/bin/pytest -q
@@ -42,7 +45,7 @@ git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 | Job | 내용 |
 |-----|------|
 | `repo-guards` | guards, versions, **commitlint (hard)** |
-| `python` | ruff, pyright, pytest, bandit, pip-audit |
+| `python` | 빈 PostgreSQL Alembic upgrade·schema drift·catalog gate, ruff, pyright, pytest, bandit, pip-audit |
 | `contract` | OpenAPI export + DTO drift |
 | `web` | **eslint**, **vitest 전체**, build, a11y smoke, bundle, pnpm audit |
 | `secrets-scan` | gitleaks |
@@ -85,7 +88,17 @@ bash ops/ci/apply_main_branch_protection.sh              # 기본: ginishuh/soge
 bash ops/ci/apply_main_branch_protection.sh OWNER/REPO   # 다른 포크
 ```
 
-Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다.
+Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다. `python` job의 migration gate는 테스트 fixture와 독립적으로 빈 PostgreSQL에서 실행되며, `alembic_version`, `pg_extension`, `pg_indexes` readback까지 통과해야 한다.
+
+## Alembic migration/schema drift gate (D5)
+
+`ops/ci/migration_gate.py`가 D5의 authoritative schema gate다.
+
+- `--require-empty`: public table이 없는 PostgreSQL에서 `alembic upgrade head`를 실행한다.
+- upgrade 직후 `alembic check`를 실행해 현재 모델 metadata와 migration-created catalog의 drift를 검출한다. 모델에 표현 가능한 기존 PostgreSQL 인덱스는 metadata에 선언했고, 일반 drift를 숨기는 `include_object`/`compare_index` blanket 예외는 두지 않았다.
+- `alembic_version`가 단일 head인지, `pg_trgm` extension이 존재하는지, 기존 5개와 D5의 2개 GIN trgm index 이름·operator class가 `pg_indexes`에서 일치하는지 확인한다.
+- `tests/api/test_migration_gate.py`의 negative regression은 정상 모델의 컬럼·테이블·인덱스가 migration에 누락되었을 때 Alembic comparator가 각각 `add_column`·`add_table`·`add_index`를 반환하는 것을 고정한다.
+- 기존 schema DB에는 `--require-empty` 없이 같은 upgrade를 적용하고 current/catalog를 readback한다. 역사적으로 남은 별도 인덱스는 삭제하거나 gate에서 숨기지 않고 별도 drift로 기록한다. 따라서 기존 local `appdb`의 `signup_activation_issue_logs` 추가 index 4개가 있으면 authoritative `alembic check`는 의도적으로 FAIL하며, D5에서 임의로 정렬하지 않는다.
 
 ## 훅 통합 테스트
 

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -27,12 +27,24 @@ pnpm -C apps/web install
 .venv/bin/python ops/ci/guards.py
 .venv/bin/python ops/ci/check_versions.py
 pnpm exec commitlint --from origin/main --to HEAD --config docs/commitlint.config.cjs
-# 빈 PostgreSQL 서비스에서 최초 revision부터 upgrade/check/catalog readback
-DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test \
+# D5 전용 disposable PostgreSQL만 사용한다. appdb/appdb_test/운영 DB는 금지.
+# 기존 DB가 있으면 먼저 정확한 이름만 drop하고 같은 이름으로 create한다.
+D5_DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/d5_migration_gate_local
+docker compose --profile dev exec -T postgres_test psql -U app -d postgres \
+  -c 'DROP DATABASE IF EXISTS d5_migration_gate_local'
+docker compose --profile dev exec -T postgres_test psql -U app -d postgres \
+  -c 'CREATE DATABASE d5_migration_gate_local'
+D5_DATABASE_URL="$D5_DATABASE_URL" \
+  DATABASE_URL="$D5_DATABASE_URL" \
   .venv/bin/python ops/ci/migration_gate.py --require-empty
-# 이미 upgrade된 DB의 무변경 catalog/version readback만 필요한 경우
-DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test \
+# upgrade 후 같은 disposable DB의 version/extension/index catalog만 readback
+D5_DATABASE_URL="$D5_DATABASE_URL" \
+  DATABASE_URL="$D5_DATABASE_URL" \
   .venv/bin/python ops/ci/migration_gate.py --readback-only
+docker compose --profile dev exec -T postgres_test psql -U app -d postgres \
+  -c 'DROP DATABASE IF EXISTS d5_migration_gate_local'
+# GitHub CI는 service host/port를 workflow가 주입한다. 위 localhost URL을 CI에 복사하지 않는다.
+# canonical 운영 절차: docs/agent_runbook_vps.md의 D5 migration/readback 절
 .venv/bin/ruff check apps/api
 .venv/bin/python -m pyright --project pyrightconfig.json
 .venv/bin/pytest -q
@@ -106,8 +118,8 @@ Python gate의 `--readback-only` 경로를 사용하므로 API 이미지 안에�
 - `--readback-only`: upgrade와 `alembic check`를 생략하고 current/head, extension,
   기대 index catalog만 읽는다. DB mutation이 없는 운영 readback 전용 모드다.
 - upgrade 직후 `alembic check`를 실행해 현재 모델 metadata와 migration-created catalog의 drift를 검출한다. 모델에 표현 가능한 기존 PostgreSQL 인덱스는 metadata에 선언했고, 일반 drift를 숨기는 `include_object`/`compare_index` blanket 예외는 두지 않았다.
-- `alembic_version`가 단일 head인지, `pg_trgm` extension이 존재하는지, 기존 5개와 D5의 2개 GIN trgm index가 public `members`의 기대 column에 있고 `gin_trgm_ops`를 사용하며 `indisvalid`·`indisready`·`indislive`인지 구조적으로 확인한다. `pg_indexes.indexdef` 문자열 포함 여부로 PASS를 만들지 않는다.
-- `tests/api/test_migration_gate.py`는 전용 disposable PostgreSQL에 repository `apps/api/migrations/env.py`, `models.Base.metadata`, 실제 gate subprocess를 연결한다. 정상 head를 적용한 뒤 unmigrated column/table/index를 주입하면 실제 `alembic check`가 실패하고, 실패한 concurrent index catalog도 readback gate가 nonzero가 되는 것을 고정한다.
+- `alembic_version`가 단일 head인지, `pg_trgm` extension이 존재하는지, 기존 5개와 D5의 2개 GIN trgm index가 public `members`의 기대 column에 있고 `gin_trgm_ops`를 사용하며 `pg_index.indpred IS NULL`, `indisvalid`·`indisready`·`indislive`인지 구조적으로 확인한다. `pg_indexes.indexdef` 문자열 포함 여부로 PASS를 만들지 않는다.
+- `tests/api/test_migration_gate.py`는 전용 disposable PostgreSQL에 repository `apps/api/migrations/env.py`, `models.Base.metadata`, 실제 gate subprocess를 연결한다. 정상 head를 적용한 뒤 unmigrated column/table/index를 주입하면 실제 `alembic check`가 실패하고, 실패한 concurrent index와 valid same-name partial index도 readback gate가 nonzero가 되는 것을 고정한다.
 - 기존 schema DB에는 `--require-empty` 없이 같은 upgrade를 적용하고 current/catalog를 readback한다. 역사적으로 남은 별도 인덱스는 삭제하거나 gate에서 숨기지 않고 별도 drift로 기록한다. 따라서 기존 local `appdb`의 `signup_activation_issue_logs` 추가 index 4개가 있으면 authoritative `alembic check`는 의도적으로 FAIL하며, D5에서 임의로 정렬하지 않는다.
 
 `--require-empty`를 local에서 다시 실행할 때는 매번 정확한 disposable DB를

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -30,6 +30,9 @@ pnpm exec commitlint --from origin/main --to HEAD --config docs/commitlint.confi
 # 빈 PostgreSQL 서비스에서 최초 revision부터 upgrade/check/catalog readback
 DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test \
   .venv/bin/python ops/ci/migration_gate.py --require-empty
+# 이미 upgrade된 DB의 무변경 catalog/version readback만 필요한 경우
+DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/appdb_test \
+  .venv/bin/python ops/ci/migration_gate.py --readback-only
 .venv/bin/ruff check apps/api
 .venv/bin/python -m pyright --project pyrightconfig.json
 .venv/bin/pytest -q
@@ -88,22 +91,41 @@ bash ops/ci/apply_main_branch_protection.sh              # 기본: ginishuh/soge
 bash ops/ci/apply_main_branch_protection.sh OWNER/REPO   # 다른 포크
 ```
 
-Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다. `python` job의 migration gate는 테스트 fixture와 독립적으로 빈 PostgreSQL에서 실행되며, `alembic_version`, `pg_extension`, `pg_indexes` readback까지 통과해야 한다.
+Draft PR은 job이 skip되므로 Ready 전환 후 CI가 녹색인지 확인한다. `python` job의
+migration gate는 테스트 fixture와 독립적으로 빈 PostgreSQL에서 실행되며,
+`alembic_version`, `pg_extension`, `pg_class`/`pg_index`/`pg_am`/`pg_attribute`/
+`pg_opclass` 구조적 catalog readback까지 통과해야 한다. 운영 readback도 같은
+Python gate의 `--readback-only` 경로를 사용하므로 API 이미지 안에서 별도 `psql`
+명령을 유지하지 않는다.
 
 ## Alembic migration/schema drift gate (D5)
 
 `ops/ci/migration_gate.py`가 D5의 authoritative schema gate다.
 
 - `--require-empty`: public table이 없는 PostgreSQL에서 `alembic upgrade head`를 실행한다.
+- `--readback-only`: upgrade와 `alembic check`를 생략하고 current/head, extension,
+  기대 index catalog만 읽는다. DB mutation이 없는 운영 readback 전용 모드다.
 - upgrade 직후 `alembic check`를 실행해 현재 모델 metadata와 migration-created catalog의 drift를 검출한다. 모델에 표현 가능한 기존 PostgreSQL 인덱스는 metadata에 선언했고, 일반 drift를 숨기는 `include_object`/`compare_index` blanket 예외는 두지 않았다.
-- `alembic_version`가 단일 head인지, `pg_trgm` extension이 존재하는지, 기존 5개와 D5의 2개 GIN trgm index 이름·operator class가 `pg_indexes`에서 일치하는지 확인한다.
-- `tests/api/test_migration_gate.py`의 negative regression은 정상 모델의 컬럼·테이블·인덱스가 migration에 누락되었을 때 Alembic comparator가 각각 `add_column`·`add_table`·`add_index`를 반환하는 것을 고정한다.
+- `alembic_version`가 단일 head인지, `pg_trgm` extension이 존재하는지, 기존 5개와 D5의 2개 GIN trgm index가 public `members`의 기대 column에 있고 `gin_trgm_ops`를 사용하며 `indisvalid`·`indisready`·`indislive`인지 구조적으로 확인한다. `pg_indexes.indexdef` 문자열 포함 여부로 PASS를 만들지 않는다.
+- `tests/api/test_migration_gate.py`는 전용 disposable PostgreSQL에 repository `apps/api/migrations/env.py`, `models.Base.metadata`, 실제 gate subprocess를 연결한다. 정상 head를 적용한 뒤 unmigrated column/table/index를 주입하면 실제 `alembic check`가 실패하고, 실패한 concurrent index catalog도 readback gate가 nonzero가 되는 것을 고정한다.
 - 기존 schema DB에는 `--require-empty` 없이 같은 upgrade를 적용하고 current/catalog를 readback한다. 역사적으로 남은 별도 인덱스는 삭제하거나 gate에서 숨기지 않고 별도 drift로 기록한다. 따라서 기존 local `appdb`의 `signup_activation_issue_logs` 추가 index 4개가 있으면 authoritative `alembic check`는 의도적으로 FAIL하며, D5에서 임의로 정렬하지 않는다.
+
+`--require-empty`를 local에서 다시 실행할 때는 매번 정확한 disposable DB를
+drop/create한다. `CREATE/DROP INDEX CONCURRENTLY`가 포함된
+`autocommit_block()`에서 여러 pending revision 중 뒤 revision이 실패하면 앞선
+revision이 부분 커밋된 상태와 중간 `alembic current`가 남을 수 있다. 실패 후에는
+current와 invalid/not-ready index를 먼저 readback하고, 이름이 남은 invalid index를
+`IF NOT EXISTS`로 덮으려 하지 말고 정확한 index만 concurrent drop 후 재실행한다.
+
+관측된 CI 영향은 migration gate 약 1.6초, Python job 약 4분 15초였고 병렬화·캐시
+구조 변경은 하지 않았다.
 
 ## 훅 통합 테스트
 
 ```bash
 bash ops/ci/test_githooks.sh
+# cloud-migrate fixed-entrypoint and shell-argument contract
+bash ops/ci/test_cloud_migrate.sh
 # 또는
 make test-hooks
 ```

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -32,3 +32,50 @@
   `pr286admin` fixture 계정을 삭제했다. 삭제 후 두 row count 모두 0이며 3000/3001
   포트와 PR286 임시 파일도 남기지 않았다. `.agents/skills/playwright-cli`
   는 CLI 버전 경고 때문에 설치·갱신하지 않았다.
+
+## D5 migration gate 및 동문 검색 인덱스 정비
+
+- 기준점/범위: `2f136ef276e71734c6cd2f553e58774f3acdacd5`에서 #252·#266을 함께
+  구현했다. 운영 DB/VPS에는 접근하지 않았고, local PostgreSQL의 비민감 row를
+  read-only 확인한 뒤 120,000-row synthetic disposable DB를 별도로 사용했다.
+- Baseline 정렬: 기존 `name`, `email`, 개인/회사 주소, `job_title`의 5개 trgm
+  index와 RSVP/push의 기존 migration-created index를 `apps/api/models.py`
+  metadata에 표현했다. `include_object`/`compare_index` blanket 예외나 index
+  삭제는 추가하지 않았다. fresh baseline `alembic check`는 clean이며, 일반
+  unmigrated column/table/index를 각각 검출하는 negative regression도 추가했다.
+- 선택: 120,000행에서 `student_id`는 120,000 distinct, `company`는 11,413
+  distinct이고 대표 partial hit 2.00%였다. `major` 20 distinct/10.00%,
+  `industry` 12 distinct/8.33%는 low-selectivity로 planner가 Seq Scan을
+  선택했다. 따라서 D5 신규 GIN은 `student_id`·`company`만 채택했다.
+- Migration/gate: `d5f2a1c9e7b3`가 `pg_trgm`과 두 GIN index를
+  `CONCURRENTLY`+autocommit으로 upgrade/downgrade한다. `ops/ci/migration_gate.py`
+  는 empty upgrade, `alembic check`, current=head, extension/index catalog를
+  권위 있게 확인하고 GitHub CI python job의 첫 DB 단계로 실행된다.
+- DB/API 측정: 결과 digest는 exact/partial/case-insensitive와 major/industry
+  representative query 모두 before/after 동일했다. default planner 5회 median은
+  student 42.018→1.958ms, company 33.797→7.845ms, q OR 88.076→2.099ms였고,
+  major/industry는 Seq Scan을 유지했다. clean index size는 company 6,584 kB,
+  student_id 6,224 kB, 전체 relation은 101→116 MB였다. rollback INSERT 10,000행
+  3회 median은 1,090.621→1,105.327ms(+1.35%)였으며 local noise/rollback 측정임을
+  기록했다.
+- Readback: empty DB, c8 baseline DB, downgrade/re-upgrade DB가
+  `d5f2a1c9e7b3`, `pg_trgm=1.6`, 기대 index catalog와 `alembic check`를 통과했다.
+  기존 local `appdb`도 upgrade exit 0 및 version/extension/두 신규 index readback을
+  통과했다. 다만 해당 DB에 authoritative gate를 재실행하면 역사적 signup issue log
+  index 4개가 `remove_index` drift로 보고되어 `alembic check`가 FAIL한다. 이는 D5
+  범위 밖의 기존 schema drift라서 삭제·숨김하지 않고, 별도 index 조사/migration
+  선택지로 남겼다.
+- 실제 browser E2E: 저장소 `.agents/skills/playwright-cli`를 사용해 headed
+  `d5-browser-final`/`d5-anon-final` ephemeral session을 실행했다. production Web
+  `http://127.0.0.1:3000` + real API `http://127.0.0.1:3001` + 전용 PostgreSQL
+  `d5_browser_260802`만 연결했고 mock·storage-state·운영 계정/URL은 사용하지 않았다.
+  홈에서 실제 `로그인` click → 학번/비밀번호 실제 keyboard typing → 실제
+  `동문 수첩` click → 검색어 `d5student001` typing 후 1명 readback → 상세 검색을
+  열고 회사 `Acme` typing 후 `김경제`·`박경제` 2명 readback을 수행했다. 별도
+  anonymous session은 `동문 수첩` click 후 `/login` 화면으로 차단됐다. CLI version
+  warning만 있었고 repository skill은 갱신하지 않았다.
+- browser 진단: 최초 disposable seed에서 `example.invalid`가 Pydantic EmailStr
+  reserved-domain 검증을 받아 한 차례 API 500이 발생했다. production code를
+  우회하지 않고 전용 test row email만 `example.com`으로 교정한 뒤 최종 flow를
+  재실행해 valid session의 목록·검색은 200/PASS로 readback했다. API/Web/browser
+  프로세스와 두 browser session은 검증 후 종료한다.

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -94,8 +94,9 @@
 - gate 보완: `--readback-only`는 upgrade와 `alembic check`를 건너뛰고 DB를 변경하지
   않는다. index readback은 `pg_class`/`pg_namespace`/`pg_index`/`pg_am`/
   `pg_attribute`/`pg_opclass`를 join해 public table/column, GIN, `gin_trgm_ops`와
-  `indisvalid`·`indisready`·`indislive`를 확인한다. `ScriptDirectory.get_heads()`는
-  list로 정규화해 기존 list/tuple false FAIL도 제거했다.
+  `indisvalid`·`indisready`·`indislive`를 확인한다. `ScriptDirectory.get_heads()`의
+  list/tuple 지적은 old exact head와 GitHub CI에서 비교가 이미 PASS한 오탐으로
+  확인되어 동작 변경 없이 기존 반환 계약을 유지했다.
 - regression: SQLite/합성 metadata test를 실제 repository Alembic gate subprocess로
   교체했다. 전용 disposable PostgreSQL에서 정상 `upgrade head`/readback 후 column,
   table, index drift를 주입하면 `command.check()`가 nonzero가 된다. duplicate

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -79,3 +79,45 @@
   우회하지 않고 전용 test row email만 `example.com`으로 교정한 뒤 최종 flow를
   재실행해 valid session의 목록·검색은 200/PASS로 readback했다. API/Web/browser
   프로세스와 두 browser session은 검증 후 종료한다.
+
+## D5 review follow-up — 운영 migration 진입점·readback·실제 PostgreSQL regression
+
+- P1 재현: old exact head `895d9e68e66f04f60e30ad10d1d0633cccd63620`의 API image에서
+  `ops/cloud-migrate.sh`가 `docker run IMAGE bash -lc "alembic ..."`를 호출했지만,
+  고정 `infra/api-entrypoint.sh`가 `$@`를 사용하지 않아 uvicorn을 기동했다. 실제
+  local disposable DB는 비어 있었고, 명령은 Alembic 결과 없이 12초 timeout으로
+  종료되어 운영 migration 진입점 bug를 확정했다.
+- 최소 수정: `cloud-migrate.sh`에 `--entrypoint /bin/sh`를 고정하고 image 뒤에
+  `-lc "$ALEMBIC_CMD"`를 전달했다. API runtime entrypoint는 변경하지 않았고,
+  shell command는 배열 인수로 유지해 `DATABASE_URL`을 출력하지 않는다. API
+  Dockerfile에는 동일 image readback을 위해 `ops/ci/migration_gate.py`를 복사했다.
+- gate 보완: `--readback-only`는 upgrade와 `alembic check`를 건너뛰고 DB를 변경하지
+  않는다. index readback은 `pg_class`/`pg_namespace`/`pg_index`/`pg_am`/
+  `pg_attribute`/`pg_opclass`를 join해 public table/column, GIN, `gin_trgm_ops`와
+  `indisvalid`·`indisready`·`indislive`를 확인한다. `ScriptDirectory.get_heads()`는
+  list로 정규화해 기존 list/tuple false FAIL도 제거했다.
+- regression: SQLite/합성 metadata test를 실제 repository Alembic gate subprocess로
+  교체했다. 전용 disposable PostgreSQL에서 정상 `upgrade head`/readback 후 column,
+  table, index drift를 주입하면 `command.check()`가 nonzero가 된다. duplicate
+  company rows로 실패한 concurrent unique btree index fixture도 gate FAIL을 확인하고
+  DB를 drop했다. 별도 shell contract test는 `--entrypoint /bin/sh`, `-lc`, 배열 인수,
+  secret 미출력을 고정한다.
+- 문서/권위: 운영 API image readback과 CI migration gate가 동일 Python gate를
+  사용한다. concurrent 실패 시 invalid index가 `IF NOT EXISTS` 재시도를 막을 수
+  있고, `autocommit_block()` 뒤 중간 current/부분 적용이 남을 수 있음을 runbook과
+  CI 문서에 기록했다. 관측값은 migration gate 약 1.6초, Python job 약 4분 15초,
+  병렬·캐시 구조 변경 없음이다.
+- 최종 수정 image `d5-review-api-after-p1`를 실제로 build하고, 전용 local
+  PostgreSQL `d5_cloud_migrate_260802`를 빈 상태에서 준비했다. 실제
+  `ops/cloud-migrate.sh`는 `/bin/sh -lc` 경로로 모든 revision을
+  `d5f2a1c9e7b3`까지 적용하고 exit 0이었다. 같은 image의
+  `migration_gate.py --readback-only`는 upgrade/check를 건너뛰며
+  `alembic current=head: d5f2a1c9e7b3`, `pg_trgm`, valid/ready/live catalog를
+  PASS했다. 구조적 row readback도 7개 index 모두 `members`, 기대 column,
+  `gin`, `gin_trgm_ops`, `True/True/True`를 확인했고 real API `/healthz`는
+  `{"ok":true}`를 반환했다.
+- 실제 browser는 이번 변경이 migration/ops-only이고 API/Web 화면·검색 결과 계약을
+  건드리지 않아 재실행하지 않았다. 이전 exact head의 저장소 playwright-cli visible
+  browser PASS와 별도로, 이번 exact image의 API health와 PostgreSQL authority를
+  위처럼 검증했다. 사용한 API runtime, image, DB와 full-test DB는 모두 종료·drop
+  대상으로 정확히 기록했다.

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -122,3 +122,34 @@
   browser PASS와 별도로, 이번 exact image의 API health와 PostgreSQL authority를
   위처럼 검증했다. 사용한 API runtime, image, DB와 full-test DB는 모두 종료·drop
   대상으로 정확히 기록했다.
+
+## D5 review follow-up — partial index false-PASS 방지 및 영문 runbook 동기화
+
+- Sol P2 root cause: 기존 structural catalog readback은 expected name/table/column,
+  GIN, `gin_trgm_ops`, `indisvalid`/`indisready`/`indislive`만 확인해,
+  같은 이름으로 선점된 valid partial index `WHERE false`를 full index처럼
+  PASS시킬 수 있었다. migration의 `IF NOT EXISTS`가 원하는 full index 생성을
+  건너뛸 수 있는 경로다.
+- 수정: `pg_index.indpred IS NULL`을 catalog query의 구조적 `is_full_index`
+  상태로 읽고 모든 expected index에 강제했다. 문자열 parsing이나 blanket 예외는
+  추가하지 않았다.
+- 실제 PostgreSQL regression: 전용 disposable DB에서 기대 이름의 valid GIN partial
+  `idx_members_company_trgm ... WHERE false`를 만들고 API/repository gate의
+  `--readback-only`가 `full_index=false`로 nonzero가 되는 것을 고정했다.
+  기존 column/table/index drift와 invalid/wrong-method concurrent index regression도
+  유지하며 finally에서 index·row·DB를 정리한다.
+- 문서: `docs/ci_quality_gates.md` 상단 local 예시를 공유 `appdb_test`에서
+  `d5_migration_gate_local` drop/create/readback/drop 흐름으로 교체하고 CI service
+  URL과 local URL을 구분했다. `docs/agent_runbook_vps_en.md`에는 one-shot
+  entrypoint override, 동일 API image Python readback, full-index expectation,
+  invalid/partial same-name cleanup, `autocommit_block()` partial application,
+  disposable-only `--require-empty`를 한국어 SSOT와 함께 기록했다.
+- 영향 분석: gate/docs/test-only 변경으로 API/Web 화면·검색 결과 계약은 변하지
+  않아 visible browser E2E는 재실행하지 않는다. 실제 disposable PostgreSQL
+  migration/readback과 partial fixture rejection을 browser 증거와 별도로 기록한다.
+- local full pytest는 기존 전체 fixture order에서 `302 passed, 1 failed`로
+  `tests/api/test_d4_posts_authority.py::test_public_hides_notice_draft_and_future`
+  의 admin session 401이 남았다. D5 변경과 무관한 기존 D4 auth/fixture-order
+  failure로 판단했고 테스트를 약화하거나 범위 밖 fixture를 수정하지 않았다.
+  전용 fresh DB에서 해당 D4 파일은 `13 passed`, D5 migration-gate regression은
+  `1 passed`였으며 CI exact-head 결과를 최종 권위로 재확인한다.

--- a/docs/plan_d5_migration_search_260802.md
+++ b/docs/plan_d5_migration_search_260802.md
@@ -154,3 +154,28 @@ PR #287의 후속 review에서 확인된 운영 진입점·readback·regression 
 - `autocommit_block()`에서 뒤 revision이 실패하면 앞선 revision이 커밋된 부분 적용
   상태와 중간 current가 남을 수 있다. invalid index는 `IF NOT EXISTS`로 덮지 않고
   exact catalog 확인 → `DROP INDEX CONCURRENTLY` → retry → readback 순서를 따른다.
+
+## Review follow-up — partial index false-PASS 및 영문 운영 절차
+
+- Sol P2는 유효하다. expected name/table/column/GIN/opclass와
+  valid/ready/live만 확인하면 `WHERE false` partial index가 같은 이름을
+  선점한 경우 migration `IF NOT EXISTS`와 readback이 false PASS할 수 있다.
+- `ops/ci/migration_gate.py`는 `pg_index.indpred IS NULL`을
+  `is_full_index`로 구조적으로 읽고 모든 expected index에 full-index 계약을
+  강제한다. partial, invalid, not-ready, not-live, wrong-method 상태는 모두
+  nonzero다.
+- 실제 repository Alembic path의 disposable PostgreSQL regression은 정상 head와
+  일반 column/table/index drift, 실패한 invalid/wrong-method concurrent index,
+  valid same-name GIN partial index를 각각 gate 실패로 확인한다. partial fixture는
+  `idx_members_company_trgm ... WHERE false`이며 finally에서 정확히 제거한다.
+- Grok P3에 따라 CI 문서의 상단 local 예시는 공유 `appdb_test`를 제거하고
+  `d5_migration_gate_local` drop/create/readback/drop로 정렬했다. CI service
+  connection과 localhost local disposable connection을 혼동하지 않도록 명시했다.
+- Sol P3에 따라 `docs/agent_runbook_vps_en.md`를 한국어 SSOT의 D5 핵심과
+  동기화했다. 영어 절차에도 script의 entrypoint override, 동일 API image
+  `--readback-only`, full-index/valid-ready-live 계약, invalid/partial same-name
+  cleanup, partial application, disposable-only `--require-empty`가 포함된다.
+- full local pytest는 전용 disposable DB에서 기존 D4 auth/fixture-order failure
+  1건(`302 passed, 1 failed`)이 있었고, 동일 fresh DB의 D4 authority file
+  `13 passed`, D5 regression `1 passed`로 분리 확인했다. D5 범위 밖 테스트를
+  변경하지 않고 exact-head CI에서 전체 suite 결론을 확인한다.

--- a/docs/plan_d5_migration_search_260802.md
+++ b/docs/plan_d5_migration_search_260802.md
@@ -1,0 +1,126 @@
+# D5 migration gate·동문 검색 인덱스 계획 및 검증 기록
+
+## 범위와 기준점
+
+- 기준점: `main` exact head `2f136ef276e71734c6cd2f553e58774f3acdacd5`
+- 대상: GitHub #252의 빈 PostgreSQL migration/schema drift gate, #266의 동문 수첩 검색 trgm index 정비
+- 원칙: production/VPS와 운영 데이터는 조회·변경하지 않는다. 모든 seed·benchmark는 local disposable PostgreSQL에서 수행한다.
+- API 응답/OpenAPI 계약은 변경하지 않는다. 검색 결과 계약은 동일한 ordering과 대표 query 결과로 고정한다.
+
+## 조사 결과와 선택
+
+현재 `apps/api/repositories/members.py`는 `q`에 `name`·`email`·`student_id`를
+OR로 검색하고, `major`·`company`·`industry`에는 각각 `ILIKE '%...%'` 필터를
+적용한다. 기존 `e2143fa9dd96` migration의 `name`·`email`·주소 2개·`job_title`
+GIN은 metadata에 표현되지 않아 fresh `alembic check` baseline drift를 만들고
+있었고, RSVP 상태와 active push subscription의 기존 migration index도 같은
+문제였다. D5에서는 이 catalog 계약을 모델 metadata에 실제로 표현했다. 일반
+drift를 숨기는 Alembic filter는 추가하지 않았다.
+
+기존 local `appdb`는 비민감 dev row 5개뿐이고 후보 필드가 대부분 NULL이라
+선택도 판단에 부족했다. 그래서 동일한 synthetic dataset을 disposable DB 두 개에
+seed했다.
+
+| 필드 | rows | non-null | distinct | 대표 hit 비율 | plan 결론 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `student_id` | 120,000 | 120,000 | 120,000 | exact-like 1/120,000 (0.0008%) | GIN 선택, 채택 |
+| `company` | 120,000 | 120,000 | 11,413 | `%acme%` 2.00% | GIN 선택, 채택 |
+| `major` | 120,000 | 120,000 | 20 | `%경제%` 10.00% | Seq Scan, 제외 |
+| `industry` | 120,000 | 120,000 | 12 | `%금융%` 8.33% | Seq Scan, 제외 |
+
+실제 운영 검색 telemetry는 production 접근 금지 경계 때문에 사용하지 않았다.
+검색 빈도는 현재 repository/UI가 제공하는 검색 형태(`q`와 세 개의 명시적 필터)를
+기준으로 exact·partial·case-insensitive 대표 workload를 동일 횟수로 고정한
+proxy다. 따라서 아래 수치는 workload 증거이며 운영 전체 트래픽의 빈도 추정치는
+아니다.
+
+## 구현 계약
+
+- 새 Alembic revision: `d5f2a1c9e7b3`, `c8a7f3d1e2b4`에서 `pg_trgm`을 확인하고
+  `idx_members_student_id_trgm`, `idx_members_company_trgm`을 생성한다.
+- 두 index 모두 `USING gin (... gin_trgm_ops)`이며 upgrade/downgrade 모두
+  `autocommit_block()` 안의 `CONCURRENTLY`를 사용한다.
+- downgrade는 새 두 index만 역순 제거한다. 기존 index가 extension을 사용하므로
+  `pg_trgm`은 제거하지 않는다.
+- `ops/ci/migration_gate.py`는 빈 DB에서 `upgrade head` → `alembic check` →
+  `alembic_version`/extension/index catalog readback을 하나의 필수 gate로 수행한다.
+  `tests/api/test_migration_gate.py`는 일반 컬럼·테이블·인덱스 drift의 negative regression이다.
+
+## 결과 계약 및 query plan
+
+대표 결과는 인덱스 전후 동일했다. 각 결과는 `updated_at DESC, name ASC, id ASC`
+ordering으로 25개를 제한한 결과의 SHA-256 digest다.
+
+| case | before digest | after digest |
+| --- | --- | --- |
+| student exact-like | `f2dfefea8832c61cb527b59de9f87ba0` | `f2dfefea8832c61cb527b59de9f87ba0` |
+| company partial | `b212762c58a9e3c796e25d28cae7a7d5` | `b212762c58a9e3c796e25d28cae7a7d5` |
+| company case-insensitive | `a6fccd94d8a5c4a35298589977545a478` | `a6fccd94d8a5c4a35298589977545a478` |
+| major low-selectivity | `947e07e91493cb4ecde8b116868fadfc` | `947e07e91493cb4ecde8b116868fadfc` |
+| industry low-selectivity | `00c7525f1dee82d447f43a08cfed6c2f` | `00c7525f1dee82d447f43a08cfed6c2f` |
+
+`EXPLAIN (ANALYZE, BUFFERS)`는 `enable_seqscan`을 끄지 않고 default planner로
+측정했다. 동일한 local PostgreSQL 16 container에서 5회 실행한 median이다.
+
+| query | before median | after median | after plan |
+| --- | ---: | ---: | --- |
+| `student_id ILIKE '%S00000012345%'` | 42.018 ms | 1.958 ms | Bitmap Heap/Index Scan (`idx_members_student_id_trgm`) |
+| `major ILIKE '%경제%'` | 39.082 ms | 37.651 ms | Parallel Seq Scan |
+| `company ILIKE '%acme%'` | 33.797 ms | 7.845 ms | Bitmap Heap/Index Scan (`idx_members_company_trgm`) |
+| `industry ILIKE '%금융%'` | 42.555 ms | 47.021 ms | Parallel Seq Scan |
+| `name/email/student_id` OR q | 88.076 ms | 2.099 ms | BitmapOr including student GIN |
+
+응답 시간은 5회·단일 local container라 cache, parallel scheduling, noise의
+영향을 받는다. plan node와 선택도도 함께 기록했으며, major/industry는 latency
+개선 주장을 하지 않고 planner가 Seq Scan을 선택한 사실을 제외 근거로 삼았다.
+
+clean build 직후 `pg_relation_size`는 새 `company` 6,584 kB, `student_id`
+6,224 kB였고 members 전체 relation 합계는 before 101 MB, after 116 MB였다.
+즉 새 두 index의 초기 overhead는 약 12.5 MB다. 쓰기 비용은 10,000-row
+`EXPLAIN ANALYZE INSERT`를 rollback하는 3회 측정에서 before median 1,090.621 ms,
+after median 1,105.327 ms(+14.706 ms, +1.35%)였다. 이 역시 local/noisy,
+rollback-only 측정이므로 운영 SLA가 아니다.
+
+## 검증 matrix
+
+- empty disposable DB: 최초 revision부터 `upgrade head`, `current=head`,
+  `alembic check`, extension/index catalog readback PASS
+- existing baseline disposable DB: c8 head에서 D5 upgrade, `alembic check`,
+  catalog readback PASS
+- existing local `appdb`: D5 upgrade exit 0, `alembic_version=d5f2a1c9e7b3`,
+  `pg_trgm=1.6`, 두 새 index definition readback PASS
+- existing local `appdb`에 authoritative gate를 재실행하면 기존
+  `signup_activation_issue_logs`의 역사적 추가 index 4개
+  (`issued_at`, `issued_by_student_id`, `issued_type`, `signup_request_id`)가
+  `remove_index` drift로 보고되어 `alembic check`가 FAIL한다. 이 항목은 D5
+  검색 필드 범위를 넘어가므로 삭제·blanket filter·임의 migration으로 확대하지
+  않았다. 후속 선택지는 (a) 해당 index의 실제 필요성과 출처를 조사해 별도
+  migration으로 metadata/catalog를 정렬하거나, (b) 보존이 명시된 경우에만
+  정확한 이름 단위 계약을 추가하는 것이다.
+- downgrade/upgrade: disposable gate DB에서 D5 downgrade 후 c8 readback,
+  재upgrade와 migration gate PASS
+- baseline drift: metadata에 기존 7개 index 계약을 추가한 뒤 fresh `alembic check`
+  가 `No new upgrade operations detected`로 종료
+- negative regression: unmigrated normal model column/table/index가 각각 `add_column`/`add_table`/`add_index`로 검출
+
+실제 visible browser는 저장소 `playwright-cli` skill의 ephemeral session으로
+검증했다. `d5-browser-final`에서 production Web → real local API → 전용 local
+PostgreSQL 순서의 실제 화면 flow를 사용해 로그인 후 동문 수첩에 진입하고,
+검색어 `d5student001` typing 결과 1명과 상세 회사 필터 `Acme` typing 결과
+2명을 readback했다. `d5-anon-final`에서는 같은 동문 수첩 링크 click이
+`/login` 화면으로 닫히는 권한 경계를 확인했다. mock, storage-state, 운영 URL·계정은
+사용하지 않았다. 처음 disposable seed의 reserved-domain email 오류는 test row만
+교정한 뒤 최종 browser flow를 재실행했다.
+
+local `appdb`에는 D5 범위 밖의 과거 `signup_activation_issue_logs` 단일 index
+4개(`issued_at`, `issued_by_student_id`, `issued_type`, `signup_request_id`)가
+남아 있다. D5는 이를 삭제하거나 숨기지 않았다. 해당 legacy drift를 정리하는 것은
+별도 migration 설계가 필요한 범위라 이번 작업에 확대하지 않는다.
+
+## 남은 위험
+
+- 운영 실제 분포와 telemetry를 사용하지 않았으므로 선택도는 synthetic workload
+  기준이다. 배포 후 query statistics와 index bloat/쓰기 지연을 별도 운영 관측
+  항목으로 확인해야 한다.
+- `CONCURRENTLY`는 lock을 줄이지만 build 시간이 들고 invalid index 재시도 시
+  catalog 확인이 필요하다. 이번 검증은 운영 DB에 적용하지 않았다.

--- a/docs/plan_d5_migration_search_260802.md
+++ b/docs/plan_d5_migration_search_260802.md
@@ -124,3 +124,33 @@ local `appdb`에는 D5 범위 밖의 과거 `signup_activation_issue_logs` 단�
   항목으로 확인해야 한다.
 - `CONCURRENTLY`는 lock을 줄이지만 build 시간이 들고 invalid index 재시도 시
   catalog 확인이 필요하다. 이번 검증은 운영 DB에 적용하지 않았다.
+
+## Review follow-up — 2026-08-02
+
+PR #287의 후속 review에서 확인된 운영 진입점·readback·regression 범위만 보완했다.
+
+- old exact head `895d9e68e66f04f60e30ad10d1d0633cccd63620`에서
+  `cloud-migrate.sh`를 실제 API image로 실행했을 때 image의 고정
+  `infra/api-entrypoint.sh`가 인수 `bash -lc "alembic ..."`를 무시하고 uvicorn을
+  시작했다. 12초 timeout 뒤에도 Alembic one-shot process가 되지 않는 P1을
+  재현했다. 수정은 `cloud-migrate.sh`의 `--entrypoint /bin/sh`와 `-lc`뿐이며,
+  API runtime entrypoint 전역 동작은 바꾸지 않았다.
+- API image에 `ops/ci/migration_gate.py`를 포함하고, 운영 readback은 같은 image를
+  `--entrypoint /bin/sh -lc 'python ops/ci/migration_gate.py --readback-only'`로
+  실행한다. 이 모드는 upgrade/check를 하지 않고 current/head, `pg_trgm`,
+  table/column/method/opclass 및 `indisvalid`/`indisready`/`indislive` catalog만
+  읽는다. `pg_indexes.indexdef` 문자열 파싱은 제거했다.
+- negative regression은 SQLite 합성 comparator를 제거하고 전용 disposable
+  PostgreSQL DB를 생성한다. repository `migrations/env.py`와 `models.Base.metadata`
+  를 통한 실제 gate subprocess가 정상 head 뒤 주입한 column/table/index drift를
+  nonzero로 거부한다. duplicate value로 실패한 `CREATE UNIQUE INDEX CONCURRENTLY`
+  가 남긴 invalid/wrong-method index도 readback-only gate가 거부한 뒤 DB를
+  drop하여 정리한다.
+- local actual browser E2E는 이번 변경이 API/Web 화면과 검색 결과 계약을 건드리지
+  않는 migration/ops-only 수정이고 이전 exact head에서 real local API+DB browser
+  flow가 PASS했으므로 재실행하지 않았다. 대신 실제 API image에서 disposable
+  PostgreSQL로 migration exit 0, Alembic head, extension/index flag readback과
+  `/healthz` smoke를 별도로 수행한다.
+- `autocommit_block()`에서 뒤 revision이 실패하면 앞선 revision이 커밋된 부분 적용
+  상태와 중간 current가 남을 수 있다. invalid index는 `IF NOT EXISTS`로 덮지 않고
+  exact catalog 확인 → `DROP INDEX CONCURRENTLY` → retry → readback 순서를 따른다.

--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /app
 
 COPY --from=build /install /usr/local
 COPY apps/api ./apps/api
+COPY ops/ci/migration_gate.py ./ops/ci/migration_gate.py
 COPY infra/api-entrypoint.sh /app/infra/api-entrypoint.sh
 
 RUN mkdir -p uploads \

--- a/ops/ci/migration_gate.py
+++ b/ops/ci/migration_gate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run the authoritative PostgreSQL Alembic migration and drift gate."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from alembic.util.exc import CommandError
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+ROOT = Path(__file__).resolve().parents[2]
+ALEMBIC_CONFIG = ROOT / "apps/api/alembic.ini"
+EXPECTED_GIN_INDEXES = {
+    "idx_members_name_trgm": "name gin_trgm_ops",
+    "idx_members_email_trgm": "email gin_trgm_ops",
+    "idx_members_addr_personal_trgm": "addr_personal gin_trgm_ops",
+    "idx_members_addr_company_trgm": "addr_company gin_trgm_ops",
+    "idx_members_job_title_trgm": "job_title gin_trgm_ops",
+    "idx_members_student_id_trgm": "student_id gin_trgm_ops",
+    "idx_members_company_trgm": "company gin_trgm_ops",
+}
+
+
+def _database_url() -> str:
+    url = (
+        os.environ.get("MIGRATION_GATE_DATABASE_URL")
+        or os.environ.get("DATABASE_URL")
+        or os.environ.get("TEST_DB_URL")
+        or ""
+    )
+    if not url.startswith("postgresql+psycopg://"):
+        raise SystemExit(
+            "[migration-gate] DATABASE_URL must use postgresql+psycopg://"
+        )
+    return url
+
+
+def _alembic_config(url: str) -> Config:
+    os.environ["DATABASE_URL"] = url
+    config = Config(str(ALEMBIC_CONFIG))
+    config.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+    return config
+
+
+def _assert_empty_database(engine: Engine) -> None:
+    with engine.connect() as connection:
+        table_count = connection.execute(
+            text(
+                "SELECT count(*) FROM pg_catalog.pg_class AS c "
+                "JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = 'public' "
+                "AND c.relkind IN ('r', 'p')"
+            )
+        ).scalar_one()
+        if int(table_count) != 0:
+            raise SystemExit(
+                "[migration-gate] --require-empty expected no public tables, "
+                f"found {table_count}"
+            )
+
+
+def _assert_head_and_catalog(engine: Engine, config: Config) -> None:
+    script = ScriptDirectory.from_config(config)
+    heads = script.get_heads()
+    if len(heads) != 1:
+        raise SystemExit(f"[migration-gate] expected one Alembic head, found {heads}")
+
+    with engine.connect() as connection:
+        versions = list(
+            connection.execute(
+                text("SELECT version_num FROM alembic_version ORDER BY version_num")
+            ).scalars()
+        )
+        if versions != heads:
+            raise SystemExit(
+                "[migration-gate] alembic_version does not match head: "
+                f"current={versions}, head={heads}"
+            )
+
+        extension = connection.execute(
+            text(
+                "SELECT 1 FROM pg_catalog.pg_extension "
+                "WHERE extname = 'pg_trgm'"
+            )
+        ).scalar_one_or_none()
+        if extension != 1:
+            raise SystemExit("[migration-gate] pg_trgm extension is missing")
+
+        index_names = list(EXPECTED_GIN_INDEXES)
+        rows = connection.execute(
+            text(
+                "SELECT indexname, indexdef "
+                "FROM pg_catalog.pg_indexes "
+                "WHERE schemaname = 'public' AND indexname = ANY(:names)"
+            ),
+            {"names": index_names},
+        ).all()
+        found = {
+            str(name): " ".join(str(definition).lower().split())
+            for name, definition in rows
+        }
+        missing = sorted(set(index_names) - set(found))
+        if missing:
+            raise SystemExit(f"[migration-gate] missing indexes: {missing}")
+        invalid = [
+            name
+            for name, definition in found.items()
+            if " using gin " not in definition
+            or EXPECTED_GIN_INDEXES[name].lower() not in definition
+        ]
+        if invalid:
+            raise SystemExit(
+                "[migration-gate] invalid GIN index definitions: "
+                f"{invalid}"
+            )
+
+    print(f"[migration-gate] alembic current=head: {heads[0]}")
+    print("[migration-gate] pg_trgm and expected GIN indexes: present")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--require-empty",
+        action="store_true",
+        help="fail unless the public schema is empty before upgrade",
+    )
+    args = parser.parse_args()
+    url = _database_url()
+    config = _alembic_config(url)
+    engine = create_engine(url, pool_pre_ping=True)
+    try:
+        if args.require_empty:
+            _assert_empty_database(engine)
+        print("[migration-gate] alembic upgrade head")
+        command.upgrade(config, "head")
+        print("[migration-gate] alembic check")
+        try:
+            command.check(config)
+        except CommandError as exc:
+            raise SystemExit(f"[migration-gate] schema drift detected: {exc}") from exc
+        _assert_head_and_catalog(engine, config)
+    finally:
+        engine.dispose()
+    print("[migration-gate] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/ci/migration_gate.py
+++ b/ops/ci/migration_gate.py
@@ -6,25 +6,87 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
+from typing import cast
 
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 from alembic.util.exc import CommandError
-from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
+from sqlalchemy import bindparam, create_engine, text
+from sqlalchemy.engine import Connection, Engine, RowMapping
 
 ROOT = Path(__file__).resolve().parents[2]
 ALEMBIC_CONFIG = ROOT / "apps/api/alembic.ini"
 EXPECTED_GIN_INDEXES = {
-    "idx_members_name_trgm": "name gin_trgm_ops",
-    "idx_members_email_trgm": "email gin_trgm_ops",
-    "idx_members_addr_personal_trgm": "addr_personal gin_trgm_ops",
-    "idx_members_addr_company_trgm": "addr_company gin_trgm_ops",
-    "idx_members_job_title_trgm": "job_title gin_trgm_ops",
-    "idx_members_student_id_trgm": "student_id gin_trgm_ops",
-    "idx_members_company_trgm": "company gin_trgm_ops",
+    "idx_members_name_trgm": {"table": "members", "column": "name"},
+    "idx_members_email_trgm": {"table": "members", "column": "email"},
+    "idx_members_addr_personal_trgm": {
+        "table": "members",
+        "column": "addr_personal",
+    },
+    "idx_members_addr_company_trgm": {
+        "table": "members",
+        "column": "addr_company",
+    },
+    "idx_members_job_title_trgm": {
+        "table": "members",
+        "column": "job_title",
+    },
+    "idx_members_student_id_trgm": {
+        "table": "members",
+        "column": "student_id",
+    },
+    "idx_members_company_trgm": {"table": "members", "column": "company"},
 }
+INDEX_CATALOG_QUERY = text(
+    """
+    SELECT
+        index_class.relname AS index_name,
+        table_class.relname AS table_name,
+        access_method.amname AS access_method,
+        array_agg(table_attribute.attname ORDER BY index_keys.ordinality)
+            AS column_names,
+        array_agg(operator_class.opcname ORDER BY index_keys.ordinality)
+            AS operator_classes,
+        index_meta.indisvalid,
+        index_meta.indisready,
+        index_meta.indislive
+    FROM pg_catalog.pg_class AS index_class
+    JOIN pg_catalog.pg_namespace AS index_namespace
+      ON index_namespace.oid = index_class.relnamespace
+    JOIN pg_catalog.pg_index AS index_meta
+      ON index_meta.indexrelid = index_class.oid
+    JOIN pg_catalog.pg_class AS table_class
+      ON table_class.oid = index_meta.indrelid
+    JOIN pg_catalog.pg_namespace AS table_namespace
+      ON table_namespace.oid = table_class.relnamespace
+    JOIN pg_catalog.pg_am AS access_method
+      ON access_method.oid = index_class.relam
+    LEFT JOIN LATERAL unnest(index_meta.indkey) WITH ORDINALITY
+        AS index_keys(attnum, ordinality)
+      ON TRUE
+    LEFT JOIN pg_catalog.pg_attribute AS table_attribute
+      ON table_attribute.attrelid = index_meta.indrelid
+     AND table_attribute.attnum = index_keys.attnum
+    LEFT JOIN LATERAL unnest(index_meta.indclass) WITH ORDINALITY
+        AS operator_keys(opclass_oid, ordinality)
+      ON operator_keys.ordinality = index_keys.ordinality
+    LEFT JOIN pg_catalog.pg_opclass AS operator_class
+      ON operator_class.oid = operator_keys.opclass_oid
+     AND operator_class.opcmethod = access_method.oid
+    WHERE index_class.relkind = 'i'
+      AND index_namespace.nspname = 'public'
+      AND table_namespace.nspname = 'public'
+      AND index_class.relname IN :index_names
+    GROUP BY
+        index_class.relname,
+        table_class.relname,
+        access_method.amname,
+        index_meta.indisvalid,
+        index_meta.indisready,
+        index_meta.indislive
+    """
+).bindparams(bindparam("index_names", expanding=True))
 
 
 def _database_url() -> str:
@@ -65,86 +127,134 @@ def _assert_empty_database(engine: Engine) -> None:
             )
 
 
-def _assert_head_and_catalog(engine: Engine, config: Config) -> None:
+def _assert_alembic_head(connection: Connection, config: Config) -> str:
     script = ScriptDirectory.from_config(config)
-    heads = script.get_heads()
+    heads = list(script.get_heads())
     if len(heads) != 1:
         raise SystemExit(f"[migration-gate] expected one Alembic head, found {heads}")
-
-    with engine.connect() as connection:
-        versions = list(
-            connection.execute(
-                text("SELECT version_num FROM alembic_version ORDER BY version_num")
-            ).scalars()
+    versions = [
+        str(version)
+        for version in connection.execute(
+            text("SELECT version_num FROM alembic_version ORDER BY version_num")
+        ).scalars()
+    ]
+    if versions != heads:
+        raise SystemExit(
+            "[migration-gate] alembic_version does not match head: "
+            f"current={versions}, head={heads}"
         )
-        if versions != heads:
-            raise SystemExit(
-                "[migration-gate] alembic_version does not match head: "
-                f"current={versions}, head={heads}"
-            )
+    return heads[0]
 
-        extension = connection.execute(
-            text(
-                "SELECT 1 FROM pg_catalog.pg_extension "
-                "WHERE extname = 'pg_trgm'"
-            )
-        ).scalar_one_or_none()
-        if extension != 1:
-            raise SystemExit("[migration-gate] pg_trgm extension is missing")
 
-        index_names = list(EXPECTED_GIN_INDEXES)
-        rows = connection.execute(
-            text(
-                "SELECT indexname, indexdef "
-                "FROM pg_catalog.pg_indexes "
-                "WHERE schemaname = 'public' AND indexname = ANY(:names)"
-            ),
-            {"names": index_names},
-        ).all()
-        found = {
-            str(name): " ".join(str(definition).lower().split())
-            for name, definition in rows
-        }
-        missing = sorted(set(index_names) - set(found))
-        if missing:
-            raise SystemExit(f"[migration-gate] missing indexes: {missing}")
-        invalid = [
-            name
-            for name, definition in found.items()
-            if " using gin " not in definition
-            or EXPECTED_GIN_INDEXES[name].lower() not in definition
-        ]
-        if invalid:
-            raise SystemExit(
-                "[migration-gate] invalid GIN index definitions: "
-                f"{invalid}"
-            )
+def _assert_pg_trgm(connection: Connection) -> None:
+    extension = connection.execute(
+        text(
+            "SELECT 1 FROM pg_catalog.pg_extension "
+            "WHERE extname = 'pg_trgm'"
+        )
+    ).scalar_one_or_none()
+    if extension != 1:
+        raise SystemExit("[migration-gate] pg_trgm extension is missing")
 
-    print(f"[migration-gate] alembic current=head: {heads[0]}")
-    print("[migration-gate] pg_trgm and expected GIN indexes: present")
+
+def _catalog_array(row: RowMapping, key: str) -> list[str]:
+    values = cast(list[object] | None, row[key])
+    return [str(value) for value in values or []]
+
+
+def _index_problems(index_name: str, row: RowMapping) -> list[str]:
+    expected = EXPECTED_GIN_INDEXES[index_name]
+    problems: list[str] = []
+    if row["table_name"] != expected["table"]:
+        problems.append(f"table={row['table_name']!r}")
+    columns = _catalog_array(row, "column_names")
+    if columns != [expected["column"]]:
+        problems.append(f"columns={columns!r}")
+    if row["access_method"] != "gin":
+        problems.append(f"method={row['access_method']!r}")
+    operator_classes = _catalog_array(row, "operator_classes")
+    if operator_classes != ["gin_trgm_ops"]:
+        problems.append(f"opclasses={operator_classes!r}")
+    for flag in ("indisvalid", "indisready", "indislive"):
+        if not bool(row[flag]):
+            problems.append(f"{flag}=false")
+    return problems
+
+
+def _assert_index_catalog(connection: Connection) -> None:
+    index_names = list(EXPECTED_GIN_INDEXES)
+    rows: list[RowMapping] = list(
+        connection.execute(
+            INDEX_CATALOG_QUERY,
+            {"index_names": index_names},
+        )
+        .mappings()
+        .all()
+    )
+    found = {str(row["index_name"]): row for row in rows}
+    missing = sorted(set(index_names) - set(found))
+    if missing:
+        raise SystemExit(f"[migration-gate] missing indexes: {missing}")
+
+    invalid: list[str] = []
+    for index_name in EXPECTED_GIN_INDEXES:
+        problems = _index_problems(index_name, found[index_name])
+        if problems:
+            invalid.append(f"{index_name}: {', '.join(problems)}")
+    if invalid:
+        raise SystemExit(
+            "[migration-gate] invalid expected index catalog state: "
+            + "; ".join(invalid)
+        )
+
+
+def _assert_head_and_catalog(engine: Engine, config: Config) -> None:
+    with engine.connect() as connection:
+        head = _assert_alembic_head(connection, config)
+        _assert_pg_trgm(connection)
+        _assert_index_catalog(connection)
+
+    print(f"[migration-gate] alembic current=head: {head}")
+    print(
+        "[migration-gate] pg_trgm and expected GIN indexes: "
+        "present with valid/ready/live catalog state"
+    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--require-empty",
         action="store_true",
         help="fail unless the public schema is empty before upgrade",
+    )
+    mode.add_argument(
+        "--readback-only",
+        action="store_true",
+        help="read Alembic and PostgreSQL catalog state without changing the DB",
     )
     args = parser.parse_args()
     url = _database_url()
     config = _alembic_config(url)
     engine = create_engine(url, pool_pre_ping=True)
     try:
-        if args.require_empty:
-            _assert_empty_database(engine)
-        print("[migration-gate] alembic upgrade head")
-        command.upgrade(config, "head")
-        print("[migration-gate] alembic check")
-        try:
-            command.check(config)
-        except CommandError as exc:
-            raise SystemExit(f"[migration-gate] schema drift detected: {exc}") from exc
+        if args.readback_only:
+            print(
+                "[migration-gate] readback-only: skipping alembic upgrade and check"
+            )
+        else:
+            if args.require_empty:
+                _assert_empty_database(engine)
+            print("[migration-gate] alembic upgrade head")
+            command.upgrade(config, "head")
+            print("[migration-gate] alembic check")
+            try:
+                command.check(config)
+            except CommandError as exc:
+                raise SystemExit(
+                    f"[migration-gate] schema drift detected: {exc}"
+                ) from exc
         _assert_head_and_catalog(engine, config)
     finally:
         engine.dispose()

--- a/ops/ci/migration_gate.py
+++ b/ops/ci/migration_gate.py
@@ -129,7 +129,7 @@ def _assert_empty_database(engine: Engine) -> None:
 
 def _assert_alembic_head(connection: Connection, config: Config) -> str:
     script = ScriptDirectory.from_config(config)
-    heads = list(script.get_heads())
+    heads = script.get_heads()
     if len(heads) != 1:
         raise SystemExit(f"[migration-gate] expected one Alembic head, found {heads}")
     versions = [

--- a/ops/ci/migration_gate.py
+++ b/ops/ci/migration_gate.py
@@ -48,6 +48,7 @@ INDEX_CATALOG_QUERY = text(
             AS column_names,
         array_agg(operator_class.opcname ORDER BY index_keys.ordinality)
             AS operator_classes,
+        (index_meta.indpred IS NULL) AS is_full_index,
         index_meta.indisvalid,
         index_meta.indisready,
         index_meta.indislive
@@ -82,6 +83,7 @@ INDEX_CATALOG_QUERY = text(
         index_class.relname,
         table_class.relname,
         access_method.amname,
+        (index_meta.indpred IS NULL),
         index_meta.indisvalid,
         index_meta.indisready,
         index_meta.indislive
@@ -175,6 +177,8 @@ def _index_problems(index_name: str, row: RowMapping) -> list[str]:
     operator_classes = _catalog_array(row, "operator_classes")
     if operator_classes != ["gin_trgm_ops"]:
         problems.append(f"opclasses={operator_classes!r}")
+    if not bool(row["is_full_index"]):
+        problems.append("full_index=false")
     for flag in ("indisvalid", "indisready", "indislive"):
         if not bool(row[flag]):
             problems.append(f"{flag}=false")

--- a/ops/ci/test_cloud_migrate.sh
+++ b/ops/ci/test_cloud_migrate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+capture_file=$(mktemp)
+output_file=$(mktemp)
+trap 'rm -f "$capture_file" "$output_file"' EXIT
+export capture_file
+
+docker() {
+  printf '%s\n' "$@" >"$capture_file"
+}
+export -f docker
+
+secret_url='postgresql+psycopg://app:secret@postgres:5432/appdb'
+custom_command='alembic -c apps/api/alembic.ini upgrade head --tag d5 review'
+
+API_IMAGE=d5-contract-api \
+DATABASE_URL="$secret_url" \
+DOCKER_NETWORK=d5-contract-network \
+ALEMBIC_CMD="$custom_command" \
+bash "$ROOT/ops/cloud-migrate.sh" >"$output_file"
+
+mapfile -t docker_args <"$capture_file"
+[[ "${docker_args[0]}" == "run" ]]
+[[ "${docker_args[1]}" == "--rm" ]]
+[[ "${docker_args[2]}" == "--entrypoint" ]]
+[[ "${docker_args[3]}" == "/bin/sh" ]]
+[[ "${docker_args[4]}" == "--network" ]]
+[[ "${docker_args[5]}" == "d5-contract-network" ]]
+[[ "${docker_args[6]}" == "-e" ]]
+[[ "${docker_args[7]}" == "DATABASE_URL=$secret_url" ]]
+[[ "${docker_args[8]}" == "d5-contract-api" ]]
+[[ "${docker_args[9]}" == "-lc" ]]
+[[ "${docker_args[10]}" == "$custom_command" ]]
+! grep -F "$secret_url" "$output_file"
+
+echo "cloud-migrate command contract: PASS"

--- a/ops/cloud-migrate.sh
+++ b/ops/cloud-migrate.sh
@@ -15,7 +15,9 @@ fi
 
 ALEMBIC_CMD=${ALEMBIC_CMD:-"alembic -c apps/api/alembic.ini upgrade head"}
 
-DOCKER_ARGS=(--rm)
+# The API image has a fixed uvicorn entrypoint.  Migration commands must
+# explicitly bypass it so this container remains a one-shot Alembic process.
+DOCKER_ARGS=(--rm --entrypoint /bin/sh)
 
 # 동일 네트워크가 필요하면 명시적으로 연결
 if [[ -n "${DOCKER_NETWORK:-}" ]]; then
@@ -42,6 +44,6 @@ fi
 echo "[migrate] image=${API_IMAGE} env=${ENV_FILE:-<none>} network=${DOCKER_NETWORK:-<none>}"
 docker run "${DOCKER_ARGS[@]}" \
   "${API_IMAGE}" \
-  bash -lc "${ALEMBIC_CMD}"
+  -lc "${ALEMBIC_CMD}"
 
 echo "Alembic 마이그레이션 완료"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 from bcrypt import gensalt, hashpw  # 테스트 전용(최상위 임포트)
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -88,6 +88,11 @@ def client(tmp_path: Path) -> Generator[TestClient, None, None]:
 
     # 동기 엔진으로 테이블 생성 (metadata.create_all은 동기만 지원)
     sync_engine = create_engine(engine_url)
+    # models.Base.metadata에는 PostgreSQL GIN trigram catalog 계약도 표현되어
+    # 있으므로, fixture가 create_all()을 사용하더라도 연산자 클래스를 먼저
+    # 준비한다. 실제 migration gate는 별도로 빈 DB upgrade를 검증한다.
+    with sync_engine.begin() as connection:
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
     # PostgreSQL ENUM 타입은 create_all 과정에서 누락될 수 있어 선행 생성합니다.
     models.Member.__table__.c.visibility.type.create(
         bind=sync_engine, checkfirst=True
@@ -338,6 +343,8 @@ async def async_client(
     )
 
     sync_engine = create_engine(engine_url)
+    with sync_engine.begin() as connection:
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
     models.Base.metadata.create_all(bind=sync_engine)
 
     async def override_get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/tests/api/test_migration_gate.py
+++ b/tests/api/test_migration_gate.py
@@ -130,6 +130,17 @@ def _create_invalid_company_index(target: Engine) -> None:
             )
 
 
+def _create_partial_company_index(target: Engine) -> None:
+    with target.execution_options(isolation_level="AUTOCOMMIT").connect() as connection:
+        connection.execute(
+            text(
+                "CREATE INDEX idx_members_company_trgm "
+                "ON public.members USING gin "
+                "(company gin_trgm_ops) WHERE false"
+            )
+        )
+
+
 def _cleanup_invalid_company_index(target: Engine) -> None:
     with target.execution_options(isolation_level="AUTOCOMMIT").connect() as connection:
         connection.execute(
@@ -193,6 +204,12 @@ def test_repository_migration_gate_detects_postgresql_drift() -> None:
             "indisvalid=false" in invalid_output
             or "method='btree'" in invalid_output
         )
+
+        _cleanup_invalid_company_index(target)
+        _create_partial_company_index(target)
+        partial_index = _run_gate(database_url, "--readback-only")
+        assert partial_index.returncode != 0, _output(partial_index)
+        assert "full_index=false" in _output(partial_index)
     finally:
         if target is not None:
             _cleanup_invalid_company_index(target)

--- a/tests/api/test_migration_gate.py
+++ b/tests/api/test_migration_gate.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import Column, Index, Integer, MetaData, String, Table, create_engine
+
+
+def test_alembic_comparison_detects_normal_model_drift() -> None:
+    """Normal column, table, and index drift must remain visible."""
+    engine = create_engine("sqlite://")
+    actual = MetaData()
+    Table(
+        "migration_gate_probe",
+        actual,
+        Column("id", Integer, primary_key=True),
+        Column("existing_value", String(32)),
+    )
+    actual.create_all(engine)
+
+    expected = MetaData()
+    probe = Table(
+        "migration_gate_probe",
+        expected,
+        Column("id", Integer, primary_key=True),
+        Column("existing_value", String(32)),
+        Column("unmigrated_column", String(32)),
+    )
+    Index("ix_migration_gate_probe_existing_value", probe.c.existing_value)
+    Table("unmigrated_model_table", expected, Column("id", Integer, primary_key=True))
+
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        changes = compare_metadata(context, expected)
+
+    assert any(
+        change[0] == "add_column"
+        and getattr(change[3], "name", None) == "unmigrated_column"
+        for change in changes
+    )
+    assert any(
+        change[0] == "add_index"
+        and getattr(change[1], "name", None)
+        == "ix_migration_gate_probe_existing_value"
+        for change in changes
+    )
+    assert any(
+        change[0] == "add_table"
+        and getattr(change[1], "name", None) == "unmigrated_model_table"
+        for change in changes
+    )

--- a/tests/api/test_migration_gate.py
+++ b/tests/api/test_migration_gate.py
@@ -1,50 +1,202 @@
 from __future__ import annotations
 
-from alembic.autogenerate import compare_metadata
-from alembic.migration import MigrationContext
-from sqlalchemy import Column, Index, Integer, MetaData, String, Table, create_engine
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import IntegrityError
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TEST_DB_URL = "postgresql+psycopg://app:devpass@localhost:5434/appdb_test"
 
 
-def test_alembic_comparison_detects_normal_model_drift() -> None:
-    """Normal column, table, and index drift must remain visible."""
-    engine = create_engine("sqlite://")
-    actual = MetaData()
-    Table(
-        "migration_gate_probe",
-        actual,
-        Column("id", Integer, primary_key=True),
-        Column("existing_value", String(32)),
+def _maintenance_url() -> str:
+    configured = (
+        os.environ.get("MIGRATION_GATE_REGRESSION_DATABASE_URL")
+        or os.environ.get("TEST_DB_URL")
+        or DEFAULT_TEST_DB_URL
     )
-    actual.create_all(engine)
+    url = make_url(configured)
+    database = url.database or ""
+    if "test" not in database and os.environ.get("TEST_DB_FORCE") != "1":
+        raise RuntimeError(
+            "migration gate regression requires a disposable test database; "
+            "set TEST_DB_FORCE=1 only for an explicitly disposable target"
+        )
+    return url.set(database="postgres").render_as_string(hide_password=False)
 
-    expected = MetaData()
-    probe = Table(
-        "migration_gate_probe",
-        expected,
-        Column("id", Integer, primary_key=True),
-        Column("existing_value", String(32)),
-        Column("unmigrated_column", String(32)),
+
+def _run_gate(database_url: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment["MIGRATION_GATE_DATABASE_URL"] = database_url
+    environment["DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, str(ROOT / "ops/ci/migration_gate.py"), *arguments],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
     )
-    Index("ix_migration_gate_probe_existing_value", probe.c.existing_value)
-    Table("unmigrated_model_table", expected, Column("id", Integer, primary_key=True))
 
+
+def _output(result: subprocess.CompletedProcess[str]) -> str:
+    return f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def _drop_database(engine: Engine, database_name: str) -> None:
     with engine.connect() as connection:
-        context = MigrationContext.configure(connection)
-        changes = compare_metadata(context, expected)
+        connection.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_catalog.pg_stat_activity "
+                "WHERE datname = :database_name AND pid <> pg_backend_pid()"
+            ),
+            {"database_name": database_name},
+        )
+        connection.execute(
+            text(f'DROP DATABASE IF EXISTS "{database_name}"')
+        )
 
-    assert any(
-        change[0] == "add_column"
-        and getattr(change[3], "name", None) == "unmigrated_column"
-        for change in changes
+
+def _inject_schema_drift(target: Engine) -> None:
+    with target.begin() as connection:
+        connection.execute(
+            text(
+                "ALTER TABLE public.members "
+                "ADD COLUMN d5_regression_column integer"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE public.d5_regression_table "
+                "(id integer PRIMARY KEY)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE INDEX d5_regression_index "
+                "ON public.members (student_id)"
+            )
+        )
+
+
+def _remove_schema_drift(target: Engine) -> None:
+    with target.begin() as connection:
+        connection.execute(text("DROP INDEX public.d5_regression_index"))
+        connection.execute(
+            text("ALTER TABLE public.members DROP COLUMN d5_regression_column")
+        )
+        connection.execute(text("DROP TABLE public.d5_regression_table"))
+
+
+def _seed_duplicate_company_rows(target: Engine) -> None:
+    with target.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public.members "
+                "(student_id, email, name, cohort, roles, status, visibility, "
+                "company) "
+                "VALUES "
+                "('D5INVALID001', 'd5-invalid-1@example.com', 'D5 invalid one', "
+                "'2020', ARRAY['member'], 'active', 'all', 'D5 invalid company'), "
+                "('D5INVALID002', 'd5-invalid-2@example.com', 'D5 invalid two', "
+                "'2021', ARRAY['member'], 'active', 'all', 'D5 invalid company')"
+            )
+        )
+
+
+def _create_invalid_company_index(target: Engine) -> None:
+    with target.execution_options(isolation_level="AUTOCOMMIT").connect() as connection:
+        connection.execute(
+            text(
+                "DROP INDEX CONCURRENTLY IF EXISTS "
+                "public.idx_members_company_trgm"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            connection.execute(
+                text(
+                    "CREATE UNIQUE INDEX CONCURRENTLY idx_members_company_trgm "
+                    "ON public.members USING btree (company)"
+                )
+            )
+
+
+def _cleanup_invalid_company_index(target: Engine) -> None:
+    with target.execution_options(isolation_level="AUTOCOMMIT").connect() as connection:
+        connection.execute(
+            text(
+                "DROP INDEX CONCURRENTLY IF EXISTS "
+                "public.idx_members_company_trgm"
+            )
+        )
+    with target.begin() as connection:
+        connection.execute(
+            text(
+                "DELETE FROM public.members "
+                "WHERE student_id IN ('D5INVALID001', 'D5INVALID002')"
+            )
+        )
+
+
+def test_repository_migration_gate_detects_postgresql_drift() -> None:
+    """The repository Alembic environment must reject real PostgreSQL drift."""
+    maintenance = create_engine(
+        _maintenance_url(),
+        isolation_level="AUTOCOMMIT",
+        pool_pre_ping=True,
     )
-    assert any(
-        change[0] == "add_index"
-        and getattr(change[1], "name", None)
-        == "ix_migration_gate_probe_existing_value"
-        for change in changes
-    )
-    assert any(
-        change[0] == "add_table"
-        and getattr(change[1], "name", None) == "unmigrated_model_table"
-        for change in changes
-    )
+    database_name = f"d5_migration_gate_{uuid.uuid4().hex[:12]}"
+    target: Engine | None = None
+    created = False
+    try:
+        with maintenance.connect() as connection:
+            connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+        created = True
+        configured_url = make_url(_maintenance_url()).set(database=database_name)
+        database_url = configured_url.render_as_string(hide_password=False)
+
+        initial = _run_gate(database_url, "--require-empty")
+        assert initial.returncode == 0, _output(initial)
+
+        readback = _run_gate(database_url, "--readback-only")
+        assert readback.returncode == 0, _output(readback)
+        assert "skipping alembic upgrade and check" in readback.stdout
+
+        target = create_engine(database_url, pool_pre_ping=True)
+        _inject_schema_drift(target)
+
+        drift = _run_gate(database_url)
+        assert drift.returncode != 0, _output(drift)
+        drift_output = _output(drift)
+        assert "d5_regression_column" in drift_output
+        assert "d5_regression_table" in drift_output
+        assert "d5_regression_index" in drift_output
+
+        _remove_schema_drift(target)
+        _seed_duplicate_company_rows(target)
+        _create_invalid_company_index(target)
+
+        invalid_index = _run_gate(database_url, "--readback-only")
+        assert invalid_index.returncode != 0, _output(invalid_index)
+        invalid_output = _output(invalid_index)
+        assert "idx_members_company_trgm" in invalid_output
+        assert (
+            "indisvalid=false" in invalid_output
+            or "method='btree'" in invalid_output
+        )
+    finally:
+        if target is not None:
+            _cleanup_invalid_company_index(target)
+            target.dispose()
+        if created:
+            _drop_database(maintenance, database_name)
+        maintenance.dispose()


### PR DESCRIPTION
Closes #252
Closes #266

## 요약

D5 후속 review에서 확인된 운영 migration 진입점과 catalog false-PASS 경로를 보완했어. PR은 API/Web 계약 변경 없이 PostgreSQL migration, authoritative schema gate, 운영 readback, 실제 disposable PostgreSQL regression만 다뤄.

- 기준 main exact head: `2f136ef276e71734c6cd2f553e58774f3acdacd5`
- 최종 branch head: `bbae30fa34c963be3debff4a33f10adda3dc6ab0`
- 주요 구현 commit: `797ad610c40d644b1e35eee8f7eb3e6a627bcb8d`
- revision: `d5f2a1c9e7b3` (`c8a7f3d1e2b4` → `d5f2a1c9e7b3`)
- 운영 DB/VPS, 운영 URL/계정/데이터는 접근하지 않았어.

## #266 인덱스 선택 근거

production telemetry는 경계상 사용하지 않았고, 현재 repository 검색 workload와 120,000행 synthetic disposable PostgreSQL에서 exact/partial/case-insensitive 대표 검색을 default planner로 `EXPLAIN (ANALYZE, BUFFERS)` 5회 측정했어. `enable_seqscan=off`는 사용하지 않았어.

| 필드 | 데이터 근거 | plan/결정 |
|---|---|---|
| `student_id` | 120,000 distinct / exact-like hit 1건(0.0008%) | Seq Scan 42.018ms → Bitmap Heap/GIN 1.958ms; 선택 |
| `company` | 11,413 distinct / 대표 partial hit 2.00% | Seq Scan 33.797ms → Bitmap Heap/GIN 7.845ms; 선택 |
| `major` | 20 distinct / `%경제%` 10.00% | Parallel Seq Scan 유지, 39.082ms → 37.651ms; 제외 |
| `industry` | 12 distinct / `%금융%` 8.33% | Parallel Seq Scan 유지, 42.555ms → 47.021ms; 제외 |

신규 GIN은 `student_id`와 `company`만 채택했어. OR workload(`name/email/student_id`)는 88.076ms → 2.099ms였고 대표 검색 결과 digest는 index 전후 동일했어. clean index size는 `company=6,584 kB`, `student_id=6,224 kB`, members relation은 101MB → 116MB였어. 10,000행 rollback-only INSERT 3회 median은 1,090.621ms → 1,105.327ms(+1.35%)이며 localhost cache/스케줄링/rollback 측정의 노이즈 한계를 문서에 기록했어.

## P1 운영 migration 진입점

old exact head `895d9e68e66f04f60e30ad10d1d0633cccd63620`에서 실제 API image로 `ops/cloud-migrate.sh`를 실행해 고정 `infra/api-entrypoint.sh`가 전달된 `bash -lc "alembic ..."`를 무시하고 uvicorn을 시작하는 버그를 12초 timeout으로 재현했어.

- `cloud-migrate.sh`에만 `--entrypoint /bin/sh`를 추가하고 image 뒤에 `-lc "$ALEMBIC_CMD"`를 전달했어.
- API runtime entrypoint 전역 동작은 바꾸지 않았고, Docker command는 배열 인수로 유지해 `DATABASE_URL`을 출력하지 않아.
- API image에 `ops/ci/migration_gate.py`를 포함해 운영 readback과 CI가 같은 Python gate authority를 사용하게 했어.
- `ops/ci/test_cloud_migrate.sh`가 `/bin/sh`, `-lc`, custom command 인수 보존과 secret 미출력을 고정하며 CI repo-guards에서도 실행돼.

## migration/gate

- `--require-empty`: public table이 없는 PostgreSQL에서 `upgrade head` → `alembic check` → current/head, extension, index catalog readback.
- `--readback-only`: upgrade와 `alembic check`를 생략하고 DB를 변경하지 않으며 current/head, `pg_trgm`, 기대 index 상태만 읽어.
- index readback은 `pg_class` + `pg_namespace` + `pg_index` + `pg_am` + `pg_attribute` + `pg_opclass`를 구조적으로 join해 public `members` table/column, `gin`, `gin_trgm_ops`, `indisvalid=true`, `indisready=true`, `indislive=true`를 모두 검증해. `pg_indexes.indexdef` 문자열 parsing은 제거했어.
- `ScriptDirectory.get_heads()`의 list/tuple 지적은 old exact head와 GitHub CI에서 비교가 이미 PASS한 오탐으로 확인되어 기존 반환 계약을 유지했어.
- 기존 migration-created 5개 trgm index와 RSVP/push index는 `apps/api/models.py` metadata에 표현했고 blanket `include_object`/`compare_index` 예외와 index 삭제는 추가하지 않았어.
- 실패한 concurrent index가 남긴 invalid/wrong-method index를 `IF NOT EXISTS`로 덮지 못하는 위험과 `autocommit_block()` 중간 current/부분 커밋을 runbook에 기록했어.

## 실제 API image → PostgreSQL evidence

전용 local PostgreSQL container와 disposable DB만 사용했어.

- `d5-review-api-after-p1`를 실제 build.
- `ops/cloud-migrate.sh` → `/bin/sh -lc` → real Alembic 최초 revision부터 `d5f2a1c9e7b3`까지 exit 0.
- image 내부 `python ops/ci/migration_gate.py --readback-only`: `alembic current=head: d5f2a1c9e7b3`, `pg_trgm`, valid/ready/live catalog PASS.
- 구조적 catalog row 7개 모두 `members`, 기대 column, `gin`, `gin_trgm_ops`, `True/True/True` readback.
- real API image `/healthz`: `{"ok":true}`.
- 기존 schema 상태는 cloud-migrate 후 `--readback-only`로 별도 확인했고, fresh empty gate도 API image에서 `--require-empty` PASS.

## 실제 repository Alembic regression

`tests/api/test_migration_gate.py`의 SQLite/합성 comparator를 제거하고 전용 disposable PostgreSQL DB를 매 테스트 생성/삭제하도록 바꿨어. repository `apps/api/migrations/env.py`, `models.Base.metadata`, 실제 gate subprocess를 사용해:

- 정상 head 적용 후 column/table/index drift 주입 → 실제 `command.check()` nonzero.
- duplicate company rows로 실패한 `CREATE UNIQUE INDEX CONCURRENTLY`가 남긴 invalid/wrong-method `idx_members_company_trgm` → `--readback-only` nonzero.
- fixture index/row와 disposable DB는 finally에서 정확히 제거.

## 검증

### 자동화

- guards PASS; API Ruff PASS; full Pyright PASS: 0 errors(기존 third-party warning 2개); ops gate/test targeted Pyright PASS.
- previous D5 full pytest: `303 passed, 1 warning`; current follow-up targeted PostgreSQL regression: `1 passed`; current isolated full pytest: `302 passed, 1 failed` in existing D4 auth/fixture-order (`test_public_hides_notice_draft_and_future`). The D4 file alone passed `13 passed`; the D5 change did not alter D4 fixtures.
- Web lint PASS; Web test PASS: `77 files / 269 tests`; Web production build PASS.
- OpenAPI export + DTO generation + generated diff check PASS (API 계약 변경 없음).
- githooks, cloud migration shell contract, Bandit, pip-audit strict, accessibility smoke, bundle `1181/1536 KB`, pnpm prod audit, commitlint/compileall 모두 PASS.

### 실제 browser E2E

이번 follow-up은 migration/ops-only라 API/Web 화면·검색 결과 계약을 변경하지 않았고, 이전 exact head에서 저장소 `playwright-cli` skill의 headed visible browser E2E가 이미 PASS했으므로 재실행하지 않았어. 이번 head에서는 mock 없는 실제 API image + real local PostgreSQL health/readback을 별도 검증했어. 이전 browser 증거는 production Web `127.0.0.1:3000` → real API `127.0.0.1:3001` → local DB에서 실제 로그인/type/click/동문 수첩 검색 결과와 anonymous 권한 화면을 확인했고, storage-state/운영 URL·계정·데이터를 사용하지 않았어.

## 남은 위험

- 기존 local `appdb`의 역사적 `signup_activation_issue_logs` index 4개(`issued_at`, `issued_by_student_id`, `issued_type`, `signup_request_id`)는 D5 범위 밖이라 삭제/숨김/임의 migration하지 않았어. authoritative `alembic check`에서 `remove_index` drift로 계속 FAIL할 수 있으며, 별도 조사 후 정확한 catalog 계약 migration 여부를 결정해야 해.
- 실제 운영 telemetry를 사용하지 않았으므로 선택도와 latency는 synthetic/local workload 근거야. 배포 후 query statistics, bloat, write latency를 별도 관측해야 해.
- local gitleaks는 이번 diff와 무관한 baseline `2f136ef...`의 `apps/api/routers/auth.py:95`(`payload.password`) generic-api-key false positive 1건을 보고했어. 해당 파일은 이번 commit에서 변경하지 않았고, 비밀값은 추가하지 않았어.
- observed CI impact는 migration gate 약 1.6초, Python job 약 4분 15초이며 병렬/캐시 구조는 변경하지 않았어.

상세 수치와 cleanup/readback 절차는 `docs/plan_d5_migration_search_260802.md`, `docs/dev_log_260802.md`, `docs/agent_runbook_vps.md`에 기록했어.
 
## Latest review follow-up — exact head bbae30f
 
Sol P2와 Grok/Sol P3만 반영했어.
 
- `ops/ci/migration_gate.py` now reads `(pg_index.indpred IS NULL)` as the structural `is_full_index` catalog state and rejects every expected partial index with nonzero `full_index=false`. Existing table/column/Gin/opclass and `indisvalid`/`indisready`/`indislive` checks remain.
- `tests/api/test_migration_gate.py` adds a valid same-name `idx_members_company_trgm USING gin (company gin_trgm_ops) WHERE false` fixture. The actual repository Alembic/gate path rejects it, while the existing column/table/index drift and invalid/wrong-method concurrent regressions remain.
- `docs/ci_quality_gates.md` now uses only a named disposable `d5_migration_gate_local` drop/create/readback/drop flow; it explicitly separates GitHub CI service connection details from localhost. `docs/agent_runbook_vps_en.md` is synchronized with the Korean D5 operational rules, including one-shot entrypoint override, same-image Python readback, full-index expectation, invalid/partial same-name cleanup, autocommit partial application, and disposable-only `--require-empty`.
- Actual current-source API image proof: `--require-empty` and `--readback-only` PASS on disposable PostgreSQL; a valid same-name partial fixture produces `full_index=false` and exit 1. Temporary image/context/database were removed afterward.
- Local static gates, Web lint/test/build, OpenAPI/DTO no-drift, githooks, shell contract, Bandit, and pip-audit passed. Visible browser E2E was not rerun because this is gate/docs/test-only and no API/Web/search contract changed; prior real-browser proof remains separately recorded.
- Exact-head CI is being tracked separately below; no merge/auto-merge or review-thread reply/resolve was performed.
