### PR TITLE
feat(ops): 운영 빌드·컨테이너 guard 적용 (D6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,10 @@ JWT_SECRET=change-me
 # (이 값은 Python의 json.loads 등으로 파싱됩니다. 예: https://fastapi.tiangolo.com/tutorial/cors/#use-corsmiddleware)
 CORS_ORIGINS=["http://localhost:3000"]
 
-# Web(Next.js)에서 API 베이스 URL
-# apps/web/lib/api.ts는 NEXT_PUBLIC_WEB_API_BASE를 사용합니다.
+# Web(Next.js) 브라우저 공개 API 베이스 URL(개발에서는 HTTP loopback 허용)
 NEXT_PUBLIC_WEB_API_BASE=http://localhost:3001
+# Web 서버 컴포넌트가 Docker 내부에서 API에 연결할 때만 사용하는 server-only URL
+API_INTERNAL_URL=http://api_dev:3001
 
 # 레이트 리밋 설정 (SlowAPI)
 RATE_LIMIT_DEFAULT=120/minute

--- a/.env.web.example
+++ b/.env.web.example
@@ -26,6 +26,7 @@ NEXT_PUBLIC_ENABLE_SW=1
 NEXT_PUBLIC_RELAX_CSP=
 
 # 5) 이미지 외부 도메인(쉼표 구분, 빌드타임 적용)
-# 프로덕션에서 API 서버가 이미지를 서빙하면 해당 도메인 추가 필수.
-# 예) NEXT_PUBLIC_IMAGE_DOMAINS=api.sogangeconomics.com
+# NEXT_PUBLIC_WEB_API_BASE의 API 이미지 origin은 자동 허용됩니다.
+# 그 밖의 외부 이미지 host만 쉼표로 추가합니다.
+# 예) NEXT_PUBLIC_IMAGE_DOMAINS=cdn.sogangeconomics.com
 NEXT_PUBLIC_IMAGE_DOMAINS=

--- a/.env.web.example
+++ b/.env.web.example
@@ -8,6 +8,8 @@
 NEXT_PUBLIC_SITE_URL=https://sogangeconomics.com
 # API 베이스 URL (예: https://api.sogangeconomics.com)
 NEXT_PUBLIC_WEB_API_BASE=https://api.sogangeconomics.com
+# Next 서버 전용 내부 API URL. 브라우저 번들에는 포함하지 않습니다.
+# API_INTERNAL_URL=http://alumni-api:3001
 
 # 2) 웹 푸시(선택)
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@
   - [ ] 파괴적 변경(락/다운타임 가능)이면 라벨과 설명을 PR 본문에 명시
   - [ ] 레이트리밋/보안 헤더 영향 검토(변경 시 `docs/security_hardening.md` 반영)
 - Web
-  - [ ] 로컬 `pnpm -C apps/web build` 성공(경고/에러 없음)
+  - [ ] 로컬 `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build` 성공(경고/에러 없음)
   - [ ] ESLint(Flat config) 통과, 우회 주석 없음
   - [ ] Tailwind 유틸/토큰 사용 검증(필요 시 스냅샷 첨부)
 - 보안/컴플라이언스

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: bash ops/ci/test_cloud_migrate.sh
       - name: Cloud start command contract
         run: bash ops/ci/test_cloud_start.sh
+      - name: VPS deploy command contract
+        run: bash ops/ci/test_deploy_vps.sh
       - name: Enforce standardized versions
         run: python ops/ci/check_versions.py
       - name: Validate Dependabot policy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,6 @@ jobs:
     needs: repo-guards
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_WEB_API_BASE: https://api.example.com
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -198,6 +196,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-
       - name: Build
+        env:
+          NEXT_PUBLIC_WEB_API_BASE: https://api.example.com
         run: pnpm -C apps/web build
       - name: Accessibility smoke (axe)
         run: pnpm -C apps/web exec vitest run __tests__/a11y-smoke.test.tsx --silent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: bash ops/ci/test_githooks.sh
       - name: Cloud migration command contract
         run: bash ops/ci/test_cloud_migrate.sh
+      - name: Cloud start command contract
+        run: bash ops/ci/test_cloud_start.sh
       - name: Enforce standardized versions
         run: python ops/ci/check_versions.py
       - name: Validate Dependabot policy
@@ -156,6 +158,8 @@ jobs:
     needs: repo-guards
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_WEB_API_BASE: https://api.example.com
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       WEB_BASE_URL: http://127.0.0.1:3000
       NEXT_PUBLIC_WEB_API_BASE: http://127.0.0.1:3001
+      WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
       E2E_MOCK_API_CONTROL_URL: http://127.0.0.1:3001
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lighthouse-debug.yml
+++ b/.github/workflows/lighthouse-debug.yml
@@ -33,6 +33,9 @@ jobs:
         run: pnpm -C apps/web install --frozen-lockfile
 
       - name: Build (web)
+        env:
+          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
         run: pnpm -C apps/web build
 
       - name: Start server
@@ -77,6 +80,7 @@ jobs:
           NEXT_PUBLIC_RELAX_CSP: "1"
           NEXT_PUBLIC_ENABLE_SW: "0"
           NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
 
       - name: Lighthouse CI (debug desktop)
         id: lhci_desktop
@@ -94,6 +98,7 @@ jobs:
           NEXT_PUBLIC_RELAX_CSP: "1"
           NEXT_PUBLIC_ENABLE_SW: "0"
           NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
 
       - name: Attach debug note
         if: ${{ always() }}

--- a/.github/workflows/lighthouse-debug.yml
+++ b/.github/workflows/lighthouse-debug.yml
@@ -41,6 +41,9 @@ jobs:
         run: pnpm -C apps/web build
 
       - name: Start server
+        env:
+          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
+          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
         run: pnpm -C apps/web start &
 
       - name: Wait for server

--- a/.github/workflows/lighthouse-debug.yml
+++ b/.github/workflows/lighthouse-debug.yml
@@ -36,12 +36,11 @@ jobs:
         env:
           NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
           WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
+          NEXT_PUBLIC_RELAX_CSP: "1"
+          NEXT_PUBLIC_ENABLE_SW: "0"
         run: pnpm -C apps/web build
 
       - name: Start server
-        env:
-          NEXT_PUBLIC_RELAX_CSP: "1"
-          NEXT_PUBLIC_ENABLE_SW: "0"
         run: pnpm -C apps/web start &
 
       - name: Wait for server
@@ -77,10 +76,6 @@ jobs:
           LHCI_COLLECT__SETTINGS__DISABLE_STORAGE_RESET: false
           LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_FCP: 120000
           LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_LOAD: 120000
-          NEXT_PUBLIC_RELAX_CSP: "1"
-          NEXT_PUBLIC_ENABLE_SW: "0"
-          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
-          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
 
       - name: Lighthouse CI (debug desktop)
         id: lhci_desktop
@@ -95,10 +90,6 @@ jobs:
           LHCI_COLLECT__SETTINGS__DISABLE_STORAGE_RESET: false
           LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_FCP: 120000
           LHCI_COLLECT__SETTINGS__MAX_WAIT_FOR_LOAD: 120000
-          NEXT_PUBLIC_RELAX_CSP: "1"
-          NEXT_PUBLIC_ENABLE_SW: "0"
-          NEXT_PUBLIC_WEB_API_BASE: "http://localhost:3000"
-          WEB_BUILD_ALLOW_INSECURE_LOCAL_API: "1"
 
       - name: Attach debug note
         if: ${{ always() }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@
 # Web
 pnpm -C apps/web lint
 pnpm -C apps/web test
-pnpm -C apps/web build
+NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build
 
 # API 계약 변경
 .venv/bin/python scripts/export_openapi.py

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ make schema-gen
   - 사전: `docker network create sogecon_net || true`, `.env.api` 준비(`APP_ENV=prod`, 강한 `JWT_SECRET`, `DATABASE_URL=...@sogecon-db:5432/...`).
   - 실행(예시):
     - `bash scripts/deploy-vps.sh -t <TAG> -p ghcr.io/<owner>/<repo> \
-      --network sogecon_net --uploads "$PWD/uploads" -e .env.api -w "" \
+      --pull-images --network sogecon_net --uploads "$PWD/uploads" -e .env.api -w .env.web \
       --api-health http://localhost:3001/healthz --web-health http://localhost:3000/`
   - 특성: GHCR에 빌드된 이미지를 그대로 실행(배포 동작·보안·CORS 검증에 적합).
 
@@ -137,7 +137,7 @@ make schema-gen
 - 품질 게이트 SSOT: `docs/ci_quality_gates.md`
 - 훅 활성화: `git config core.hooksPath .githooks` + `pnpm install`(루트, commitlint) + `make venv && make api-install`
 - Python: `ruff` · `pyright` · `pytest -q`(PR CI)
-- Web: `pnpm -C apps/web lint` · `pnpm -C apps/web test` · `pnpm -C apps/web build`
+- Web: `pnpm -C apps/web lint` · `pnpm -C apps/web test` · `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`
 - 훅 스모크: `bash ops/ci/test_githooks.sh`
 - 단축키: `make test-api`, `make schema-gen` 등은 `Makefile` 참고.
 - CI: `.github/workflows/ci.yml` — commitlint(hard), API/Web 전체 검증, 보안 스캔. E2E·DTO·CodeQL은 별도 workflow.
@@ -166,17 +166,25 @@ MIT © 2025 Traum — 자세한 내용은 `LICENSE` 참조.
 
 ---
 문서 기본 언어는 한국어입니다. 사용자 노출 텍스트/README 역시 한국어를 우선합니다. 필요한 경우 간단한 영어 요약을 함께 제공합니다.
-## 배포 가이드(Prod: Web standalone + systemd, API/DB 컨테이너)
+## 배포 가이드(Prod target: full Docker, systemd rollback fallback)
 
-권장 운영 구성은 “Web(Next.js) 비컨테이너 + systemd + Nginx”이며, API/DB는 컨테이너로 유지합니다. 기존 “Web 컨테이너” 경로도 병행 지원하지만, 단순성·관찰성·롤백 속도 측면에서 standalone 구성을 권장합니다.
+Operator-confirmed current state는 migration 전까지 Web이 `sogecon-web`
+systemd standalone release이고 API/PostgreSQL이 Docker 컨테이너인 구성입니다.
+대표가 결정한 near-term target은 API/Web/PostgreSQL full Docker 구성입니다.
+기존 D6 `ops/cloud-start.sh`의 full-container guard를 target entry point로
+사용하며, systemd standalone release는 cutover 중 rollback fallback으로
+유지합니다.
 
-- 원클릭(권장): GitHub Actions → `web-standalone-deploy` → environment=`prod`
-  - CI가 `apps/web`을 `output: 'standalone'`으로 빌드 → 아카이브 업로드(SCP) → 원격에서 `ops/web-deploy.sh` 실행(릴리스 디렉터리 전개 + `current` 링크 전환 + systemd 재시작) → 헬스체크
-  - 서버 1회 준비: Node 24.12.0(asdf), `/srv/www/sogecon/releases`, Nginx 프록시(127.0.0.1:3000), systemd 유닛(`ops/systemd/sogecon-web.service`) 설치, sudoers(NOPASSWD) 설정
-  - 상세: `docs/agent_runbook_vps.md` (KR) / `_en.md` (EN)
+- full-Docker migration flow: HTTPS `NEXT_PUBLIC_WEB_API_BASE`로 Web image build/pull → `API_INTERNAL_URL`을 Docker network runtime 값으로 준비 → image/env/network preflight → cutover 시점에만 `sogecon-web` systemd stop/disable → `ops/cloud-start.sh` → API/Web health와 representative browser flow readback
+  - 상세 절차: `docs/agent_runbook_vps.md` (KR) / `_en.md` (EN)
+  - `API_INTERNAL_URL=http://alumni-api:3001`은 Web runtime env file(`.env.web`)에 넣고, 공개 API 주소는 `NEXT_PUBLIC_WEB_API_BASE`로 build-time 주입합니다.
 
-- TL;DR(컨테이너 경로 — 병행 지원)
-  - 순서: 태그 선택 → 이미지 pull → Alembic → 재기동 → 헬스체크(최대 90초 재시도)
+- Web standalone(systemd) current-state/rollback fallback
+  - migration 전 operator-confirmed 상태 확인 또는 full-Docker Web rollback에만 사용합니다.
+  - standalone 산출물과 `/srv/www/sogecon/current` symlink는 cutover 전에 보존합니다.
+
+- Full Docker target quick path
+  - 순서: 태그 선택 → 이미지 pull → Alembic → 재기동 → image health/readiness 및 public health readback
   - 수동 예시(서버):
     ```bash
     TAG=<sha>
@@ -186,17 +194,18 @@ MIT © 2025 Traum — 자세한 내용은 `LICENSE` 참조.
     API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:$TAG ENV_FILE=.env.api DOCKER_NETWORK=sogecon_net ./ops/cloud-migrate.sh
     API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:$TAG WEB_IMAGE=ghcr.io/<owner>/<repo>/alumni-web:$TAG \
       DOCKER_NETWORK=sogecon_net API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web ./ops/cloud-start.sh
-    # 헬스(2xx 기대, 재기동 직후 5xx 허용 구간: ≤90s)
-    for i in {1..90}; do code=$(curl -sf -o /dev/null -w "%{http_code}" https://api.<도메인>/healthz || true); [ "$code" = 200 ] && break; sleep 1; done
-    for i in {1..90}; do code=$(curl -sf -o /dev/null -w "%{http_code}" https://<도메인>/ || true); [ "$code" = 200 ] && break; sleep 1; done
+    # public health readback after cloud-start's image health wait
+    curl -fsS https://api.<도메인>/healthz
+    curl -fsS https://<도메인>/
     ```
-  - 원클릭: `scripts/deploy-vps.sh -t <tag> --network sogecon_net --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
+  - 원클릭 full-Docker 실행: `scripts/deploy-vps.sh -t <tag> --pull-images --network sogecon_net -e .env.api -w .env.web --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
 
-### Web standalone(systemd) 수동 절차(요약)
-서버에 레포가 `/srv/sogecon-app`로 클론되어 있다고 가정합니다. CI 없이 수동으로 전개하려면:
+### Web standalone(systemd) rollback fallback(요약)
+full-Docker cutover 전 현재 release를 보존하거나 Web rollback을 수행할 때만 사용합니다.
 ```bash
 # 1) 로컬/CI에서 빌드
-pnpm -C apps/web install && pnpm -C apps/web build  # output: 'standalone'
+NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web install
+NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web build  # output: 'standalone'
 tar -C . -czf web-standalone-<sha7>.tar.gz \
   apps/web/.next/standalone apps/web/.next/static apps/web/public
 
@@ -212,6 +221,8 @@ CI=1 RELEASE_BASE=/srv/www/sogecon SERVICE_NAME=sogecon-web \
 REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
 ```
 참고 파일: `ops/web-deploy.sh`, `ops/web-rollback.sh`, `ops/systemd/sogecon-web.service`, `ops/nginx/sogecon.conf`, `ops/nginx/nginx-site-web.conf`
+
+### Full-Docker target image build/run reference
 
 - 컨테이너 빌드/푸시(GHCR 권장)
   - AMD64 빌드: 
@@ -242,7 +253,7 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
   API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
   ./ops/cloud-start.sh
   ```
-- 원클릭 스크립트(서버): `scripts/deploy-vps.sh -t <tag> --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
+- 원클릭 full-Docker 스크립트(서버): `scripts/deploy-vps.sh -t <tag> --pull-images -e .env.api -w .env.web --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
 - 리버스 프록시: Nginx 예시는 `ops/nginx-examples/` 참고(127.0.0.1:3000/3001로 프록시, TLS는 Nginx에서 처리).
 
 ### 보안 헤더/CSP 주의
@@ -252,7 +263,7 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
 - Google Analytics: `NEXT_PUBLIC_ANALYTICS_ID`가 설정되면 `https://www.googletagmanager.com` 스크립트와 `https://www.google-analytics.com` 전송 도메인이 자동 허용됩니다.
 
 #### 운영 체크리스트
-- [ ] `pnpm -C apps/web build` 후 `pnpm -C apps/web start` + reverse proxy 구성에서 브라우저 DevTools → Network 헤더로 CSP 적용 상태를 확인합니다.
+- [ ] `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web build` 후 `pnpm -C apps/web start` + reverse proxy 구성에서 브라우저 DevTools → Network 헤더로 CSP 적용 상태를 확인합니다.
 - [ ] `style-src 'unsafe-inline'`을 그대로 둘 경우, 인라인 스타일 삽입이 필요한 컴포넌트만 사용하는지(Next 빌트인 스타일 태그) 정기적으로 점검하고 별도 인라인 스니펫을 추가하지 않도록 리뷰합니다.
 - [ ] relax 모드(`NEXT_PUBLIC_RELAX_CSP=1`)는 개발/사내 환경에서만 사용하고, 운영에서는 제거했는지 배포 전 체크합니다.
 
@@ -267,7 +278,7 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
     ```
 
 ### 롤백(요약)
-- 직전 안정 태그로 이미지 pull → 재기동으로 복구합니다(대부분의 변경에서 DB downgrade 불필요).
+- D6+ HEALTHCHECK 이미지끼리는 직전 안정 태그로 pull → 현재 D6+ `cloud-start.sh` 재기동으로 복구합니다. pre-D6 이미지처럼 HEALTHCHECK가 없는 태그는 해당 이미지와 matched release set인 pre-D6 deployment script/release checkout으로 롤백합니다(대부분의 변경에서 DB downgrade 불필요).
   ```bash
   PREV=<stable-tag>
   docker pull ghcr.io/<owner>/<repo>/alumni-api:$PREV
@@ -275,6 +286,9 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
   API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:$PREV WEB_IMAGE=ghcr.io/<owner>/<repo>/alumni-web:$PREV \
     DOCKER_NETWORK=sogecon_net API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web ./ops/cloud-start.sh
   ```
+  Web rollback fallback: stop/remove the Web container, restore the previous
+  `/srv/www/sogecon/current` symlink/release, then run
+  `systemctl enable --now sogecon-web`.
 
 ### Nginx 502 완화 팁
 - 재기동 직후 잠깐의 502는 정상일 수 있습니다. 필요 시 업스트림 타임아웃을 보수적으로 조정합니다.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ make schema-gen
 - 웹(Next.js)
   - `NEXT_PUBLIC_*`는 “빌드타임 고정”입니다. 값 변경 시 반드시 재빌드가 필요합니다.
   - 대표 키: `NEXT_PUBLIC_WEB_API_BASE`(API 베이스), `NEXT_PUBLIC_SITE_URL`(공개 URL), `NEXT_PUBLIC_VAPID_PUBLIC_KEY`.
+  - production build의 API 베이스는 HTTPS가 필수이며, `API_INTERNAL_URL`은 서버 전용 Docker 내부 URL입니다. loopback HTTP local/test build만 `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 명시합니다.
 - 서버 배포(API/Web)
   - API 런타임 env 파일: `.env.api`(루트), 예시는 `.env.api.example` 참고.
   - Web 런타임 env 파일(선택): `.env.web`(예시는 `.env.web.example`). 단, `NEXT_PUBLIC_*`는 빌드타임 주입이 원칙.

--- a/README.md
+++ b/README.md
@@ -235,13 +235,16 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
   - ARM 맥에서 AMD64 서버용: `PLATFORMS=linux/amd64 USE_BUILDX=1` 추가
 - Web 이미지 빌드 주의(Next.js + pnpm)
   - `corepack`으로 pnpm 버전 고정: Dockerfile에서 `corepack prepare pnpm@10.17.1 --activate` 사용.
-  - 런타임에서 `pnpm`이 필요 없도록 빌드 단계에서 의존성을 포함시킵니다.
-  - 실행 커맨드: `node node_modules/next/dist/bin/next start -p 3000`(런타임 최소화).
+  - 생성된 standalone artifact에 의존성·public·`.next/static`을 함께 넣고, 런타임에는 빌드 시점 public 설정을 다시 주입하지 않습니다.
+  - 실행 커맨드: `node apps/web/server.js`(생성된 standalone entrypoint).
 - 서버 실행(예: `/srv/sogecon`에 클론되어 있다고 가정)
   ```bash
   # 1) 이미지 풀
   docker pull ghcr.io/<owner>/<repo>/alumni-api:<tag>
   docker pull ghcr.io/<owner>/<repo>/alumni-web:<tag>
+
+  # Docker 내부 API hostname(alumni-api)을 해석할 user-defined network
+  docker network inspect sogecon_net >/dev/null 2>&1 || docker network create sogecon_net
 
   # 2) 마이그레이션(최초/스키마 변경 시)
   API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:<tag> \

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
 - Google Analytics: `NEXT_PUBLIC_ANALYTICS_ID`가 설정되면 `https://www.googletagmanager.com` 스크립트와 `https://www.google-analytics.com` 전송 도메인이 자동 허용됩니다.
 
 #### 운영 체크리스트
-- [ ] `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web build` 후 `pnpm -C apps/web start` + reverse proxy 구성에서 브라우저 DevTools → Network 헤더로 CSP 적용 상태를 확인합니다.
+- [ ] `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web build` 후 `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web start` + reverse proxy 구성에서 브라우저 DevTools → Network 헤더로 CSP 적용 상태를 확인합니다.
 - [ ] `style-src 'unsafe-inline'`을 그대로 둘 경우, 인라인 스타일 삽입이 필요한 컴포넌트만 사용하는지(Next 빌트인 스타일 태그) 정기적으로 점검하고 별도 인라인 스니펫을 추가하지 않도록 리뷰합니다.
 - [ ] relax 모드(`NEXT_PUBLIC_RELAX_CSP=1`)는 개발/사내 환경에서만 사용하고, 운영에서는 제거했는지 배포 전 체크합니다.
 

--- a/README.md
+++ b/README.md
@@ -245,15 +245,15 @@ REPO_ROOT=/srv/sogecon-app/_tmp/web-standalone-<sha7> bash ./ops/web-deploy.sh
 
   # 2) 마이그레이션(최초/스키마 변경 시)
   API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:<tag> \
-  ENV_FILE=.env.api ./ops/cloud-migrate.sh
+  ENV_FILE=.env.api DOCKER_NETWORK=sogecon_net ./ops/cloud-migrate.sh
 
   # 3) 재기동
   API_IMAGE=ghcr.io/<owner>/<repo>/alumni-api:<tag> \
   WEB_IMAGE=ghcr.io/<owner>/<repo>/alumni-web:<tag> \
-  API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
+  API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web DOCKER_NETWORK=sogecon_net \
   ./ops/cloud-start.sh
   ```
-- 원클릭 full-Docker 스크립트(서버): `scripts/deploy-vps.sh -t <tag> --pull-images -e .env.api -w .env.web --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
+- 원클릭 full-Docker 스크립트(서버): `scripts/deploy-vps.sh -t <tag> --pull-images --network sogecon_net -e .env.api -w .env.web --api-health https://api.<도메인>/healthz --web-health https://<도메인>/`
 - 리버스 프록시: Nginx 예시는 `ops/nginx-examples/` 참고(127.0.0.1:3000/3001로 프록시, TLS는 Nginx에서 처리).
 
 ### 보안 헤더/CSP 주의

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,7 +10,7 @@ bcrypt==5.0.0
 itsdangerous==2.2.0
 email-validator==2.3.0
 pywebpush==2.3.0
-cryptography==49.0.0
+cryptography==50.0.0
 Pillow==12.3.0
 sentry-sdk[starlette]==2.64.0
 apscheduler==3.11.3

--- a/apps/web/__tests__/api-asset-url.test.ts
+++ b/apps/web/__tests__/api-asset-url.test.ts
@@ -11,4 +11,13 @@ describe('API 이미지 URL', () => {
     expect(resolveApiAssetUrl('https://cdn.example.com/example.png')).toBe('https://cdn.example.com/example.png');
     expect(resolveApiAssetUrl('/images/home/hero.svg')).toBe('/images/home/hero.svg');
   });
+
+  it('SSR 자산 URL은 내부 fetch base가 아니라 공개 API base를 사용한다', () => {
+    expect(resolveApiAssetUrl('/media/images/server-rendered.png', {
+      publicBase: 'https://public-api.example.com///',
+      internalBase: 'http://api:3001',
+      isBrowser: false,
+      nodeEnv: 'production',
+    })).toBe('https://public-api.example.com/media/images/server-rendered.png');
+  });
 });

--- a/apps/web/__tests__/api-base-resolution.test.ts
+++ b/apps/web/__tests__/api-base-resolution.test.ts
@@ -39,6 +39,7 @@ describe('API base selection', () => {
 
   it('does not invent a production localhost fallback', () => {
     expect(() => resolveApiBase({
+      publicBase: '',
       isBrowser: false,
       nodeEnv: 'production',
     })).toThrow('NEXT_PUBLIC_WEB_API_BASE');
@@ -52,6 +53,7 @@ describe('API base selection', () => {
       currentHostname: '192.0.2.20',
     })).toBe('http://192.0.2.20:3001');
     expect(resolveApiBase({
+      publicBase: '',
       isBrowser: false,
       nodeEnv: 'test',
     })).toBe('http://localhost:3001');

--- a/apps/web/__tests__/api-base-resolution.test.ts
+++ b/apps/web/__tests__/api-base-resolution.test.ts
@@ -22,6 +22,21 @@ describe('API base selection', () => {
     })).toBe('https://api.example.com');
   });
 
+  it('normalizes trailing slashes without changing the server/browser split', () => {
+    expect(resolveApiBase({
+      publicBase: 'https://api.example.com///',
+      internalBase: 'http://api:3001///',
+      isBrowser: false,
+      nodeEnv: 'production',
+    })).toBe('http://api:3001');
+    expect(resolveApiBase({
+      publicBase: 'https://api.example.com///',
+      internalBase: 'http://api:3001///',
+      isBrowser: true,
+      nodeEnv: 'production',
+    })).toBe('https://api.example.com');
+  });
+
   it('does not invent a production localhost fallback', () => {
     expect(() => resolveApiBase({
       isBrowser: false,

--- a/apps/web/__tests__/api-base-resolution.test.ts
+++ b/apps/web/__tests__/api-base-resolution.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveApiBase } from '../lib/api';
+
+describe('API base selection', () => {
+  it('uses server-only API_INTERNAL_URL on the server', () => {
+    expect(resolveApiBase({
+      publicBase: 'https://api.example.com',
+      internalBase: 'http://api:3001',
+      isBrowser: false,
+      nodeEnv: 'production',
+    })).toBe('http://api:3001');
+  });
+
+  it('always uses the public build-time URL in the browser', () => {
+    expect(resolveApiBase({
+      publicBase: 'https://api.example.com',
+      internalBase: 'http://api:3001',
+      isBrowser: true,
+      nodeEnv: 'production',
+      currentHostname: 'alumni.example.com',
+    })).toBe('https://api.example.com');
+  });
+
+  it('does not invent a production localhost fallback', () => {
+    expect(() => resolveApiBase({
+      isBrowser: false,
+      nodeEnv: 'production',
+    })).toThrow('NEXT_PUBLIC_WEB_API_BASE');
+  });
+
+  it('keeps current-host and localhost fallback behavior limited to dev/test', () => {
+    expect(resolveApiBase({
+      publicBase: 'http://localhost:3001',
+      isBrowser: true,
+      nodeEnv: 'development',
+      currentHostname: '192.0.2.20',
+    })).toBe('http://192.0.2.20:3001');
+    expect(resolveApiBase({
+      isBrowser: false,
+      nodeEnv: 'test',
+    })).toBe('http://localhost:3001');
+  });
+
+  it('does not rewrite loopback public URLs in production', () => {
+    expect(resolveApiBase({
+      publicBase: 'http://127.0.0.1:3001',
+      isBrowser: true,
+      nodeEnv: 'production',
+      currentHostname: '192.0.2.20',
+    })).toBe('http://127.0.0.1:3001');
+  });
+});

--- a/apps/web/__tests__/build-config.test.ts
+++ b/apps/web/__tests__/build-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+// next.config.js loads this small CommonJS module directly during `next build`.
+import { validateProductionWebApiBase } from '../lib/build-config';
+
+describe('production Web API build configuration', () => {
+  it.each([undefined, '', '   '])('rejects missing or blank API base: %j', (apiBase) => {
+    expect(() => validateProductionWebApiBase({ apiBase })).toThrow('NEXT_PUBLIC_WEB_API_BASE');
+  });
+
+  it.each(['api.example.com', 'https://', 'ftp://api.example.com'])('rejects malformed/non-absolute URLs: %s', (apiBase) => {
+    expect(() => validateProductionWebApiBase({ apiBase })).toThrow();
+  });
+
+  it('rejects HTTP production API URLs without the explicit local escape hatch', () => {
+    expect(() => validateProductionWebApiBase({ apiBase: 'http://localhost:3001' })).toThrow();
+  });
+
+  it('accepts HTTPS API URLs', () => {
+    expect(validateProductionWebApiBase({ apiBase: 'https://api.example.com/v1' })).toBe('https://api.example.com/v1');
+  });
+
+  it.each(['http://localhost:3001', 'http://127.0.0.1:3001', 'http://[::1]:3001'])('accepts explicit HTTP loopback escape: %s', (apiBase) => {
+    expect(validateProductionWebApiBase({ apiBase, allowInsecureLocalApi: '1' })).toBe(apiBase);
+  });
+
+  it.each(['http://api.example.com:3001', 'http://192.0.2.10:3001'])('rejects arbitrary-host HTTP even with escape: %s', (apiBase) => {
+    expect(() => validateProductionWebApiBase({ apiBase, allowInsecureLocalApi: '1' })).toThrow('loopback');
+  });
+});

--- a/apps/web/__tests__/build-config.test.ts
+++ b/apps/web/__tests__/build-config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // next.config.js loads this small CommonJS module directly during `next build`.
 import {
+  allowsLocalApiImageOptimization,
   getPublicApiImageRemotePattern,
   validateProductionWebApiBase,
 } from '../lib/build-config';
@@ -55,6 +56,14 @@ describe('production Web API build configuration', () => {
 
   it.each(['http://localhost:3001', 'http://127.0.0.1:3001', 'http://[::1]:3001'])('accepts explicit HTTP loopback escape: %s', (apiBase) => {
     expect(validateProductionWebApiBase({ apiBase, allowInsecureLocalApi: '1' })).toBe(apiBase);
+  });
+
+  it.each(['http://localhost:3001', 'http://127.0.0.1:3001', 'http://[::1]:3001'])('allows local image optimization for loopback API: %s', (apiBase) => {
+    expect(allowsLocalApiImageOptimization(apiBase)).toBe(true);
+  });
+
+  it('does not allow local image optimization for a public API', () => {
+    expect(allowsLocalApiImageOptimization('https://api.example.com')).toBe(false);
   });
 
   it.each(['http://api.example.com:3001', 'http://192.0.2.10:3001'])('rejects arbitrary-host HTTP even with escape: %s', (apiBase) => {

--- a/apps/web/__tests__/build-config.test.ts
+++ b/apps/web/__tests__/build-config.test.ts
@@ -54,6 +54,16 @@ describe('production Web API build configuration', () => {
     });
   });
 
+  it('keeps IPv6 brackets for Next remote patterns while normalizing loopback checks', () => {
+    const apiBase = 'http://[::1]:3001';
+    expect(getPublicApiImageRemotePattern(apiBase)).toEqual({
+      protocol: 'http',
+      hostname: '[::1]',
+      port: '3001',
+    });
+    expect(allowsLocalApiImageOptimization(apiBase)).toBe(true);
+  });
+
   it.each(['http://localhost:3001', 'http://127.0.0.1:3001', 'http://[::1]:3001'])('accepts explicit HTTP loopback escape: %s', (apiBase) => {
     expect(validateProductionWebApiBase({ apiBase, allowInsecureLocalApi: '1' })).toBe(apiBase);
   });

--- a/apps/web/__tests__/build-config.test.ts
+++ b/apps/web/__tests__/build-config.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // next.config.js loads this small CommonJS module directly during `next build`.
-import { validateProductionWebApiBase } from '../lib/build-config';
+import {
+  getPublicApiImageRemotePattern,
+  validateProductionWebApiBase,
+} from '../lib/build-config';
 
 describe('production Web API build configuration', () => {
-  it.each([undefined, '', '   '])('rejects missing or blank API base: %j', (apiBase) => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each(['', '   '])('rejects a blank API base: %j', (apiBase) => {
     expect(() => validateProductionWebApiBase({ apiBase })).toThrow('NEXT_PUBLIC_WEB_API_BASE');
+  });
+
+  it('rejects a missing API base from the process environment', () => {
+    vi.stubEnv('NEXT_PUBLIC_WEB_API_BASE', '');
+    expect(() => validateProductionWebApiBase()).toThrow('NEXT_PUBLIC_WEB_API_BASE');
   });
 
   it.each(['api.example.com', 'https://', 'ftp://api.example.com'])('rejects malformed/non-absolute URLs: %s', (apiBase) => {
@@ -21,6 +33,24 @@ describe('production Web API build configuration', () => {
 
   it('accepts HTTPS API URLs', () => {
     expect(validateProductionWebApiBase({ apiBase: 'https://api.example.com/v1' })).toBe('https://api.example.com/v1');
+  });
+
+  it.each([
+    'https://api.example.com?tenant=x',
+    'https://api.example.com/#fragment',
+    'https://api.example.com?',
+    'https://api.example.com#',
+    'https://user:pass@api.example.com/v1',
+  ])('rejects URL parts that break API path concatenation: %s', (apiBase) => {
+    expect(() => validateProductionWebApiBase({ apiBase })).toThrow('NEXT_PUBLIC_WEB_API_BASE');
+  });
+
+  it('derives the public API image origin, including an explicit port', () => {
+    expect(getPublicApiImageRemotePattern('https://api.example.com:8443/v1')).toEqual({
+      protocol: 'https',
+      hostname: 'api.example.com',
+      port: '8443',
+    });
   });
 
   it.each(['http://localhost:3001', 'http://127.0.0.1:3001', 'http://[::1]:3001'])('accepts explicit HTTP loopback escape: %s', (apiBase) => {

--- a/apps/web/__tests__/build-config.test.ts
+++ b/apps/web/__tests__/build-config.test.ts
@@ -13,7 +13,10 @@ describe('production Web API build configuration', () => {
   });
 
   it('rejects HTTP production API URLs without the explicit local escape hatch', () => {
-    expect(() => validateProductionWebApiBase({ apiBase: 'http://localhost:3001' })).toThrow();
+    expect(() => validateProductionWebApiBase({
+      apiBase: 'http://localhost:3001',
+      allowInsecureLocalApi: '',
+    })).toThrow();
   });
 
   it('accepts HTTPS API URLs', () => {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -38,7 +38,7 @@ export default [
 
   // JS config files (no type info) — relax TS unsafe rules here only
   {
-    files: ['**/*.config.js', 'next.config.js'],
+    files: ['**/*.config.js', 'next.config.js', 'lib/build-config.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
       // 사용하지 않는 변수는 경고가 아닌 에러로 취급(가드레일 준수)

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,29 +1,73 @@
 // 공통 API 클라이언트 래퍼
 // - fetch 옵션 통일, 에러 포맷 처리, BASE_URL 주입
 
-// API 기본 호스트는 가능한 한 현재 호스트를 따릅니다(포트만 3001 고정).
-// 환경변수에 localhost/127.0.0.1이 들어있으면 모바일/원격에서 동작하지 않으므로 무시하고 현재 호스트를 사용합니다.
-function resolveApiBase(): string {
-  const envBase = process.env.NEXT_PUBLIC_WEB_API_BASE;
+const DEV_LIKE_ENVS = new Set(['development', 'test']);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
-  if (typeof window !== 'undefined') {
-    // 클라이언트 사이드
-    const h = window.location.hostname;
-    if (!envBase) return `http://${h}:3001`;
-    const isLocal = /^(?:https?:\/\/)?(localhost|127\.0\.0\.1)(:\d+)?/i.test(envBase);
-    if (isLocal) return `http://${h}:3001`;
-    return envBase;
+type ApiBaseResolutionOptions = {
+  publicBase?: string;
+  internalBase?: string;
+  isBrowser?: boolean;
+  nodeEnv?: string;
+  currentHostname?: string;
+};
+
+function isLoopbackUrl(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return LOOPBACK_HOSTS.has(url.hostname.toLowerCase().replace(/^\[|\]$/g, ''));
+  } catch {
+    return false;
   }
-
-  // 서버 사이드: Docker Compose 환경에서는 컨테이너 간 통신을 위해 내부 URL 사용
-  // NEXT_PUBLIC_API_INTERNAL_URL이 설정되어 있으면 Docker 환경으로 간주
-  const internalUrl = process.env.NEXT_PUBLIC_API_INTERNAL_URL;
-  if (internalUrl) {
-    return internalUrl;
-  }
-
-  return envBase ?? 'http://localhost:3001';
 }
+
+function hostWithBrackets(hostname: string): string {
+  return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
+}
+
+function getBrowserValue(value: boolean | undefined): boolean {
+  return value === undefined ? typeof window !== 'undefined' : value;
+}
+
+function getCurrentHostname(value: string | undefined, isBrowser: boolean): string {
+  if (value) return value;
+  if (isBrowser && typeof window !== 'undefined') return window.location.hostname;
+  return 'localhost';
+}
+
+function getInternalBase(options: ApiBaseResolutionOptions, isBrowser: boolean): string | undefined {
+  if (isBrowser) return undefined;
+  const value = options.internalBase === undefined ? process.env.API_INTERNAL_URL : options.internalBase;
+  return value?.trim() || undefined;
+}
+
+function resolvePublicBase(publicUrl: string, isBrowser: boolean, nodeEnv: string, currentHostname: string): string {
+  const shouldRewriteLoopback = isBrowser && DEV_LIKE_ENVS.has(nodeEnv) && isLoopbackUrl(publicUrl);
+  if (shouldRewriteLoopback) return `http://${hostWithBrackets(currentHostname)}:3001`;
+  return publicUrl;
+}
+
+function resolveMissingBase(nodeEnv: string, currentHostname: string): string {
+  if (!DEV_LIKE_ENVS.has(nodeEnv)) {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE is required outside development and test environments.');
+  }
+  return `http://${hostWithBrackets(currentHostname)}:3001`;
+}
+
+export function resolveApiBase(options: ApiBaseResolutionOptions = {}): string {
+  const isBrowser = getBrowserValue(options.isBrowser);
+  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV ?? 'development';
+  const publicValue = options.publicBase === undefined ? process.env.NEXT_PUBLIC_WEB_API_BASE : options.publicBase;
+  const publicUrl = publicValue?.trim();
+  const internalBase = getInternalBase(options, isBrowser);
+  const currentHostname = getCurrentHostname(options.currentHostname, isBrowser);
+
+  if (internalBase) return internalBase;
+  if (publicUrl) return resolvePublicBase(publicUrl, isBrowser, nodeEnv, currentHostname);
+  return resolveMissingBase(nodeEnv, currentHostname);
+}
+
 export const API_BASE = resolveApiBase();
 
 export function resolveApiAssetUrl(value: string): string {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -4,7 +4,7 @@
 const DEV_LIKE_ENVS = new Set(['development', 'test']);
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
-type ApiBaseResolutionOptions = {
+export type ApiBaseResolutionOptions = {
   publicBase?: string;
   internalBase?: string;
   isBrowser?: boolean;
@@ -26,6 +26,10 @@ function hostWithBrackets(hostname: string): string {
   return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
 }
 
+function normalizeApiBase(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
 function getBrowserValue(value: boolean | undefined): boolean {
   return value === undefined ? typeof window !== 'undefined' : value;
 }
@@ -39,13 +43,14 @@ function getCurrentHostname(value: string | undefined, isBrowser: boolean): stri
 function getInternalBase(options: ApiBaseResolutionOptions, isBrowser: boolean): string | undefined {
   if (isBrowser) return undefined;
   const value = options.internalBase === undefined ? process.env.API_INTERNAL_URL : options.internalBase;
-  return value?.trim() || undefined;
+  return value?.trim() ? normalizeApiBase(value.trim()) : undefined;
 }
 
 function resolvePublicBase(publicUrl: string, isBrowser: boolean, nodeEnv: string, currentHostname: string): string {
-  const shouldRewriteLoopback = isBrowser && DEV_LIKE_ENVS.has(nodeEnv) && isLoopbackUrl(publicUrl);
+  const normalizedPublicUrl = normalizeApiBase(publicUrl);
+  const shouldRewriteLoopback = isBrowser && DEV_LIKE_ENVS.has(nodeEnv) && isLoopbackUrl(normalizedPublicUrl);
   if (shouldRewriteLoopback) return `http://${hostWithBrackets(currentHostname)}:3001`;
-  return publicUrl;
+  return normalizedPublicUrl;
 }
 
 function resolveMissingBase(nodeEnv: string, currentHostname: string): string {
@@ -70,8 +75,18 @@ export function resolveApiBase(options: ApiBaseResolutionOptions = {}): string {
 
 export const API_BASE = resolveApiBase();
 
-export function resolveApiAssetUrl(value: string): string {
-  if (value.startsWith('/media/')) return `${API_BASE}${value}`;
+export function resolveApiAssetUrl(value: string, options: ApiBaseResolutionOptions = {}): string {
+  if (value.startsWith('/media/')) {
+    const isBrowser = getBrowserValue(options.isBrowser);
+    const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV ?? 'development';
+    const publicValue = options.publicBase === undefined ? process.env.NEXT_PUBLIC_WEB_API_BASE : options.publicBase;
+    const publicUrl = publicValue?.trim();
+    const currentHostname = getCurrentHostname(options.currentHostname, isBrowser);
+    const publicBase = publicUrl
+      ? resolvePublicBase(publicUrl, isBrowser, nodeEnv, currentHostname)
+      : resolveMissingBase(nodeEnv, currentHostname);
+    return `${publicBase}${value}`;
+  }
   return value;
 }
 

--- a/apps/web/lib/build-config.js
+++ b/apps/web/lib/build-config.js
@@ -1,7 +1,16 @@
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
+function normalizeHostname(hostname) {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
 function normalizedHostname(url) {
-  return url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return normalizeHostname(url.hostname);
+}
+
+function remotePatternHostname(url) {
+  const hostname = normalizeHostname(url.hostname);
+  return hostname.includes(':') ? `[${hostname}]` : hostname;
 }
 
 function parseAbsoluteHttpUrl(value) {
@@ -70,14 +79,14 @@ function getPublicApiImageRemotePattern(apiBase = process.env.NEXT_PUBLIC_WEB_AP
 
   return {
     protocol: parsed.protocol.slice(0, -1),
-    hostname: normalizedHostname(parsed),
+    hostname: remotePatternHostname(parsed),
     ...(parsed.port ? { port: parsed.port } : {}),
   };
 }
 
 function allowsLocalApiImageOptimization(apiBase = process.env.NEXT_PUBLIC_WEB_API_BASE) {
   const pattern = getPublicApiImageRemotePattern(apiBase);
-  return pattern !== null && LOOPBACK_HOSTS.has(pattern.hostname);
+  return pattern !== null && LOOPBACK_HOSTS.has(normalizeHostname(pattern.hostname));
 }
 
 module.exports = {

--- a/apps/web/lib/build-config.js
+++ b/apps/web/lib/build-config.js
@@ -1,0 +1,54 @@
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+function normalizedHostname(url) {
+  return url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function parseAbsoluteHttpUrl(value) {
+  if (!/^https?:\/\//i.test(value)) {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE must be an absolute http(s) URL.');
+  }
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE must be a valid absolute URL.');
+  }
+}
+
+function isExplicitLocalHttp(url, allowInsecureLocalApi) {
+  if (url.protocol !== 'http:') return false;
+  if (allowInsecureLocalApi !== '1') return false;
+  return LOOPBACK_HOSTS.has(normalizedHostname(url));
+}
+
+/**
+ * Validate the public API URL that Next embeds into the browser bundle.
+ *
+ * HTTP is intentionally accepted only for an explicit build-only local
+ * escape hatch and only when the target is a loopback host.
+ */
+function validateProductionWebApiBase({
+  apiBase = process.env.NEXT_PUBLIC_WEB_API_BASE,
+  allowInsecureLocalApi = process.env.WEB_BUILD_ALLOW_INSECURE_LOCAL_API,
+} = {}) {
+  const value = typeof apiBase === 'string' ? apiBase.trim() : '';
+  if (!value) {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE is required for a production Web build.');
+  }
+
+  const parsed = parseAbsoluteHttpUrl(value);
+
+  const isHttps = parsed.protocol === 'https:';
+  const isExplicitLocalHttpValue = isExplicitLocalHttp(parsed, allowInsecureLocalApi);
+
+  if (!isHttps && !isExplicitLocalHttpValue) {
+    if (parsed.protocol === 'http:' && allowInsecureLocalApi === '1') {
+      throw new Error('WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 only permits HTTP loopback API URLs.');
+    }
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE must use HTTPS for a production Web build.');
+  }
+
+  return value;
+}
+
+module.exports = { LOOPBACK_HOSTS, validateProductionWebApiBase };

--- a/apps/web/lib/build-config.js
+++ b/apps/web/lib/build-config.js
@@ -15,6 +15,15 @@ function parseAbsoluteHttpUrl(value) {
   }
 }
 
+function rejectUnsupportedUrlParts(url) {
+  if (url.username || url.password) {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE must not include user credentials.');
+  }
+  if (url.href.includes('?') || url.href.includes('#')) {
+    throw new Error('NEXT_PUBLIC_WEB_API_BASE must not include a query string or fragment.');
+  }
+}
+
 function isExplicitLocalHttp(url, allowInsecureLocalApi) {
   if (url.protocol !== 'http:') return false;
   if (allowInsecureLocalApi !== '1') return false;
@@ -37,6 +46,7 @@ function validateProductionWebApiBase({
   }
 
   const parsed = parseAbsoluteHttpUrl(value);
+  rejectUnsupportedUrlParts(parsed);
 
   const isHttps = parsed.protocol === 'https:';
   const isExplicitLocalHttpValue = isExplicitLocalHttp(parsed, allowInsecureLocalApi);
@@ -51,4 +61,22 @@ function validateProductionWebApiBase({
   return value;
 }
 
-module.exports = { LOOPBACK_HOSTS, validateProductionWebApiBase };
+function getPublicApiImageRemotePattern(apiBase = process.env.NEXT_PUBLIC_WEB_API_BASE) {
+  const value = typeof apiBase === 'string' ? apiBase.trim() : '';
+  if (!value) return null;
+
+  const parsed = parseAbsoluteHttpUrl(value);
+  rejectUnsupportedUrlParts(parsed);
+
+  return {
+    protocol: parsed.protocol.slice(0, -1),
+    hostname: normalizedHostname(parsed),
+    ...(parsed.port ? { port: parsed.port } : {}),
+  };
+}
+
+module.exports = {
+  LOOPBACK_HOSTS,
+  getPublicApiImageRemotePattern,
+  validateProductionWebApiBase,
+};

--- a/apps/web/lib/build-config.js
+++ b/apps/web/lib/build-config.js
@@ -75,7 +75,13 @@ function getPublicApiImageRemotePattern(apiBase = process.env.NEXT_PUBLIC_WEB_AP
   };
 }
 
+function allowsLocalApiImageOptimization(apiBase = process.env.NEXT_PUBLIC_WEB_API_BASE) {
+  const pattern = getPublicApiImageRemotePattern(apiBase);
+  return pattern !== null && LOOPBACK_HOSTS.has(pattern.hostname);
+}
+
 module.exports = {
+  allowsLocalApiImageOptimization,
   LOOPBACK_HOSTS,
   getPublicApiImageRemotePattern,
   validateProductionWebApiBase,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const path = require('node:path');
+const { PHASE_PRODUCTION_BUILD } = require('next/constants');
+const { validateProductionWebApiBase } = require('./lib/build-config');
 
 // Bundle analyzer: pnpm -C apps/web analyze (Webpack 전용)
 // 런타임에서는 devDependency가 없으므로 조건부 로드
@@ -81,4 +83,9 @@ const nextConfig = {
   },
 };
 
-module.exports = withBundleAnalyzer(nextConfig);
+module.exports = (phase) => {
+  if (phase === PHASE_PRODUCTION_BUILD) {
+    validateProductionWebApiBase();
+  }
+  return withBundleAnalyzer(nextConfig);
+};

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const path = require('node:path');
 const { PHASE_PRODUCTION_BUILD } = require('next/constants');
-const { validateProductionWebApiBase } = require('./lib/build-config');
+const {
+  getPublicApiImageRemotePattern,
+  validateProductionWebApiBase,
+} = require('./lib/build-config');
 
 // Bundle analyzer: pnpm -C apps/web analyze (Webpack 전용)
 // 런타임에서는 devDependency가 없으므로 조건부 로드
@@ -27,9 +30,12 @@ const remoteDomainsEnv = (process.env.NEXT_PUBLIC_IMAGE_DOMAINS || '')
   .map((d) => d.trim())
   .filter(Boolean);
 
+const publicApiImagePattern = getPublicApiImageRemotePattern();
+
 const imageRemotePatterns = [
   { protocol: 'http', hostname: 'localhost', port: '3001' },
   { protocol: 'http', hostname: '127.0.0.1', port: '3001' },
+  ...(publicApiImagePattern ? [publicApiImagePattern] : []),
   ...remoteDomainsEnv.map((hostname) => ({ protocol: 'https', hostname })),
 ];
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,7 @@
 const path = require('node:path');
 const { PHASE_PRODUCTION_BUILD } = require('next/constants');
 const {
+  allowsLocalApiImageOptimization,
   getPublicApiImageRemotePattern,
   validateProductionWebApiBase,
 } = require('./lib/build-config');
@@ -39,15 +40,7 @@ const imageRemotePatterns = [
   ...remoteDomainsEnv.map((hostname) => ({ protocol: 'https', hostname })),
 ];
 
-const apiHostname = (() => {
-  try {
-    return new URL(process.env.NEXT_PUBLIC_WEB_API_BASE || '').hostname;
-  } catch {
-    return '';
-  }
-})();
-
-const allowLocalImageOptimization = apiHostname === 'localhost' || apiHostname === '127.0.0.1';
+const allowLocalImageOptimization = allowsLocalApiImageOptimization();
 
 const nextConfig = {
   poweredByHeader: false,

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,7 +53,7 @@ services:
       CI: "true"
       NEXT_TELEMETRY_DISABLED: "1"
       NEXT_PUBLIC_WEB_API_BASE: http://localhost:3001
-      NEXT_PUBLIC_API_INTERNAL_URL: http://api_dev:3001
+      API_INTERNAL_URL: http://api_dev:3001
       NEXT_PUBLIC_SITE_URL: http://localhost:3000
       NEXT_PUBLIC_ENABLE_SW: "0"
       NEXT_PUBLIC_IMAGE_DOMAINS: localhost

--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -2,7 +2,22 @@
 
 > English version: `docs/agent_runbook_vps_en.md`
 
-본 문서는 VPS에 레포를 클론한 뒤 에이전트(Codex CLI/Claude)가 안전하게 배포/재배포 작업을 수행할 수 있도록 표준 절차를 제공합니다. 기본 배포는 서버에서 로컬 이미지를 빌드하는 방식입니다.
+본 문서는 VPS에 레포를 클론한 뒤 에이전트(Codex CLI/Claude)가 안전하게 배포/재배포 작업을 수행할 수 있도록 표준 절차를 제공합니다.
+
+## 운영 토폴로지와 주 제어 흐름
+
+- API: Docker 컨테이너 `alumni-api`
+- PostgreSQL: Docker 컨테이너 `sogecon-db`
+- Web: Docker가 아닌 systemd 서비스 `sogecon-web`; `/srv/www/sogecon/current`
+  standalone 릴리스에서 실행
+- `compose.yaml`은 로컬 dev/test 전용입니다. VPS 운영 컨테이너는
+  `docker run` 기반 운영 스크립트로 관리합니다.
+
+operator-confirmed current state는 migration 전까지 Web이 standalone
+systemd release이고 API/PostgreSQL이 Docker인 구성입니다. 대표가 결정한
+near-term target은 API/Web/PostgreSQL full Docker 구성입니다. 기존 D6
+`cloud-start.sh` full-container guard를 target entry point로 사용하며,
+standalone systemd release는 cutover 중 rollback fallback으로 보존합니다.
 
 ## 요구 사항
 - Docker 설치
@@ -24,12 +39,62 @@ sudo mkdir -p /var/lib/sogecon/uploads
 sudo chown 1000:1000 /var/lib/sogecon/uploads
 ```
 
-## 2) 배포 경로 A — 서버 로컬 빌드(권장, `deploy-vps` 미사용)
+## 2) Target 배포 경로 — full Docker(API + Web + PostgreSQL)
 체크리스트(요약)
-- [ ] 전용 네트워크 존재(`sogecon_net`)
 - [ ] `.env.api`에 `DATABASE_URL=postgresql+psycopg://…@sogecon-db:5432/…`
-- [ ] `git pull` → 로컬 빌드 → 마이그레이션 → 재기동 순서
-- [ ] 헬스체크 200(워밍업 ≤90s 허용)
+- [ ] Web image를 HTTPS `NEXT_PUBLIC_WEB_API_BASE`로 build/pull
+- [ ] `API_INTERNAL_URL=http://alumni-api:3001` 등 Docker network runtime 값 준비
+- [ ] image/env/network preflight 후에만 `sogecon-web` stop/disable
+- [ ] `ops/cloud-start.sh`로 API healthy → Web healthy 순서 확인
+- [ ] API/Web health와 representative browser flow readback
+
+### 2.1 Migration 전 current state 및 rollback fallback
+
+현재 operator-confirmed Web release는 아래 standalone 경로로 보존한다.
+full-Docker cutover 전 확인하거나 rollback할 때 사용하며 target primary로
+간주하지 않는다.
+
+```bash
+cd /srv/sogecon-app
+git pull --ff-only origin main
+
+NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> \
+  pnpm -C apps/web install
+NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> \
+  pnpm -C apps/web build
+
+RELEASE_BASE=/srv/www/sogecon SERVICE_NAME=sogecon-web \
+  REPO_ROOT=/srv/sogecon-app CI=1 bash ops/web-deploy.sh
+systemctl is-active --quiet sogecon-web
+curl -fsS https://<도메인>/
+```
+
+`ops/web-deploy.sh`가 `/srv/www/sogecon/current`를 standalone release로
+전환하고 systemd 서비스를 재시작한다. 이 worker는 운영 endpoint를 직접
+확인하지 않았으며, 확인 결과를 기록할 때는 operator-provided current-state
+evidence로 구분한다.
+
+### 2.2 Full-Docker cutover 절차
+
+실제 migration은 별도 승인된 운영 작업에서만 수행한다. 순서는 다음과 같다.
+
+1. `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인>`을 지정해 Web image를
+   build하거나 정확한 release tag의 Web image를 pull한다.
+2. `.env.web`에 `API_INTERNAL_URL=http://alumni-api:3001`을 넣고 API/Web env
+   file, Docker network를 준비한 뒤 `docker image inspect`, env-file 존재 확인,
+   `docker network inspect`를 먼저 수행한다.
+3. preflight가 통과한 뒤 cutover 시점에만 `sogecon-web` systemd를 stop/disable
+   한다. preflight 전에 systemd를 중지하지 않는다.
+4. `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=.env.api
+   WEB_ENV_FILE=.env.web DOCKER_NETWORK=sogecon_net
+   bash ops/cloud-start.sh`를 실행한다. script의 기존 full-container
+   preflight와 API→Web health guard를 유지한다.
+5. API/Web health endpoint와 대표 browser flow를 확인한다. 이 PR에서는 이
+   migration과 production readback을 수행하지 않는다.
+
+rollback 시에는 Web container를 stop/rm하고, 보존한 이전
+`/srv/www/sogecon/current` symlink/release를 복구한 뒤
+`systemctl enable --now sogecon-web`으로 systemd fallback을 재활성화한다.
 
 ### D6 cloud-start resource/health guard defaults
 
@@ -53,6 +118,10 @@ health가 없거나 `unhealthy`, `exited`, `dead`이거나 timeout이면 nonzero
 inspect하지 않고 알려진 env-file/database 값은 로그에서 가린다. 자동 DB rollback이나
 기존 컨테이너 복구는 하지 않는다.
 
+`scripts/deploy-vps.sh`의 `HEALTH_TIMEOUT`은 외부 `curl` 재시도 횟수(정수 초)다.
+Docker healthcheck duration은 `CONTAINER_HEALTH_TIMEOUT`(기본 `5s`)으로만
+조정한다.
+
 리소스 튜닝 예:
 
 ```bash
@@ -65,10 +134,13 @@ API_MEMORY=1g WEB_CPUS=1.5 HEALTH_WAIT_TIMEOUT=180 \
 운영 readback은 `docker inspect`에서 `User`, `HostConfig.Memory/NanoCpus/PidsLimit`,
 `LogConfig`, `SecurityOpt`, `CapDrop`, `State.Health`, `RestartPolicy`,
 `NetworkSettings.Ports`, `Mounts`, `NetworkSettings.Networks`를 확인한다.
-실패 시 정확히 알고 있는 이전 API/Web image tag를 같은 script에 넣어 재실행한다.
-두 이미지 모두 healthy라는 성공 출력이 rollback 완료 증거다.
+실패 시 D6+ HEALTHCHECK가 포함된 정확한 이전 API/Web image tag를 현재
+`cloud-start.sh`에 넣어 재실행한다. pre-D6 이미지처럼 HEALTHCHECK가 없는
+태그로 롤백해야 하면 해당 이미지와 함께 배포된 pre-D6 deployment script/release
+checkout으로 롤백한다. D6+ 롤백은 두 이미지와 D6+ `cloud-start.sh`가 matched
+release set이며, 두 이미지 모두 healthy라는 성공 출력이 완료 증거다.
 
-### 2.1 D4 게시글 공개성 배포 전 read-only audit
+### 2.3 D4 게시글 공개성 배포 전 read-only audit
 
 D4의 공개성 계약은 board 4종은 `published_at`과 무관하게 공개하고,
 `notice`/`news` 및 레거시·미지 카테고리는 발행일시가 현재 시각 이하일 때만
@@ -174,6 +246,11 @@ DATABASE_URL=postgresql+psycopg://app:devpass@localhost:5434/d5_migration_gate_l
 마지막으로 전용 DB를 drop하고, migration 실패 시 남은 invalid index와 중간
 `alembic current`를 배포 기록에 남긴다.
 
+### Full-Docker target 전체 명령
+
+다음 image build/start 흐름은 target full-Docker 운영 경로다. 실제 실행은
+별도 승인된 migration 작업에서만 수행한다.
+
 ```bash
 cd /srv/sogecon-app
 git pull --ff-only origin main
@@ -185,8 +262,17 @@ export WEB_IMAGE="${IMAGE_PREFIX}/alumni-web:${TAG}"
 
 docker network inspect sogecon_net >/dev/null 2>&1 || docker network create sogecon_net
 
-IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" bash ops/cloud-build.sh
+IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" \
+  NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> \
+  bash ops/cloud-build.sh
 ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net bash ops/cloud-migrate.sh
+docker image inspect "$API_IMAGE" "$WEB_IMAGE"
+test -f .env.api && test -f .env.web
+grep -q '^API_INTERNAL_URL=http://alumni-api:3001$' .env.web
+docker network inspect sogecon_net >/dev/null
+# cutover point: only after the preflight above
+sudo systemctl stop sogecon-web
+sudo systemctl disable sogecon-web
 API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
   API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
   DOCKER_NETWORK=sogecon_net \
@@ -196,7 +282,7 @@ curl -fsS https://api.<도메인>/healthz
 curl -fsS https://<도메인>/
 ```
 
-## 3) 배포 경로 B — 외부 레지스트리 이미지 pull(선택, `deploy-vps` 미사용)
+## 3) Full-Docker target 경로 B — 외부 레지스트리 pull
 레지스트리를 반드시 써야 하는 경우에만 사용합니다.
 ```bash
 cd /srv/sogecon-app
@@ -238,9 +324,11 @@ API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
 - 별도 도메인(교차 사이트): `COOKIE_SAMESITE=none`, `COOKIE_SECURE=true` (HTTPS 필수)
 - 설정 위치: `.env.api` → `apps/api/main.py`의 `SessionMiddleware`에 반영됨
 
-## 5) 웹 비컨테이너(Next.js standalone + systemd + Nginx)
+## 5) Web standalone rollback fallback(Next.js standalone + systemd + Nginx)
 
-컨테이너 대신 Next.js `standalone` 산출물을 systemd 서비스로 구동합니다. DB/API는 기존 컨테이너 구성을 유지합니다.
+현재 operator-confirmed migration 전 상태와 full-Docker Web rollback을 위해
+Next.js `standalone` 산출물을 systemd 서비스로 보존합니다. full-Docker target의
+영구 primary는 이 systemd 경로가 아닙니다.
 
 사전 준비(1회)
 - Node 고정 설치: `asdf plugin add nodejs && asdf install nodejs 24.12.0 && asdf global nodejs 24.12.0`
@@ -259,7 +347,7 @@ sogecon ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload, /bin/systemctl restart
 ```
 
 배포 절차
-1. 레포 루트에서 웹 빌드: `pnpm -C apps/web install && pnpm -C apps/web build`
+1. 레포 루트에서 웹 빌드: `NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web install && NEXT_PUBLIC_WEB_API_BASE=https://api.<도메인> pnpm -C apps/web build`
 2. 산출물 전개/링크 전환: `bash ops/web-deploy.sh` (환경변수: `RELEASE_BASE`, `SERVICE_NAME` 커스터마이즈 가능)
 3. 상태 확인: `systemctl status sogecon-web` (active), `curl -i http://127.0.0.1:3000/` (200)
 

--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -31,6 +31,43 @@ sudo chown 1000:1000 /var/lib/sogecon/uploads
 - [ ] `git pull` → 로컬 빌드 → 마이그레이션 → 재기동 순서
 - [ ] 헬스체크 200(워밍업 ≤90s 허용)
 
+### D6 cloud-start resource/health guard defaults
+
+`ops/cloud-start.sh`는 image와 supplied env file, Docker network를 먼저
+preflight한 뒤 기존 컨테이너를 중지한다. 두 실제 `docker run`에 다음 기본값을
+적용하며 모두 환경변수로 override할 수 있다.
+
+| 대상 | memory | cpus | pids-limit |
+| --- | --- | --- | --- |
+| API | `768m` | `1.0` | `256` |
+| Web | `512m` | `1.0` | `256` |
+
+공통으로 `json-file` `max-size=10m`, `max-file=5`,
+`no-new-privileges=true`, `cap-drop ALL`, `restart unless-stopped`,
+loopback-only publication을 적용한다. image healthcheck의 interval/timeout/
+retries/start-period 기본값은 `10s/5s/9/15s`이고, API가 healthy가 되기 전에는
+Web을 시작하지 않는다. 두 서비스 모두 120초 안에 healthy가 되어야 성공한다.
+
+health가 없거나 `unhealthy`, `exited`, `dead`이거나 timeout이면 nonzero로
+종료하며 제한된 inspect state와 최근 40줄 로그만 출력한다. env/config 전체를
+inspect하지 않고 알려진 env-file/database 값은 로그에서 가린다. 자동 DB rollback이나
+기존 컨테이너 복구는 하지 않는다.
+
+리소스 튜닝 예:
+
+```bash
+API_MEMORY=1g WEB_CPUS=1.5 HEALTH_WAIT_TIMEOUT=180 \
+  API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
+  API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
+  DOCKER_NETWORK=sogecon_net bash ops/cloud-start.sh
+```
+
+운영 readback은 `docker inspect`에서 `User`, `HostConfig.Memory/NanoCpus/PidsLimit`,
+`LogConfig`, `SecurityOpt`, `CapDrop`, `State.Health`, `RestartPolicy`,
+`NetworkSettings.Ports`, `Mounts`, `NetworkSettings.Networks`를 확인한다.
+실패 시 정확히 알고 있는 이전 API/Web image tag를 같은 script에 넣어 재실행한다.
+두 이미지 모두 healthy라는 성공 출력이 rollback 완료 증거다.
+
 ### 2.1 D4 게시글 공개성 배포 전 read-only audit
 
 D4의 공개성 계약은 board 4종은 `published_at`과 무관하게 공개하고,

--- a/docs/agent_runbook_vps_en.md
+++ b/docs/agent_runbook_vps_en.md
@@ -1,6 +1,21 @@
 # VPS Agent Runbook (for Docker + Nginx servers)
 
-This runbook helps an on‑box agent (Codex CLI/Claude) deploy and redeploy the app on a VPS. The default path builds images directly on the VPS.
+This runbook helps an on‑box agent (Codex CLI/Claude) deploy and redeploy the app on a VPS.
+
+## Operational topology and primary control flow
+
+- API: Docker container `alumni-api`
+- PostgreSQL: Docker container `sogecon-db`
+- Web: systemd service `sogecon-web`, running the standalone release at
+  `/srv/www/sogecon/current`; Web is not a Docker service on the current VPS.
+- `compose.yaml` is local dev/test only. VPS operational containers are managed
+  by `docker run` deployment scripts.
+
+The operator-confirmed current state is a systemd standalone Web release with
+Docker API/PostgreSQL until migration. The accepted near-term target is full
+Docker for API, Web, and PostgreSQL. The existing D6 full-container guards in
+`cloud-start.sh` are the target entry point; the standalone systemd release is
+preserved as a cutover rollback fallback, not the target primary architecture.
 
 ## Requirements
 - Docker installed
@@ -22,12 +37,61 @@ sudo mkdir -p /var/lib/sogecon/uploads
 sudo chown 1000:1000 /var/lib/sogecon/uploads
 ```
 
-## 2) Deploy path A — on-box local build (recommended, no `deploy-vps`)
+## 2) Target deploy path — full Docker (API + Web + PostgreSQL)
 Checklist (quick)
-- [ ] Dedicated network exists (`sogecon_net`)
 - [ ] `.env.api` uses container DNS in `DATABASE_URL` (e.g., `sogecon-db`)
-- [ ] `git pull` → local build → migrate → restart order
-- [ ] Health 200 (allow warm‑up ≤90s)
+- [ ] Build/pull the Web image with an HTTPS `NEXT_PUBLIC_WEB_API_BASE`
+- [ ] Prepare `API_INTERNAL_URL=http://alumni-api:3001` or the approved Docker-network runtime value
+- [ ] Preflight images, env files, and network before stopping/disabling `sogecon-web`
+- [ ] Use `ops/cloud-start.sh` and confirm API healthy before Web healthy
+- [ ] Read back API/Web health and representative browser flows
+
+### 2.1 Current state and rollback fallback
+
+The operator-confirmed current Web release is preserved through the standalone
+systemd path below until cutover. Use it for pre-cutover verification or
+rollback; it is not the target primary path.
+
+```bash
+cd /srv/sogecon-app
+git pull --ff-only origin main
+
+NEXT_PUBLIC_WEB_API_BASE=https://api.<domain> \
+  pnpm -C apps/web install
+NEXT_PUBLIC_WEB_API_BASE=https://api.<domain> \
+  pnpm -C apps/web build
+
+RELEASE_BASE=/srv/www/sogecon SERVICE_NAME=sogecon-web \
+  REPO_ROOT=/srv/sogecon-app CI=1 bash ops/web-deploy.sh
+systemctl is-active --quiet sogecon-web
+curl -fsS https://<domain>/
+```
+
+`ops/web-deploy.sh` switches `/srv/www/sogecon/current` to a standalone release
+and restarts systemd. This worker did not access production endpoints; any
+recorded 200 result is operator-provided current-state evidence.
+
+### 2.2 Full-Docker cutover procedure
+
+Perform the actual migration only as a separately approved operations task:
+
+1. Build the Web image with `NEXT_PUBLIC_WEB_API_BASE=https://api.<domain>` or
+   pull the exact release-tagged Web image.
+2. Put `API_INTERNAL_URL=http://alumni-api:3001` in `.env.web`, prepare the
+   API/Web env files and Docker network, then run image inspect, env-file
+   existence checks, and network inspect.
+3. Only after that preflight, stop and disable `sogecon-web` at the cutover
+   point. Do not stop systemd before preflight.
+4. Run `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=.env.api
+   WEB_ENV_FILE=.env.web DOCKER_NETWORK=sogecon_net bash ops/cloud-start.sh`.
+   The `API_INTERNAL_URL` value is read from `.env.web`; the existing
+   full-container preflight and API→Web health guard remain active.
+5. Verify API/Web health endpoints and representative browser flows. This PR
+   performs no production migration or production readback.
+
+For rollback, stop/remove the Web container, restore the preserved
+`/srv/www/sogecon/current` symlink/release, and run
+`systemctl enable --now sogecon-web` to re-enable the systemd fallback.
 
 ### D6 cloud-start resource and health guard defaults
 
@@ -52,6 +116,10 @@ or print the complete environment/configuration, and known env-file/database
 values are redacted from the bounded logs. It does not automatically roll back
 the database or silently restore containers.
 
+The deploy wrapper's `HEALTH_TIMEOUT` is an integer number of external curl
+wait seconds. Docker healthcheck duration uses the distinct
+`CONTAINER_HEALTH_TIMEOUT` variable (default `5s`).
+
 For tuning, override only the required values:
 
 ```bash
@@ -65,31 +133,31 @@ Operational readback should use `docker inspect` for `User`,
 `HostConfig.Memory/NanoCpus/PidsLimit`, `LogConfig`, `SecurityOpt`, `CapDrop`,
 `State.Health`, `RestartPolicy`, `NetworkSettings.Ports`, `Mounts`, and
 `NetworkSettings.Networks`. On failure, rerun the same script with the exact
-previous API/Web image tags. Both images becoming healthy is authoritative
-rollback completion evidence.
-```bash
-cd /srv/sogecon-app
-git pull --ff-only origin main
+previous D6+ API/Web image tags and the current D6+ `cloud-start.sh`. D6+
+rollback requires images that contain HEALTHCHECK definitions and the
+image/script pair is a matched release set. For a pre-D6 image without
+HEALTHCHECK, use the corresponding pre-D6 deployment script/release checkout
+instead. Both images becoming healthy is authoritative rollback completion
+evidence.
 
+### Full-Docker target local-build command
+
+```bash
 TAG=$(git rev-parse --short HEAD)
 IMAGE_PREFIX=local/sogecon
 API_IMAGE="${IMAGE_PREFIX}/alumni-api:${TAG}"
 WEB_IMAGE="${IMAGE_PREFIX}/alumni-web:${TAG}"
-
-docker network inspect sogecon_net >/dev/null 2>&1 || docker network create sogecon_net
-
-IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" bash ops/cloud-build.sh
-ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net bash ops/cloud-migrate.sh
+IMAGE_TAG="$TAG" IMAGE_PREFIX=local/sogecon \
+  NEXT_PUBLIC_WEB_API_BASE=https://api.<domain> \
+  bash ops/cloud-build.sh
+ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net \
+  bash ops/cloud-migrate.sh
 API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
   API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
-  DOCKER_NETWORK=sogecon_net \
-  bash ops/cloud-start.sh
-
-curl -fsS https://api.<domain>/healthz
-curl -fsS https://<domain>/
+  DOCKER_NETWORK=sogecon_net bash ops/cloud-start.sh
 ```
 
-## 3) Deploy path B — pull from external registry (optional, no `deploy-vps`)
+## 3) Full-Docker target path B — pull from external registry
 Use this path only when you explicitly need a registry.
 ```bash
 cd /srv/sogecon-app
@@ -183,9 +251,11 @@ production, or a VPS operational database.
 - Cross‑site domains: `COOKIE_SAMESITE=none`, `COOKIE_SECURE=true` (HTTPS required).
 - Location: `.env.api` → applied by `SessionMiddleware` in `apps/api/main.py`.
 
-## 6) Web without container (Next.js standalone + systemd + Nginx)
+## 6) Web standalone rollback fallback (Next.js standalone + systemd + Nginx)
 
-Run the Next.js `standalone` build as a systemd service. DB/API containers remain unchanged.
+The operator-confirmed pre-migration state and full-Docker Web rollback use the
+Next.js `standalone` build as a systemd service. The permanent near-term target
+primary is full Docker, not this systemd path.
 
 One‑time setup
 - Pin Node: `asdf plugin add nodejs && asdf install nodejs 24.12.0 && asdf global nodejs 24.12.0`
@@ -204,7 +274,7 @@ sogecon ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload, /bin/systemctl restart
 ```
 
 Deploy steps
-1) Build at repo root: `pnpm -C apps/web install && pnpm -C apps/web build`
+1) Build at repo root: `NEXT_PUBLIC_WEB_API_BASE=https://api.<domain> pnpm -C apps/web install && NEXT_PUBLIC_WEB_API_BASE=https://api.<domain> pnpm -C apps/web build`
 2) Rollout + symlink switch: `bash ops/web-deploy.sh` (env: `RELEASE_BASE`, `SERVICE_NAME`)
 3) Verify: `systemctl status sogecon-web` (active), `curl -i http://127.0.0.1:3000/` (200)
 

--- a/docs/agent_runbook_vps_en.md
+++ b/docs/agent_runbook_vps_en.md
@@ -28,6 +28,45 @@ Checklist (quick)
 - [ ] `.env.api` uses container DNS in `DATABASE_URL` (e.g., `sogecon-db`)
 - [ ] `git pull` → local build → migrate → restart order
 - [ ] Health 200 (allow warm‑up ≤90s)
+
+### D6 cloud-start resource and health guard defaults
+
+`ops/cloud-start.sh` preflights both images, supplied env files, and the Docker
+network before stopping any existing container. It applies these overrideable
+defaults to both actual `docker run` commands:
+
+| service | memory | cpus | pids-limit |
+| --- | --- | --- | --- |
+| API | `768m` | `1.0` | `256` |
+| Web | `512m` | `1.0` | `256` |
+
+Both services also use the `json-file` driver with `max-size=10m` and
+`max-file=5`, `no-new-privileges=true`, `cap-drop ALL`,
+`restart unless-stopped`, and loopback-only host publication. Health defaults
+are interval/timeout/retries/start-period `10s/5s/9/15s`; Web is not started
+until API is healthy, and both services must become healthy within 120 seconds.
+
+Missing health, `unhealthy`, `exited`, `dead`, or timeout exits nonzero and prints
+only concise inspect state plus the most recent 40 log lines. It does not inspect
+or print the complete environment/configuration, and known env-file/database
+values are redacted from the bounded logs. It does not automatically roll back
+the database or silently restore containers.
+
+For tuning, override only the required values:
+
+```bash
+API_MEMORY=1g WEB_CPUS=1.5 HEALTH_WAIT_TIMEOUT=180 \
+  API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
+  API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
+  DOCKER_NETWORK=sogecon_net bash ops/cloud-start.sh
+```
+
+Operational readback should use `docker inspect` for `User`,
+`HostConfig.Memory/NanoCpus/PidsLimit`, `LogConfig`, `SecurityOpt`, `CapDrop`,
+`State.Health`, `RestartPolicy`, `NetworkSettings.Ports`, `Mounts`, and
+`NetworkSettings.Networks`. On failure, rerun the same script with the exact
+previous API/Web image tags. Both images becoming healthy is authoritative
+rollback completion evidence.
 ```bash
 cd /srv/sogecon-app
 git pull --ff-only origin main

--- a/docs/agent_runbook_wsl2.md
+++ b/docs/agent_runbook_wsl2.md
@@ -1,10 +1,14 @@
 # WSL2 로컬 환경 — VPS와 동일 배포 흐름 미러링
 
 본 문서는 WSL2 로컬에서 Docker 기반 VPS mirror 흐름을 재현하는 방법을
-설명합니다. 실제 VPS의 주 토폴로지는 API `alumni-api`와 PostgreSQL
-`sogecon-db`만 Docker이고, Web은 `/srv/www/sogecon/current` standalone
-release를 사용하는 `sogecon-web` systemd 서비스입니다. 운영 시크릿은 절대
-커밋하지 말고, 로컬에서는 개발용 값이나 테스트 전용 값만 사용하세요.
+설명합니다. operator-confirmed current state는 API `alumni-api`와 PostgreSQL
+`sogecon-db`가 Docker이고 Web은 `/srv/www/sogecon/current` standalone
+release를 사용하는 `sogecon-web` systemd 서비스인 구성입니다. 승인된
+near-term target은 API/Web/PostgreSQL full Docker이며, `ops/cloud-start.sh`의
+full-container guard가 target entry point입니다. Web standalone systemd
+release는 cutover rollback fallback으로 보존하며 target primary로 바꾸지
+않습니다. 운영 시크릿은 절대 커밋하지 말고, 로컬에서는 개발용 값이나 테스트
+전용 값만 사용하세요.
 
 ## 전제 조건
 - Docker Desktop + WSL2 통합 활성화, `docker run` 사용 가능
@@ -19,11 +23,13 @@ release를 사용하는 `sogecon-web` systemd 서비스입니다. 운영 시크�
 make db-up   # root compose(dev): dev 5433 + test 5434
 ```
 
-## 2) 로컬 Docker Web mirror → 마이그레이션 → 재기동
-- 로컬에서 태그를 지정해 Docker Web 지원 경로를 재현합니다. 예: `e29de67`
-- 실제 VPS Web primary release는 HTTPS build → `ops/web-deploy.sh` →
-  `systemctl` → public URL 확인 순서이며, 이 절의 `cloud-start.sh`는 그
-  대안입니다.
+## 2) Near-term target 로컬 full-Docker Web mirror → 마이그레이션 → 재기동
+- 로컬에서 태그를 지정해 승인된 full-Docker target 경로를 재현합니다. 예:
+  `e29de67`
+- 이 절의 `cloud-start.sh`는 API healthy 후 Web healthy를 보장하는 target
+  entry point입니다. 실제 VPS의 current-state systemd standalone Web은
+  이 mirror 명령으로 변경되지 않으며, cutover rollback fallback으로
+  보존합니다.
 - production Web image build에는 브라우저가 사용할 공개 HTTPS API base를
   반드시 명시합니다. `API_INTERNAL_URL`은 실행 시 서버 fetch 전용이며 빌드
   인자로 사용하지 않습니다.

--- a/docs/agent_runbook_wsl2.md
+++ b/docs/agent_runbook_wsl2.md
@@ -1,9 +1,15 @@
 # WSL2 로컬 환경 — VPS와 동일 배포 흐름 미러링
 
-본 문서는 WSL2 로컬에서 VPS 프로덕션 배포 흐름(로컬 이미지 빌드 → DB 마이그레이션 → 컨테이너 재기동 → 헬스체크)을 그대로 재현하는 방법을 설명합니다. 운영 시크릿은 절대 커밋하지 말고, 로컬에서는 개발용 값이나 테스트 전용 값만 사용하세요.
+본 문서는 WSL2 로컬에서 Docker 기반 VPS mirror 흐름을 재현하는 방법을
+설명합니다. 실제 VPS의 주 토폴로지는 API `alumni-api`와 PostgreSQL
+`sogecon-db`만 Docker이고, Web은 `/srv/www/sogecon/current` standalone
+release를 사용하는 `sogecon-web` systemd 서비스입니다. 운영 시크릿은 절대
+커밋하지 말고, 로컬에서는 개발용 값이나 테스트 전용 값만 사용하세요.
 
 ## 전제 조건
-- Docker Desktop + WSL2 통합 활성화, `docker compose` 사용 가능
+- Docker Desktop + WSL2 통합 활성화, `docker run` 사용 가능
+- `compose.yaml`은 로컬 dev/test 전용이며 이 mirror 절차는 `ops/cloud-*.sh`
+  Docker 스크립트를 사용합니다.
 - API/Web 런타임 env 파일 준비
   - `cp .env.api.example .env.api` 후 `DATABASE_URL`을 로컬 PG로 맞춤(권장: `postgresql+psycopg://app:devpass@localhost:5433/appdb`)
   - `cp .env.web.example .env.web` (옵션; 공개 `NEXT_PUBLIC_*`는 빌드타임 고정)
@@ -13,8 +19,14 @@
 make db-up   # root compose(dev): dev 5433 + test 5434
 ```
 
-## 2) 로컬 빌드 → 마이그레이션 → 재기동(`deploy-vps` 미사용)
-- 로컬에서 태그를 지정해 VPS 동형 흐름으로 실행합니다. 예: `e29de67`
+## 2) 로컬 Docker Web mirror → 마이그레이션 → 재기동
+- 로컬에서 태그를 지정해 Docker Web 지원 경로를 재현합니다. 예: `e29de67`
+- 실제 VPS Web primary release는 HTTPS build → `ops/web-deploy.sh` →
+  `systemctl` → public URL 확인 순서이며, 이 절의 `cloud-start.sh`는 그
+  대안입니다.
+- production Web image build에는 브라우저가 사용할 공개 HTTPS API base를
+  반드시 명시합니다. `API_INTERNAL_URL`은 실행 시 서버 fetch 전용이며 빌드
+  인자로 사용하지 않습니다.
 ```
 cd /home/<user>/sogecon-app
 export TAG=e29de67
@@ -24,7 +36,9 @@ export WEB_IMAGE="${IMAGE_PREFIX}/alumni-web:${TAG}"
 
 docker network inspect sogecon_net >/dev/null 2>&1 || docker network create sogecon_net
 
-IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" bash ops/cloud-build.sh
+IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" \
+  NEXT_PUBLIC_WEB_API_BASE=https://api.example.com \
+  bash ops/cloud-build.sh
 ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net bash ops/cloud-migrate.sh
 API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" \
   API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web \
@@ -36,9 +50,9 @@ curl -I http://localhost:3000/
 ```
 
 동작 내용:
-- `ops/cloud-build.sh`로 `local/sogecon/alumni-{api,web}:<TAG>` 로컬 이미지 빌드
+- `ops/cloud-build.sh`로 `local/sogecon/alumni-{api,web}:<TAG>` Docker mirror 이미지 빌드
 - `ops/cloud-migrate.sh`로 Alembic `upgrade head` 실행(`.env.api` 또는 `DATABASE_URL` 사용)
-- `ops/cloud-start.sh`로 API/Web 컨테이너 재기동(포트: 127.0.0.1:3001/3000)
+- `ops/cloud-start.sh`로 API/Web mirror 컨테이너 재기동(포트: 127.0.0.1:3001/3000)
 - 선택적으로 헬스 체크 수행
 
 ## 3) 트러블슈팅
@@ -57,7 +71,9 @@ export TAG=<commit-sha>
 export IMAGE_PREFIX=local/sogecon
 export API_IMAGE="${IMAGE_PREFIX}/alumni-api:${TAG}"
 export WEB_IMAGE="${IMAGE_PREFIX}/alumni-web:${TAG}"
-IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" bash ops/cloud-build.sh
+IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" \
+  NEXT_PUBLIC_WEB_API_BASE=https://api.example.com \
+  bash ops/cloud-build.sh
 ENV_FILE=.env.api API_IMAGE="$API_IMAGE" DOCKER_NETWORK=sogecon_net bash ops/cloud-migrate.sh
 API_IMAGE="$API_IMAGE" WEB_IMAGE="$WEB_IMAGE" API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web DOCKER_NETWORK=sogecon_net bash ops/cloud-start.sh
 curl -I http://localhost:3001/healthz

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,8 @@
 
 ## 배포 및 환경 구성
 - **개발 환경**: `make web-dev`(포트 3000), `make api-dev`(포트 3001). 필요 시 `make db-up`으로 PostgreSQL 16 컨테이너 기동.
-- **Web API URL 계약(D6)**: `NEXT_PUBLIC_WEB_API_BASE`는 Next production build 때 검증되고 브라우저 번들에 고정되는 공개 API URL이다. production에서는 비어 있거나 malformed/relative URL, query/fragment/userinfo, HTTP URL을 거부하며 HTTPS만 허용한다. API가 제공하는 media hostname과 명시적 port는 Next Image remote pattern에 자동 반영한다. 단, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 직접 수행하는 local/test build에서만 `http://localhost`, `http://127.0.0.1`, `http://[::1]`을 허용한다. 이 escape hatch는 일반 `ops/cloud-build.sh` 운영 경로에서 전달하지 않는다.
+- **Web API URL 계약(D6)**: `NEXT_PUBLIC_WEB_API_BASE`는 Next production build 때 검증되고 브라우저 번들에 고정되는 공개 API URL이다. production에서는 비어 있거나 malformed/relative URL, query/fragment/userinfo, HTTP URL을 거부하며 HTTPS만 허용한다. API가 제공하는 media hostname과 명시적 port는 Next Image remote pattern에 자동 반영한다. IPv6 loopback은 로컬 판정에서는 정규화한 `::1`로 비교하지만, remote pattern에는 Next/Node 요청 hostname 형식인 `[::1]`을 유지한다. 단, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 직접 수행하는 local/test build에서만 `http://localhost`, `http://127.0.0.1`, `http://[::1]`을 허용한다. 이 escape hatch는 일반 `ops/cloud-build.sh` 운영 경로에서 전달하지 않는다.
+- **VPS Web build 환경 권위(D6)**: `scripts/deploy-vps.sh --local-build`의 허용된 7개 `NEXT_PUBLIC_*` build key는 inert `.env.web`과 명시적 `--web-api-base` 값만 사용한다. 해당 key들은 부모 셸에서 먼저 제거되므로, `.env.web`의 누락 또는 명시적 empty가 stale parent value를 build artifact로 전달하지 않는다. `.env.web`은 source/eval하지 않는다.
 - **Server-only API URL**: `API_INTERNAL_URL`은 Next 서버가 Docker 내부 API를 찾을 때만 사용하는 런타임 URL이다. 브라우저는 항상 `NEXT_PUBLIC_WEB_API_BASE`를 사용하며 `API_INTERNAL_URL`을 읽지 않는다. 개발·test에서만 public URL이 없거나 loopback이면 current-host/localhost fallback과 rewriting을 허용하고, production에서는 fallback으로 `http://<host>:3001`을 만들지 않는다.
 - **환경 변수**: `.env.example`을 최신화해 필수 설정 목록을 유지. 실제 `.env`는 커밋 금지.
 - **프로덕션 가정**: API와 웹을 분리 배포하되, 공통 인증 게이트웨이(Nginx, CloudFront 등) 뒤에 배치. 데이터베이스는 매니지드 PostgreSQL 사용을 권장.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,8 @@
 
 ## 배포 및 환경 구성
 - **개발 환경**: `make web-dev`(포트 3000), `make api-dev`(포트 3001). 필요 시 `make db-up`으로 PostgreSQL 16 컨테이너 기동.
+- **Web API URL 계약(D6)**: `NEXT_PUBLIC_WEB_API_BASE`는 Next production build 때 검증되고 브라우저 번들에 고정되는 공개 API URL이다. production에서는 비어 있거나 malformed/relative URL, HTTP URL을 거부하며 HTTPS만 허용한다. 단, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 직접 수행하는 local/test build에서만 `http://localhost`, `http://127.0.0.1`, `http://[::1]`을 허용한다. 이 escape hatch는 일반 `ops/cloud-build.sh` 운영 경로에서 전달하지 않는다.
+- **Server-only API URL**: `API_INTERNAL_URL`은 Next 서버가 Docker 내부 API를 찾을 때만 사용하는 런타임 URL이다. 브라우저는 항상 `NEXT_PUBLIC_WEB_API_BASE`를 사용하며 `API_INTERNAL_URL`을 읽지 않는다. 개발·test에서만 public URL이 없거나 loopback이면 current-host/localhost fallback과 rewriting을 허용하고, production에서는 fallback으로 `http://<host>:3001`을 만들지 않는다.
 - **환경 변수**: `.env.example`을 최신화해 필수 설정 목록을 유지. 실제 `.env`는 커밋 금지.
 - **프로덕션 가정**: API와 웹을 분리 배포하되, 공통 인증 게이트웨이(Nginx, CloudFront 등) 뒤에 배치. 데이터베이스는 매니지드 PostgreSQL 사용을 권장.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@
 
 ## 배포 및 환경 구성
 - **개발 환경**: `make web-dev`(포트 3000), `make api-dev`(포트 3001). 필요 시 `make db-up`으로 PostgreSQL 16 컨테이너 기동.
-- **Web API URL 계약(D6)**: `NEXT_PUBLIC_WEB_API_BASE`는 Next production build 때 검증되고 브라우저 번들에 고정되는 공개 API URL이다. production에서는 비어 있거나 malformed/relative URL, HTTP URL을 거부하며 HTTPS만 허용한다. 단, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 직접 수행하는 local/test build에서만 `http://localhost`, `http://127.0.0.1`, `http://[::1]`을 허용한다. 이 escape hatch는 일반 `ops/cloud-build.sh` 운영 경로에서 전달하지 않는다.
+- **Web API URL 계약(D6)**: `NEXT_PUBLIC_WEB_API_BASE`는 Next production build 때 검증되고 브라우저 번들에 고정되는 공개 API URL이다. production에서는 비어 있거나 malformed/relative URL, query/fragment/userinfo, HTTP URL을 거부하며 HTTPS만 허용한다. API가 제공하는 media hostname과 명시적 port는 Next Image remote pattern에 자동 반영한다. 단, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`을 직접 수행하는 local/test build에서만 `http://localhost`, `http://127.0.0.1`, `http://[::1]`을 허용한다. 이 escape hatch는 일반 `ops/cloud-build.sh` 운영 경로에서 전달하지 않는다.
 - **Server-only API URL**: `API_INTERNAL_URL`은 Next 서버가 Docker 내부 API를 찾을 때만 사용하는 런타임 URL이다. 브라우저는 항상 `NEXT_PUBLIC_WEB_API_BASE`를 사용하며 `API_INTERNAL_URL`을 읽지 않는다. 개발·test에서만 public URL이 없거나 loopback이면 current-host/localhost fallback과 rewriting을 허용하고, production에서는 fallback으로 `http://<host>:3001`을 만들지 않는다.
 - **환경 변수**: `.env.example`을 최신화해 필수 설정 목록을 유지. 실제 `.env`는 커밋 금지.
 - **프로덕션 가정**: API와 웹을 분리 배포하되, 공통 인증 게이트웨이(Nginx, CloudFront 등) 뒤에 배치. 데이터베이스는 매니지드 PostgreSQL 사용을 권장.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@
 
 ### 구현 메모
 - iOS/Android 주요 브라우저에서 설치형 PWA 기준 Web Push 지원. 설치되지 않은 상태, 또는 지원 불가 환경에서는 이메일로 폴백(Phase 1에선 폴백 없이 UI만 안내 가능).
-- 프런트 키 배포: VAPID 공개키를 빌드 타임/런타임 노출(환경변수 → 페이지 데이터 주입)하고, 비공개키는 서버 전용으로 보관.
+- 프런트 키 배포: VAPID 공개키는 `NEXT_PUBLIC_VAPID_PUBLIC_KEY`로 Web build 때 브라우저 번들에 고정하고, 비공개키는 API 서버 전용으로 보관한다. 컨테이너 재시작이나 `WEB_ENV_FILE`의 런타임 주입만으로 공개키를 바꾸지 않는다.
 - Admin UI: `/admin/notifications`에서 알림(제목/본문/URL) 발송 요청 가능.
 
 

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -21,6 +21,7 @@ WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 pnpm -C apps/web build
 
 ```bash
 bash ops/ci/test_cloud_start.sh
+bash ops/ci/test_deploy_vps.sh
 ```
 
 `repo-guards` job은 `test_cloud_migrate.sh`와 함께 이 command contract를 실행한다.
@@ -73,7 +74,7 @@ docker compose --profile dev exec -T postgres_test psql -U app -d postgres \
 .venv/bin/pytest -q
 pnpm -C apps/web lint
 pnpm -C apps/web test
-pnpm -C apps/web build
+NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build
 .venv/bin/python scripts/export_openapi.py && pnpm -C packages/schemas run gen-dts
 git diff --exit-code packages/schemas/openapi.json packages/schemas/index.d.ts
 ```

--- a/docs/ci_quality_gates.md
+++ b/docs/ci_quality_gates.md
@@ -2,6 +2,29 @@
 
 로컬 Git 훅과 GitHub Actions PR CI의 책임 분리·재현 명령을 정리한다. 상위 Epic: #174.
 
+## D6 Web build와 container command negative gates
+
+- `pnpm -C apps/web build`는 `apps/web/next.config.js`의 production phase에서
+  `NEXT_PUBLIC_WEB_API_BASE`를 검증한다. missing/blank, malformed 또는 relative,
+  HTTP는 실패하며, `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`이어도 loopback HTTP만
+  허용한다. 일반 Web CI build는 deterministic `https://api.example.com`을 사용한다.
+- 의도적인 local production E2E/Lighthouse build만 다음처럼 escape hatch를 함께
+  지정한다. `next dev`에는 이 값이 필요 없다.
+
+```bash
+NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001 \
+WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 pnpm -C apps/web build
+```
+
+- 다음 명령은 실제 `docker run` 인자, image/env/network preflight, API→Web health
+  순서, missing/unhealthy health 실패, bounded redacted logs를 검증한다.
+
+```bash
+bash ops/ci/test_cloud_start.sh
+```
+
+`repo-guards` job은 `test_cloud_migrate.sh`와 함께 이 command contract를 실행한다.
+
 ## 설계 원칙
 
 | 계층 | 목표 시간 | 역할 |

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -90,6 +90,66 @@
   files, and verified no `d6-*` containers/network or 3300/3301/3443/3444
   listeners remained. No persisted browser storage-state file was created.
 
+## D6 review follow-up — PR #288 revalidated findings
+
+- P1 root cause: the default `scripts/deploy-vps.sh` local-build branch passed
+  `--web-env` to runtime only, so `ops/cloud-build.sh` reached the production
+  Web validator without its required build-time public API base. The wrapper
+  now parses only `NEXT_PUBLIC_WEB_API_BASE` as inert text from that file,
+  supports `--web-api-base` as an explicit override, forwards it to the build,
+  and fails before Docker with a clear message when unavailable. No env file is
+  sourced or executed. VPS, WSL2, standalone, API, and CI production build
+  examples now pass an explicit HTTPS base.
+- P2 root cause: server fetches correctly preferred `API_INTERNAL_URL`, but
+  `resolveApiAssetUrl` reused that fetch base for SSR-rendered media URLs.
+  Asset resolution now uses `NEXT_PUBLIC_WEB_API_BASE` independently even on
+  the server, and public/internal API bases normalize trailing slashes.
+- P2 root cause: `HEALTH_TIMEOUT` had incompatible integer curl-wait and
+  Docker-duration meanings. `cloud-start.sh` now reads only
+  `CONTAINER_HEALTH_TIMEOUT`; `deploy-vps.sh` rejects non-positive/non-integer
+  values, and the command contracts prove inherited `HEALTH_TIMEOUT=120` is
+  ignored by `cloud-start.sh` while a duration override is honored.
+- Pre-D6 rollback compatibility is documented as a matched image plus
+  deployment-script/release-checkout set. D6+ rollback requires HEALTHCHECK
+  images; pre-D6 images use their corresponding pre-D6 deployment script.
+  The D6→D7 #254 record remains unchanged; plaintext support logging and
+  partial-commit behavior were not moved into this follow-up.
+- Direct cleanup made the HTTP rejection test independent of inherited
+  `WEB_BUILD_ALLOW_INSECURE_LOCAL_API`; cloud-start redaction now strips
+  single-quoted values as well as double-quoted values.
+- Decision override from source thread `019fbae0-8fe8-7c43-b147-601557203dc7`:
+  operator-confirmed current state remains Docker API/PostgreSQL plus standalone
+  systemd Web until cutover, while the accepted near-term target is full Docker
+  API/Web/PostgreSQL using the existing D6 `cloud-start.sh` full-container
+  guards. Standalone Web remains the bounded rollback fallback, not the target
+  primary architecture.
+- README, Korean/English VPS runbooks, and API/Web ops docs now document the
+  bounded migration: build/pull Web with explicit HTTPS
+  `NEXT_PUBLIC_WEB_API_BASE`, put Docker-network `API_INTERNAL_URL` in the Web
+  runtime env file, preflight image/env/network, stop/disable systemd only at
+  cutover, run full `cloud-start.sh`, and verify API/Web health plus a
+  representative browser flow. Rollback stops/removes Web, restores the prior
+  standalone symlink/release, and re-enables `sogecon-web`.
+- No production access or migration was performed in this PR. Because this
+  decision changed documentation/topology only and no Web code changed, the
+  prior exact-diff Web lint/test/build evidence is retained; this follow-up ran
+  only affected documentation/shell checks.
+- Follow-up checks so far: focused Web resolver/build-config tests
+  (`3 files / 22 passed`), `bash ops/ci/test_cloud_start.sh` PASS, and
+  `bash ops/ci/test_deploy_vps.sh` PASS. With Node `24.12.0`, full Web lint
+  PASS, Web tests `79 files / 289 passed`, and deterministic HTTPS
+  `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`
+  PASS. Repository/version guards and the cloud-migrate command contract also
+  passed, the githooks integration contract passed, and `git diff --check` is
+  clean.
+- Latest override verification: `bash -n scripts/deploy-vps.sh
+  ops/cloud-start.sh ops/ci/test_cloud_start.sh ops/ci/test_deploy_vps.sh`,
+  both affected command contracts, `bash ops/ci/test_cloud_migrate.sh`,
+  `.venv/bin/python ops/ci/guards.py`,
+  `.venv/bin/python ops/ci/check_versions.py`, and `git diff --check` all
+  PASS. A repository scan found no Web-omitting deployment mode or related
+  selector. No Web suite/build was rerun because Web code is unchanged.
+
 ## PR #286 관리자 이미지 전체 삭제 payload 보존
 
 - Root cause: 마지막 이미지를 관리자 편집 화면에서 삭제하면 `MultiImageUpload`가

--- a/docs/dev_log_260802.md
+++ b/docs/dev_log_260802.md
@@ -1,5 +1,95 @@
 # Dev Log 2026-08-02
 
+## D6 production Web build and container guards (#253, #257)
+
+- Root cause: the shared Web API client read the old public
+  `NEXT_PUBLIC_API_INTERNAL_URL` and invented `http://localhost:3001` when the
+  public base was absent. Production `next build` had no authoritative URL
+  contract, and `cloud-start.sh` stopped/restarted containers without image
+  preflight, resource/capability guards, or health sequencing.
+- Implementation: `NEXT_PUBLIC_WEB_API_BASE` is now validated from Next's
+  production build phase. HTTPS is required; the explicit
+  `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1` escape permits only HTTP loopback for
+  local/test builds. `API_INTERNAL_URL` is server-only, browser resolution keeps
+  the public build URL, and production has no localhost/current-host fallback.
+  Compose/env examples, CI deterministic HTTPS build, local E2E/Lighthouse escape,
+  docs, and focused resolver/validator tests were aligned.
+- Container implementation: API/Web image healthchecks use Python stdlib/Node
+  request respectively. Runtime images remain non-root and API uploads remain
+  mounted. `cloud-start.sh` now preflights images/env files/network, applies the
+  accepted memory/CPU/PID/log/security/health defaults, waits API healthy before
+  Web, and fails on missing/unhealthy/exited/dead/timeout with bounded redacted
+  state/log output. `ops/ci/test_cloud_start.sh` covers both service run lines,
+  sequencing, negative health/preflight cases, secret non-disclosure, and mode
+  `755` readback.
+- Automated evidence so far: focused Web tests `20 passed`; actual `next build`
+  matrix rejected missing, malformed/non-HTTPS, loopback without escape, and
+  arbitrary-host escape cases, while loopback with explicit escape and HTTPS
+  succeeded; `bash ops/ci/test_cloud_start.sh` PASS. Full static/runtime/browser
+  evidence is recorded below as it completes.
+- Automatic Web E2E: the CI-like mock API and production Web were started and
+  the suite was run in one managed process lifetime with
+  `NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001`
+  `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`,
+  `WEB_BASE_URL=http://127.0.0.1:3000`, and
+  `E2E_MOCK_API_CONTROL_URL=http://127.0.0.1:3001`. The exact result was
+  `Test Files 5 passed (5)`, `Tests 11 passed (11)`, duration 35.57s. The
+  managed server process and browser resources were then cleaned up.
+- Runtime/image evidence: built `local/sogecon-d6/alumni-api:d6-260802` and
+  `local/sogecon-d6/alumni-web:d6-260802`, plus a TLS test Web tag with
+  `NEXT_PUBLIC_WEB_API_BASE=https://127.0.0.1:3443`. The API image healthcheck is
+  the stdlib `/healthz` request and the Web image healthcheck is the Node `/`
+  request. Runtime images were verified non-root (`apiuser`, `webuser`). During
+  real runtime proof, the images also exposed a permissions defect: worktree
+  source modes were copied as unreadable to the non-root users, and the API
+  support handler needed a writable `logs` directory. The Dockerfiles now
+  normalize runtime read bits and create/chown both `uploads` and `logs`; this
+  was required for the actual image contract, not a test-only bypass.
+- Disposable runtime: created only `d6-postgres-260802` with database
+  `d6_disposable`, `d6-network-260802`, exact `/tmp/d6-uploads-260802`, and
+  test-only API/Web names. Real Alembic migrations ran to head, the disposable
+  admin was seeded, and the actual `ops/cloud-start.sh` started API before Web.
+  Docker inspect readback confirmed healthy state, non-root users,
+  `127.0.0.1` port bindings, API 768 MiB/Web 512 MiB, NanoCpus=
+  1,000,000,000 (1 CPU) for each service, PID 256,
+  json-file 10m/5, `no-new-privileges=true`, `CapDrop=ALL`, restart
+  `unless-stopped`, the dedicated network, and the API uploads mount. A safe
+  32 MiB/0.1 CPU/16 PID helper was independently inspected and removed.
+- Failure/rollback: a deliberately non-serving disposable Web image made the
+  actual health wait exit 1 with `status=running health=unhealthy` and bounded
+  logs. Exact previous/test tags were then passed to the same start script and
+  both services returned healthy. No automatic restore or database rollback
+  was used.
+- Visible browser: `playwright-cli` ephemeral sessions used HTTPS Web
+  `https://127.0.0.1:3444` through a local self-signed TLS proxy to the actual
+  API `https://127.0.0.1:3443`; requests showed browser API targets on that
+  HTTPS base, with no mock API or production/VPS access. UI login succeeded.
+  The contact form submitted through `POST /support/contact` 202 and
+  PostgreSQL plus `/app/logs/support.log` readback confirmed the effect.
+  The board UI upload control submitted `POST /uploads/images` 200 and a post
+  201; PostgreSQL `posts` and the exact uploads mount both contained the
+  resulting image. The push CTA was exercised after the same visible browser
+  context explicitly granted `notifications` for
+  `https://127.0.0.1:3444`; the browser reported
+  `Notification.permission=granted` and the service worker was active. Chrome
+  still reported `Chrome currently does not support the Push API in incognito
+  mode`, and the UI retry produced `AbortError: Registration failed -
+  permission denied` with no subscription/network/DB effect. Push is
+  therefore INCONCLUSIVE, not replaced with a lower-level API pass.
+- Existing out-of-scope observation: the first contact UI submission returned
+  500 because the pre-fix image lacked a writable `/app/logs`, but the support
+  row had already committed before the logging failure. After the image fix,
+  the retry returned 202 and created the second row. Disposable PostgreSQL
+  readback therefore showed two tickets (`D6 실제 TLS 문의` and the successful
+  `D6 실제 TLS 문의 성공`), not one clean transaction. This existing
+  transaction/logging-order behavior is recorded for follow-up and is not
+  absorbed into D6.
+- Cleanup: stopped the ephemeral Playwright sessions and TLS proxies, removed
+  all `d6-*` containers including PostgreSQL, removed `d6-network-260802`,
+  `/tmp/d6-tls-cert`, `/tmp/d6-uploads-260802`, temporary env/config/cookie
+  files, and verified no `d6-*` containers/network or 3300/3301/3443/3444
+  listeners remained. No persisted browser storage-state file was created.
+
 ## PR #286 관리자 이미지 전체 삭제 payload 보존
 
 - Root cause: 마지막 이미지를 관리자 편집 화면에서 삭제하면 `MultiImageUpload`가

--- a/docs/dev_log_260803.md
+++ b/docs/dev_log_260803.md
@@ -1,0 +1,22 @@
+# Dev Log 2026-08-03
+
+## D6 review follow-up — production Web origin and Docker network contract
+
+- CI Web job의 job-level `NEXT_PUBLIC_WEB_API_BASE`가 API base 미설정 동작을
+  검증하는 unit test에도 주입되어 exact CI에서 두 테스트가 실패하는 P1을
+  재현했다. 환경변수는 production Build step에만 두고, resolver tests는
+  `publicBase: ''`를 명시해 developer shell과 CI 환경으로부터 격리했다.
+- production public API URL은 query, fragment, userinfo를 거부하고 path prefix는
+  계속 허용한다. 동일 URL의 hostname과 explicit port를 Next Image
+  `remotePatterns`에 자동 추가해 `/media/...`가 별도 중복 env 없이 public API
+  origin에서 표시되도록 했다.
+- full-Docker entry point의 기본 network를 user-defined `sogecon_net`으로 맞췄고,
+  `deploy-vps.sh`도 같은 network를 기본 생성·전달한다. README와 Web deploy 예시의
+  누락된 network 인수를 보완했으며 command contract가 기본 network 전달을
+  검증한다. PR checklist와 security gate 문서의 production Web build 명령도
+  명시적 HTTPS API base를 사용하도록 동기화했다.
+- 검증: inherited public API env를 포함한 focused resolver/URL/image config
+  tests `25 passed`, cloud-start/deploy-vps command contracts PASS, 전체 Web lint
+  PASS, Web tests `79 files / 295 passed`, HTTPS production build PASS였다.
+  repository/version guards와 git hook integration도 PASS했고 `git diff --check`는
+  clean이다.

--- a/docs/dev_log_260803.md
+++ b/docs/dev_log_260803.md
@@ -20,3 +20,41 @@
   PASS, Web tests `79 files / 295 passed`, HTTPS production build PASS였다.
   repository/version guards와 git hook integration도 PASS했고 `git diff --check`는
   clean이다.
+
+## D6 second review follow-up — standalone runtime and public build env forwarding
+
+- Web Docker runtime now packages the generated monorepo standalone tree at its
+  original layout (`apps/web/server.js`), together with `public` and
+  `.next/static`, and runs that generated server as the non-root user. The
+  runtime no longer invokes `next start`, so image remote patterns and all
+  other public values embedded during `next build` remain authoritative without
+  duplicating `NEXT_PUBLIC_*` in `WEB_ENV_FILE`.
+- `scripts/deploy-vps.sh --local-build` safely parses only the same public
+  build allowlist as `ops/cloud-build.sh`: API base, site URL, VAPID public key,
+  analytics ID, service-worker/CSP flags, and image domains. It never
+  sources/evaluates `.env.web`; an explicit `--web-api-base` overrides only the
+  API base and preserves the other file values.
+- IPv6 loopback (`http://[::1]:3001`) now enables the same local Image
+  optimization escape hatch as IPv4 loopback. Command contracts cover immediate
+  `exited` health failure and `starting` timeout. Documentation now records
+  VAPID as build-time public configuration and the Docker standalone command.
+- The pre-existing truncated `scripts/lhci-debug.sh` is outside D6 and remains
+  a separate follow-up; this branch no longer changes that file relative to
+  `main`.
+- Audit correction: the repository-level `pnpm -C apps/web start` remains the
+  existing local `next start` command because a plain local build does not copy
+  `public`/`.next/static` into the standalone tree. Only the Docker runtime uses
+  the fully packaged standalone entrypoint. The runtime image fixes
+  `HOSTNAME=0.0.0.0` and `PORT=3000` so its loopback healthcheck reaches the
+  generated server instead of a Docker-assigned hostname binding.
+- Verification: focused config/resolver/asset tests `32 passed`; cloud-start
+  and deploy-vps command contracts PASS; Web lint PASS; default parallel Web
+  suite `79 files / 299 passed`; HTTPS production build PASS; repository and
+  version guards plus git-hook integration PASS; `git diff --check` clean.
+  A disposable Web image built with API base and VAPID test values ran with no
+  runtime `NEXT_PUBLIC_*`: Docker reported `webuser`, healthy, command
+  `node apps/web/server.js`, and `/` returned 200. The VAPID value existed in
+  the static bundle, while the API image request passed the allowlist and
+  reached the downstream fetch (500 for the deliberately nonexistent source,
+  not the former 400 rejection). The exact container, image, and temporary
+  response file were removed after readback.

--- a/docs/dev_log_260805.md
+++ b/docs/dev_log_260805.md
@@ -1,0 +1,34 @@
+# Dev Log 2026-08-05
+
+## PR #288 D6 latest review follow-up
+
+- `scripts/deploy-vps.sh --local-build` now treats the inert `.env.web` file and
+  explicit `--web-api-base` option as the authority for all seven allowlisted
+  public Web build keys. The wrapper removes those keys from its inherited
+  parent environment before invoking `ops/cloud-build.sh`, so omitted and
+  explicitly empty file values cannot retain stale CSP, VAPID, analytics, site,
+  service-worker, image-domain, or API-base settings. `.env.web` remains data
+  only and is never sourced or evaluated.
+- IPv6 loopback handling now separates normalized local detection (`::1`) from
+  the bracketed hostname (`[::1]`) emitted for Next/Node remote image patterns.
+  The focused build-config regression covers both representations.
+- Local production verification commands in `ops/deploy_web.md` and README now
+  pass the same `NEXT_PUBLIC_WEB_API_BASE` explicitly to both `build` and
+  `next start`. The Lighthouse debug workflow keeps its local build escape and
+  CSP/service-worker flags on the real Build step and removes build-only public
+  settings from the Start/LHCI steps.
+- D7 #254 support-contract work and the truncated `scripts/lhci-debug.sh` from
+  `main` remain outside this follow-up.
+- Test-authority correction: the newly added negative Docker-build assertions
+  now use explicit `if grep ...; then ... exit 1; fi` branches rather than
+  top-level `! grep` under `set -e`. The explicit-empty API-base case clears
+  `FAKE_DOCKER_LOG` immediately before invocation, so its no-build assertion
+  cannot consume a previous scenario's record.
+- Verification: the new IPv6/build-config focused test passed with `24 tests`,
+  the broader Web focused set passed with `3 files / 32 tests`, and the
+  parent-environment command contract passed with omitted, explicit-empty, and
+  stale-value cases. The requested parallel Web suite passed with
+  `79 files / 300 tests`, Web lint and deterministic HTTPS production build passed, and
+  cloud-start/cloud-migrate/deploy-vps contracts, repository/version guards,
+  githook integration, and `git diff --check` passed. No production/VPS access,
+  deployment, data mutation, GitHub write, commit, or push was performed.

--- a/docs/dev_log_260806.md
+++ b/docs/dev_log_260806.md
@@ -28,3 +28,37 @@
   배치는 정적 contract로 확인했다.
 - 이 작업에서는 production/VPS 접근, 배포, Docker runtime semantics 변경,
   data mutation, GitHub write, commit, push를 수행하지 않았다.
+
+## PR #288 dependency audit remediation
+
+- Exact head `a8a308ea4c00fae7fd20cbd111b6a39b04592a84`의 CI run
+  `31030959875`에서 `python` job의 Dependency audit가 직접 pin
+  `cryptography==49.0.0`에 대해 `PYSEC-2026-3552`를 보고했고, fix
+  version은 `50.0.0`이었다. Root cause는 API requirements가 취약 버전을
+  직접 고정한 것이며, adjacent dependency는 변경하지 않았다.
+- 최소 수정으로 `apps/api/requirements.txt`를 `cryptography==50.0.0`으로
+  올리고, 이 requirements를 exact line으로 강제하는
+  `ops/ci/check_versions.py`와 repository 버전 SSOT인 `docs/versions.md`를
+  함께 동기화했다. 별도 pip lockfile이나 constraints source는 존재하지
+  않아 새로 만들지 않았다.
+- 보안 invariant는 `enc:v1:` AES-GCM at-rest 암호화, 유효한 16/24/32-byte
+  PUSH_KEK 검증, `InvalidTag`/`CryptoError` 실패 닫힘, 기존 평문 데이터
+  호환이다. `apps/api/crypto_utils.py`와 `ops/rekey_push_kek.py`의 AESGCM
+  호출·복호화 경계 및 인증/푸시 동작은 변경하지 않았다.
+- `make api-install`로 지원 환경 `.venv`에 50.0.0을 설치했다. 설치 후
+  AESGCM, `pywebpush`, `py_vapid` import와 `enc:v1:` roundtrip이 PASS했고,
+  `pip check`도 broken requirements 없이 PASS했다. 관련 crypto 테스트 4개,
+  push-at-rest 통합 테스트 1개, auth/password focused 테스트 21개, 전체
+  pytest 303개가 PASS했다.
+- 수정 전 exact audit는 `cryptography 49.0.0 / PYSEC-2026-3552 / fix
+  50.0.0` 1건으로 재현됐고, 수정 후
+  `.venv/bin/pip-audit -r apps/api/requirements.txt -r
+  apps/api/requirements-dev.txt --strict`는 `No known vulnerabilities
+  found`를 반환했다. Ruff, Pyright(0 errors, 기존 warning 2개), Bandit,
+  repository/version guards, githooks, `git diff --check`도 PASS했다.
+- 변경-aware bypass review에서 active dependency/constraint/lock source의
+  cryptography pin은 requirements, version guard, versions SSOT의
+  `50.0.0` 세 곳뿐이었고 `49.0.0` override는 확인되지 않았다. CI audit
+  suppression이나 security check bypass는 추가하지 않았다.
+- 이 follow-up에서도 production/VPS 접근, 배포, data mutation, PR comment,
+  commit, push는 수행하지 않았다.

--- a/docs/dev_log_260806.md
+++ b/docs/dev_log_260806.md
@@ -1,0 +1,30 @@
+# Dev Log 2026-08-06
+
+## PR #288 exact-head review follow-up
+
+- Exact head `b22c9d30b956fcdaf78befdc3c805747537fe2e3`에서 Opus P2의
+  contract-test authority 결함을 수정했다. `ops/ci/test_cloud_start.sh`의
+  inherited `HEALTH_TIMEOUT`, missing-image preflight, missing-env-file
+  preflight, secret-leak negative checks와 `ops/ci/test_deploy_vps.sh`의
+  missing-API-base no-build check를 모두 명시적
+  `if grep ...; then ... exit 1; fi` branches로 바꿨다.
+- Opus P3에 맞춰 Lighthouse Start server에는 build와 동일한
+  `NEXT_PUBLIC_WEB_API_BASE=http://localhost:3000` 및
+  `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`만 다시 주입했다. CSP relax와
+  service-worker flag는 Build 단계에만 남기고 LHCI 단계에는 두지 않았다.
+- `docs/agent_runbook_wsl2.md`를 current state(systemd Web + Docker
+  API/PostgreSQL), near-term target(full Docker via `ops/cloud-start.sh`),
+  systemd rollback fallback 언어와 정합화했다. 기존 로컬 mirror build,
+  migration, health 명령은 유지했다.
+- 이전 dev log의 test-authority 기록은 수정하지 않고, 이 항목에서 보정
+  사실을 추가 기록한다. Antigravity의 short-secret redaction 생략 제안은
+  보안 계약과 범위 밖이라 채택하지 않았고, secret redaction 동작은
+  그대로 유지했다.
+- 검증: `bash -n` 양쪽 shell contract, `bash ops/ci/test_cloud_start.sh`,
+  `bash ops/ci/test_deploy_vps.sh`, repository/version guards,
+  `bash ops/ci/test_githooks.sh`, Web lint, `git diff --check`가 모두
+  PASS했다. 별도 bounded negative proof도 다섯 금지 출력 케이스를 모두
+  명시적 실패 branch로 거부하며 PASS했다. Lighthouse Build/Start/LHCI env
+  배치는 정적 contract로 확인했다.
+- 이 작업에서는 production/VPS 접근, 배포, Docker runtime semantics 변경,
+  data mutation, GitHub write, commit, push를 수행하지 않았다.

--- a/docs/plan_d6_prod_build_container_guards_260802.md
+++ b/docs/plan_d6_prod_build_container_guards_260802.md
@@ -1,0 +1,65 @@
+# D6 production build and container guards (2026-08-02)
+
+## Accepted scope
+
+This plan records the accepted implementation for GitHub #253 and #257 only.
+It does not include D7, Dependabot remediation, dependency upgrades, or
+unrelated cleanup. Base merge: `6bed2b6834b6138b128755e415f337d80dc66a87`.
+
+## Accepted design
+
+### Web API URL
+
+- `NEXT_PUBLIC_WEB_API_BASE` is the browser-visible, build-time public API URL.
+- Every real `next build` invokes the small validator from the production build
+  phase. Missing/blank, malformed/relative, and non-HTTPS URLs fail.
+- `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1` is a build-only local/test escape hatch:
+  it permits HTTP only for `localhost`, `127.0.0.1`, and `::1`; missing values and
+  arbitrary HTTP hosts still fail. The normal `ops/cloud-build.sh` path does not
+  forward it, and the runtime Web image does not retain it.
+- `API_INTERNAL_URL` replaces `NEXT_PUBLIC_API_INTERNAL_URL` and is server-only.
+  Browser resolution always uses the public URL. Current-host/localhost fallback
+  and loopback rewriting are limited to development/test; production does not
+  invent `http://<host>:3001`.
+- Browser `credentials: include`, existing public API behavior, D4 preview/cookie
+  boundaries, and local compose development remain intact.
+
+### Images and start guards
+
+- API image healthcheck uses Python stdlib against `127.0.0.1:3001/healthz` and
+  requires 2xx. Web uses Node fetch against `127.0.0.1:3000/` and requires 2xx.
+- Both runtime images remain non-root; API uploads remain mounted at `/app/uploads`.
+- `cloud-start.sh` preflights images/env files/network before stopping containers,
+  applies the accepted resource, logging, capability, restart, and health defaults,
+  waits for API healthy before Web, and succeeds only when both are healthy.
+- Missing health, unhealthy, exited/dead, or timeout is a failure with concise
+  inspect state and bounded redacted logs. No automatic DB rollback or silent
+  container restore is performed. Rollback is rerunning with exact previous tags.
+- `ops/ci/test_cloud_start.sh` is a repo-guards command contract, including
+  preflight ordering, both service run guards, health sequencing, failure modes,
+  secret non-disclosure, and executable mode readback.
+
+## Acceptance evidence slots
+
+| Gate | Evidence | Result |
+| --- | --- | --- |
+| Validator/resolver focused tests | `vitest` build-config/api-base tests: 20 passed | PASS |
+| Missing/HTTP/loopback/HTTPS build matrix | missing, malformed, HTTP/no escape, arbitrary HTTP escape, loopback/no escape rejected; loopback escape and HTTPS succeeded | PASS |
+| Cloud start command contract | `bash ops/ci/test_cloud_start.sh` → concise `PASS` | PASS |
+| Existing migration/githook guards | cloud migrate, githooks, repo guards, versions | PASS |
+| Repository/API/Web static gates | ruff, pyright (2 existing warnings), pytest 303 passed, lint, Web tests 269 passed, HTTPS build | PASS |
+| Automatic Web E2E | managed mock API + production Web: 5 files / 11 tests passed | PASS |
+| Current API/Web image build | `local/sogecon-d6/alumni-api:d6-260802`, TLS Web tag | PASS |
+| Disposable DB migration/readback | `d6-postgres-260802`, `d6_disposable`, `d6-network-260802`, exact uploads path; real migration/seed | PASS |
+| Docker inspect authority | healthy, non-root, loopback ports, resource/log/security/restart/mount/network readback | PASS |
+| Deliberately non-serving failure | actual wait returned nonzero with `health=unhealthy`, bounded logs | PASS |
+| Exact previous-tag rollback semantics | same script with exact `d6-previous-260802` tags returned both healthy | PASS |
+| Visible browser with local TLS API | ephemeral `playwright-cli`, TLS Web/API proxies, HTTPS API requests, no mock/production access | PASS |
+| Login/support/push/upload UI flows | login/support/upload and DB/filesystem readback PASS; push CTA INCONCLUSIVE due Chrome incognito Push API restriction; contact has documented first-attempt partial row | PARTIAL |
+| Exact cleanup | `d6-*` containers/network, disposable DB, TLS cert/proxy, env files, uploads, and ephemeral browser sessions removed; ports read back empty | PASS |
+
+## Verification limits
+
+Any gate that cannot run because of a missing local prerequisite is recorded as
+`INCONCLUSIVE` with the exact command and reason. A mock or lower-level API call
+does not replace the requested actual browser/runtime proof.

--- a/docs/plan_d6_prod_build_container_guards_260802.md
+++ b/docs/plan_d6_prod_build_container_guards_260802.md
@@ -58,6 +58,65 @@ unrelated cleanup. Base merge: `6bed2b6834b6138b128755e415f337d80dc66a87`.
 | Login/support/push/upload UI flows | login/support/upload and DB/filesystem readback PASS; push CTA INCONCLUSIVE due Chrome incognito Push API restriction; contact has documented first-attempt partial row | PARTIAL |
 | Exact cleanup | `d6-*` containers/network, disposable DB, TLS cert/proxy, env files, uploads, and ephemeral browser sessions removed; ports read back empty | PASS |
 
+## Revalidated review follow-up (PR #288 head `913e9012fdee980e4375c8d85421dccdde9ddeef`)
+
+### Root causes and bounded changes
+
+- P1 root cause: `scripts/deploy-vps.sh` passed `--web-env` only to the
+  runtime start step, while `ops/cloud-build.sh` receives build arguments only
+  from the shell environment. Local Web image builds therefore reached the
+  production validator without `NEXT_PUBLIC_WEB_API_BASE`. The wrapper now
+  safely parses only that exact key from the supplied env file (no `source`,
+  `eval`, expansion, or execution), supports an explicit `--web-api-base`
+  override, forwards the resolved value, and fails before Docker when absent.
+  VPS, WSL2, standalone, API, and CI build instructions now show an HTTPS
+  public base.
+- P2 root cause: `API_BASE` is intentionally the server fetch base when
+  `API_INTERNAL_URL` is set, but `resolveApiAssetUrl` reused it for SSR HTML.
+  Asset resolution now selects the public build-time base independently,
+  including during server rendering; API base trailing slashes are normalized.
+- P2 root cause: `HEALTH_TIMEOUT` represented integer external curl retries in
+  `deploy-vps.sh` but could be inherited by `cloud-start.sh` as an invalid
+  Docker duration. `deploy-vps.sh` now validates positive integer wait seconds,
+  `CONTAINER_HEALTH_TIMEOUT` is the Docker-only variable, and contract coverage
+  proves the inherited integer is ignored while the duration override works.
+- Compatibility root cause: D6 `cloud-start.sh` requires image HEALTHCHECK
+  state, so a pre-D6 image cannot be rolled back with the D6 script. The
+  authoritative runbooks now define image plus deployment script/checkout as a
+  matched release set and require the corresponding pre-D6 deployment script
+  for pre-D6 images. D6→D7 support plaintext logging/partial-commit behavior
+  remains explicitly deferred to #254.
+- Direct cleanup: HTTP rejection coverage is independent of inherited
+  `WEB_BUILD_ALLOW_INSECURE_LOCAL_API`, and secret redaction strips both
+  single- and double-quoted env-file values.
+- Decision override from source thread `019fbae0-8fe8-7c43-b147-601557203dc7`
+  keeps the operator-confirmed standalone systemd Web as the pre-cutover state
+  and rollback fallback, while accepting full Docker API/Web/PostgreSQL with
+  the existing D6 `cloud-start.sh` guards as the near-term target.
+- Korean/English VPS runbooks and API/Web ops docs now specify the bounded
+  migration: explicit HTTPS Web image build/pull, Docker-network
+  `API_INTERNAL_URL` in the Web runtime env, image/env/network preflight,
+  systemd stop/disable only at cutover, full `cloud-start.sh`, health plus
+  representative browser readback, and systemd symlink rollback.
+- No production access or migration was performed. No Web code changed, so the
+  prior exact-diff Web lint/test/build evidence is retained; this override was
+  verified with affected docs/shell checks only.
+- Latest affected checks PASS: shell syntax for the changed deployment scripts,
+  cloud-start/deploy-vps/cloud-migrate command contracts, repository/version
+  guards, and `git diff --check`. A repository scan found no Web-omitting
+  deployment mode; Web suite/build remains intentionally not rerun because Web
+  code is unchanged.
+
+### Follow-up evidence
+
+| Gate | Evidence | Result |
+| --- | --- | --- |
+| Web resolver/build-config focused regression | `pnpm -C apps/web exec vitest run __tests__/api-base-resolution.test.ts __tests__/api-asset-url.test.ts __tests__/build-config.test.ts` → 3 files / 22 tests passed | PASS |
+| Cloud-start inherited timeout and quote-redaction contract | `bash ops/ci/test_cloud_start.sh` → `cloud-start command contract: PASS` | PASS |
+| VPS local-build forwarding/missing-value/integer-timeout contract | `bash ops/ci/test_deploy_vps.sh` → `deploy-vps command contract: PASS` | PASS |
+| Full Web quality gates | Node `24.12.0`: `pnpm -C apps/web lint` PASS; `env -u WEB_BUILD_ALLOW_INSECURE_LOCAL_API -u API_INTERNAL_URL pnpm -C apps/web test` → 79 files / 289 tests passed; `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build` PASS | PASS |
+| Repository and related shell guards | `.venv/bin/python ops/ci/guards.py && .venv/bin/python ops/ci/check_versions.py` PASS; cloud-migrate and githooks contracts PASS; `git diff --check` PASS | PASS |
+
 ## Verification limits
 
 Any gate that cannot run because of a missing local prerequisite is recorded as

--- a/docs/security_hardening.md
+++ b/docs/security_hardening.md
@@ -10,7 +10,7 @@
   - 파일 600줄 초과 차단
 - Python: `ruff`(복잡도/버그베어/pyupgrade), `pyright` strict, `pytest`(PR CI)
 - 취약점 스캔: `bandit -r apps/api`, `pip-audit`(두 requirements 모두)
-- Web: `pnpm -C apps/web lint`, `pnpm -C apps/web test`, `pnpm -C apps/web build`, `pnpm -C apps/web audit --audit-level=high`
+- Web: `pnpm -C apps/web lint`, `pnpm -C apps/web test`, `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`, `pnpm -C apps/web audit --audit-level=high`
 - SAST: Semgrep 기본 규칙(`p/ci`)
 - 비밀 탐지: Gitleaks
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -22,7 +22,7 @@
 - itsdangerous==2.2.0
 - email-validator==2.3.0
 - pywebpush==2.3.0
-- cryptography==49.0.0
+- cryptography==50.0.0
 - Pillow==12.3.0
 - sentry-sdk[starlette]==2.64.0
 - apscheduler==3.11.3

--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -34,12 +34,16 @@ COPY apps/api ./apps/api
 COPY ops/ci/migration_gate.py ./ops/ci/migration_gate.py
 COPY infra/api-entrypoint.sh /app/infra/api-entrypoint.sh
 
-RUN mkdir -p uploads \
-    && chmod +x /app/infra/api-entrypoint.sh \
-    && chown apiuser:apiuser uploads
+RUN mkdir -p uploads logs \
+    && chmod -R a+rX /app/apps /app/ops /app/infra \
+    && chmod 755 /app/infra/api-entrypoint.sh \
+    && chown apiuser:apiuser uploads logs
 
 USER apiuser
 
 EXPOSE 3001
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=9 \
+  CMD python -c "import urllib.request; response = urllib.request.urlopen('http://127.0.0.1:3001/healthz', timeout=5); raise SystemExit(0 if 200 <= response.status < 300 else 1)"
 
 ENTRYPOINT ["/app/infra/api-entrypoint.sh"]

--- a/infra/web.Dockerfile
+++ b/infra/web.Dockerfile
@@ -44,21 +44,31 @@ ENV NEXT_PUBLIC_WEB_API_BASE=${NEXT_PUBLIC_WEB_API_BASE} \
     NEXT_PUBLIC_IMAGE_DOMAINS=${NEXT_PUBLIC_IMAGE_DOMAINS} \
     WEB_BUILD_ALLOW_INSECURE_LOCAL_API=${WEB_BUILD_ALLOW_INSECURE_LOCAL_API}
 
+# Next's standalone output already contains the production dependency closure
+# and embeds the build-time Next configuration. Preserve that exact artifact
+# instead of starting a separate `next start` server that re-reads runtime
+# configuration.
 RUN pnpm -C apps/web build \
-    && pnpm --filter web deploy --prod --legacy /opt/app_web \
+    && mkdir -p /opt/app_web/apps/web/.next \
+    && cp -a apps/web/.next/standalone/. /opt/app_web/ \
+    && cp -a apps/web/.next/static /opt/app_web/apps/web/.next/static \
+    && if [ -d apps/web/public ]; then cp -a apps/web/public /opt/app_web/apps/web/public; fi \
     && chmod -R a+rX /opt/app_web
 
 FROM node:${NODE_VERSION}-slim AS runtime
 
 ENV NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1
+    NEXT_TELEMETRY_DISABLED=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
 
 RUN adduser --disabled-password --gecos "" webuser
 
-WORKDIR /app/apps/web
+WORKDIR /app
 
-# Copy self-contained deployment that includes node_modules
-COPY --from=build /opt/app_web /app/apps/web
+# Keep the generated standalone directory layout. Its server lives at
+# /app/apps/web/server.js and resolves public/static assets relative to it.
+COPY --from=build --chown=webuser:webuser /opt/app_web /app
 
 USER webuser
 
@@ -67,5 +77,6 @@ EXPOSE 3000
 HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=9 \
   CMD node -e "fetch('http://127.0.0.1:3000/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
 
-# Avoid requiring pnpm in runtime; call Next directly
-CMD ["node", "node_modules/next/dist/bin/next", "start", "-p", "3000"]
+# Run the generated standalone entrypoint so build-time public configuration
+# remains authoritative at runtime.
+CMD ["node", "apps/web/server.js"]

--- a/infra/web.Dockerfile
+++ b/infra/web.Dockerfile
@@ -33,6 +33,7 @@ ARG NEXT_PUBLIC_ANALYTICS_ID=""
 ARG NEXT_PUBLIC_ENABLE_SW=""
 ARG NEXT_PUBLIC_RELAX_CSP=""
 ARG NEXT_PUBLIC_IMAGE_DOMAINS=""
+ARG WEB_BUILD_ALLOW_INSECURE_LOCAL_API=""
 
 ENV NEXT_PUBLIC_WEB_API_BASE=${NEXT_PUBLIC_WEB_API_BASE} \
     NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL} \
@@ -40,10 +41,12 @@ ENV NEXT_PUBLIC_WEB_API_BASE=${NEXT_PUBLIC_WEB_API_BASE} \
     NEXT_PUBLIC_ANALYTICS_ID=${NEXT_PUBLIC_ANALYTICS_ID} \
     NEXT_PUBLIC_ENABLE_SW=${NEXT_PUBLIC_ENABLE_SW} \
     NEXT_PUBLIC_RELAX_CSP=${NEXT_PUBLIC_RELAX_CSP} \
-    NEXT_PUBLIC_IMAGE_DOMAINS=${NEXT_PUBLIC_IMAGE_DOMAINS}
+    NEXT_PUBLIC_IMAGE_DOMAINS=${NEXT_PUBLIC_IMAGE_DOMAINS} \
+    WEB_BUILD_ALLOW_INSECURE_LOCAL_API=${WEB_BUILD_ALLOW_INSECURE_LOCAL_API}
 
 RUN pnpm -C apps/web build \
-    && pnpm --filter web deploy --prod --legacy /opt/app_web
+    && pnpm --filter web deploy --prod --legacy /opt/app_web \
+    && chmod -R a+rX /opt/app_web
 
 FROM node:${NODE_VERSION}-slim AS runtime
 
@@ -60,6 +63,9 @@ COPY --from=build /opt/app_web /app/apps/web
 USER webuser
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=9 \
+  CMD node -e "fetch('http://127.0.0.1:3000/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
 
 # Avoid requiring pnpm in runtime; call Next directly
 CMD ["node", "node_modules/next/dist/bin/next", "start", "-p", "3000"]

--- a/ops/ci/check_versions.py
+++ b/ops/ci/check_versions.py
@@ -171,7 +171,7 @@ def check_requirements() -> None:
             "itsdangerous==2.2.0",
             "email-validator==2.3.0",
             "pywebpush==2.3.0",
-            "cryptography==49.0.0",
+            "cryptography==50.0.0",
             "Pillow==12.3.0",
             "sentry-sdk[starlette]==2.64.0",
             "apscheduler==3.11.3",

--- a/ops/ci/test_cloud_start.sh
+++ b/ops/ci/test_cloud_start.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/ops/cloud-start.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+[[ "$(stat -c '%a' "$SCRIPT")" == 755 ]]
+
+export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
+export FAKE_DOCKER_MODE=success
+
+docker() {
+  local command=${1:-}
+  shift || true
+  case "${command}" in
+    image)
+      if [[ "${FAKE_DOCKER_MODE}" == missing-image && "${*}" == *"${FAKE_DOCKER_MISSING_IMAGE}"* ]]; then
+        return 1
+      fi
+      printf 'image %s\n' "$*" >>"${FAKE_DOCKER_LOG}"
+      ;;
+    network)
+      printf 'network %s\n' "$*" >>"${FAKE_DOCKER_LOG}"
+      ;;
+    ps)
+      printf '%s\n' "${FAKE_DOCKER_EXISTING_CONTAINERS:-}"
+      ;;
+    run)
+      printf 'run %s\n' "$*" >>"${FAKE_DOCKER_LOG}"
+      ;;
+    stop|rm)
+      printf '%s %s\n' "${command}" "$*" >>"${FAKE_DOCKER_LOG}"
+      ;;
+    inspect)
+      local format=${2:-}
+      local name=${3:-}
+      printf 'inspect %s %s\n' "${name}" "${format}" >>"${FAKE_DOCKER_LOG}"
+      if [[ "${format}" == *'.State.Status'* ]]; then
+        if [[ "${FAKE_DOCKER_MODE}" == exited ]]; then
+          printf 'exited\n'
+        else
+          printf 'running\n'
+        fi
+      elif [[ "${format}" == *'.State.Health.Status'* ]]; then
+        case "${FAKE_DOCKER_MODE}" in
+          missing-health) printf 'missing\n' ;;
+          unhealthy) printf 'unhealthy\n' ;;
+          starting) printf 'starting\n' ;;
+          *) printf 'healthy\n' ;;
+        esac
+      fi
+      ;;
+    logs)
+      printf 'DATABASE_URL=postgresql://app:supersecret@db:5432/appdb\n' >&2
+      ;;
+    *)
+      printf 'unexpected docker command: %s %s\n' "${command}" "$*" >&2
+      return 1
+      ;;
+  esac
+}
+export -f docker
+
+make_env_files() {
+  printf '%s\n' 'DATABASE_URL=postgresql://app:supersecret@db:5432/appdb' >"$TMP_DIR/api.env"
+  printf '%s\n' 'NEXT_PUBLIC_WEB_API_BASE=https://api.example.com' >"$TMP_DIR/web.env"
+}
+
+run_start() {
+  API_IMAGE=api-test \
+  WEB_IMAGE=web-test \
+  API_CONTAINER=d6-api \
+  WEB_CONTAINER=d6-web \
+  API_ENV_FILE="${API_ENV_OVERRIDE:-$TMP_DIR/api.env}" \
+  WEB_ENV_FILE="${WEB_ENV_OVERRIDE:-$TMP_DIR/web.env}" \
+  UPLOADS_DIR="$TMP_DIR/uploads" \
+  DOCKER_NETWORK=d6-network \
+  HEALTH_WAIT_TIMEOUT=2 \
+  bash "$SCRIPT"
+}
+
+make_env_files
+run_start >"$TMP_DIR/success.out" 2>&1
+grep -qF -- '--memory 768m' "$FAKE_DOCKER_LOG"
+grep -qF -- '--cpus 1.0' "$FAKE_DOCKER_LOG"
+grep -qF -- '--pids-limit 256' "$FAKE_DOCKER_LOG"
+grep -qF -- '--log-driver json-file' "$FAKE_DOCKER_LOG"
+grep -qF -- '--log-opt max-size=10m' "$FAKE_DOCKER_LOG"
+grep -qF -- '--log-opt max-file=5' "$FAKE_DOCKER_LOG"
+grep -qF -- '--security-opt no-new-privileges=true' "$FAKE_DOCKER_LOG"
+grep -qF -- '--cap-drop ALL' "$FAKE_DOCKER_LOG"
+grep -qF -- '--publish 127.0.0.1:3001:3001' "$FAKE_DOCKER_LOG"
+grep -qF -- '--publish 127.0.0.1:3000:3000' "$FAKE_DOCKER_LOG"
+grep -qF -- '--restart unless-stopped' "$FAKE_DOCKER_LOG"
+grep -qF -- '--volume '"$TMP_DIR"'/uploads:/app/uploads' "$FAKE_DOCKER_LOG"
+
+api_run_line=$(grep 'run .*--name d6-api' "$FAKE_DOCKER_LOG")
+web_run_line=$(grep 'run .*--name d6-web' "$FAKE_DOCKER_LOG")
+for run_line in "$api_run_line" "$web_run_line"; do
+  for shared_guard in \
+    '--restart unless-stopped' \
+    '--log-driver json-file' \
+    '--log-opt max-size=10m' \
+    '--log-opt max-file=5' \
+    '--security-opt no-new-privileges=true' \
+    '--cap-drop ALL' \
+    '--health-interval 10s' \
+    '--health-timeout 5s' \
+    '--health-retries 9' \
+    '--health-start-period 15s'; do
+    grep -qF -- "$shared_guard" <<<"$run_line"
+  done
+done
+grep -qF -- '--memory 768m' <<<"$api_run_line"
+grep -qF -- '--cpus 1.0' <<<"$api_run_line"
+grep -qF -- '--pids-limit 256' <<<"$api_run_line"
+grep -qF -- '--memory 512m' <<<"$web_run_line"
+grep -qF -- '--cpus 1.0' <<<"$web_run_line"
+grep -qF -- '--pids-limit 256' <<<"$web_run_line"
+grep -qF -- '--publish 127.0.0.1:3001:3001' <<<"$api_run_line"
+grep -qF -- '--publish 127.0.0.1:3000:3000' <<<"$web_run_line"
+grep -qF -- '--volume '"$TMP_DIR"'/uploads:/app/uploads' <<<"$api_run_line"
+api_run_number=$(grep -n 'run .*--name d6-api' "$FAKE_DOCKER_LOG" | cut -d: -f1)
+web_run_number=$(grep -n 'run .*--name d6-web' "$FAKE_DOCKER_LOG" | cut -d: -f1)
+api_healthy_line=$(grep -n 'inspect d6-api .*Health.Status' "$FAKE_DOCKER_LOG" | tail -1 | cut -d: -f1)
+(( api_run_number < api_healthy_line && api_healthy_line < web_run_number ))
+grep -qF 'API(d6-api)와 Web(d6-web) 컨테이너가 모두 healthy입니다.' "$TMP_DIR/success.out"
+
+# Image/env preflight happens before an existing container can be stopped.
+export FAKE_DOCKER_MODE=missing-image
+export FAKE_DOCKER_MISSING_IMAGE=api-test
+export FAKE_DOCKER_EXISTING_CONTAINERS=d6-api
+: >"$FAKE_DOCKER_LOG"
+if run_start >"$TMP_DIR/missing-image.out" 2>&1; then
+  echo 'missing image unexpectedly passed' >&2
+  exit 1
+fi
+! grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"
+
+# Supplied env-file preflight also fails before an existing container is stopped.
+export FAKE_DOCKER_MODE=success
+unset FAKE_DOCKER_MISSING_IMAGE
+export FAKE_DOCKER_EXISTING_CONTAINERS=d6-api
+export API_ENV_OVERRIDE="$TMP_DIR/missing-api.env"
+: >"$FAKE_DOCKER_LOG"
+if run_start >"$TMP_DIR/missing-env.out" 2>&1; then
+  echo 'missing env file unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'API_ENV_FILE' "$TMP_DIR/missing-env.out"
+! grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"
+unset API_ENV_OVERRIDE FAKE_DOCKER_EXISTING_CONTAINERS
+
+for mode in missing-health unhealthy; do
+  export FAKE_DOCKER_MODE=$mode
+  unset FAKE_DOCKER_EXISTING_CONTAINERS
+  : >"$FAKE_DOCKER_LOG"
+  if run_start >"$TMP_DIR/${mode}.out" 2>&1; then
+    echo "${mode} unexpectedly passed" >&2
+    exit 1
+  fi
+  grep -qF 'recent logs (max 40 lines)' "$TMP_DIR/${mode}.out"
+  ! grep -qF 'supersecret' "$TMP_DIR/${mode}.out"
+  grep -qF '***' "$TMP_DIR/${mode}.out"
+done
+
+echo 'cloud-start command contract: PASS'

--- a/ops/ci/test_cloud_start.sh
+++ b/ops/ci/test_cloud_start.sh
@@ -103,7 +103,10 @@ export HEALTH_TIMEOUT=120
 : >"$FAKE_DOCKER_LOG"
 run_start >"$TMP_DIR/inherited-health-timeout.out" 2>&1
 grep -qF -- '--health-timeout 5s' "$FAKE_DOCKER_LOG"
-! grep -qF -- '--health-timeout 120' "$FAKE_DOCKER_LOG"
+if grep -qF -- '--health-timeout 120' "$FAKE_DOCKER_LOG"; then
+  echo 'inherited HEALTH_TIMEOUT leaked into the Docker health duration' >&2
+  exit 1
+fi
 export CONTAINER_HEALTH_TIMEOUT=17s
 : >"$FAKE_DOCKER_LOG"
 run_start >"$TMP_DIR/container-health-timeout.out" 2>&1
@@ -151,7 +154,10 @@ if run_start >"$TMP_DIR/missing-image.out" 2>&1; then
   echo 'missing image unexpectedly passed' >&2
   exit 1
 fi
-! grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"
+if grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"; then
+  echo 'missing-image preflight stopped or removed an existing container' >&2
+  exit 1
+fi
 
 # Supplied env-file preflight also fails before an existing container is stopped.
 export FAKE_DOCKER_MODE=success
@@ -164,7 +170,10 @@ if run_start >"$TMP_DIR/missing-env.out" 2>&1; then
   exit 1
 fi
 grep -qF 'API_ENV_FILE' "$TMP_DIR/missing-env.out"
-! grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"
+if grep -qE '^(stop|rm) ' "$FAKE_DOCKER_LOG"; then
+  echo 'missing-env-file preflight stopped or removed an existing container' >&2
+  exit 1
+fi
 unset API_ENV_OVERRIDE FAKE_DOCKER_EXISTING_CONTAINERS
 
 for mode in missing-health unhealthy; do
@@ -176,7 +185,10 @@ for mode in missing-health unhealthy; do
     exit 1
   fi
   grep -qF 'recent logs (max 40 lines)' "$TMP_DIR/${mode}.out"
-  ! grep -qF 'supersecret' "$TMP_DIR/${mode}.out"
+  if grep -qF 'supersecret' "$TMP_DIR/${mode}.out"; then
+    echo "${mode} health failure leaked an unredacted secret" >&2
+    exit 1
+  fi
   grep -qF '***' "$TMP_DIR/${mode}.out"
 done
 

--- a/ops/ci/test_cloud_start.sh
+++ b/ops/ci/test_cloud_start.sh
@@ -180,4 +180,24 @@ for mode in missing-health unhealthy; do
   grep -qF '***' "$TMP_DIR/${mode}.out"
 done
 
+# A container that exits immediately is a terminal failure, not a health wait.
+export FAKE_DOCKER_MODE=exited
+: >"$FAKE_DOCKER_LOG"
+if run_start >"$TMP_DIR/exited.out" 2>&1; then
+  echo 'exited container unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'status=exited' "$TMP_DIR/exited.out"
+grep -qF 'recent logs (max 40 lines)' "$TMP_DIR/exited.out"
+
+# A still-starting health state must time out and return nonzero.
+export FAKE_DOCKER_MODE=starting
+: >"$FAKE_DOCKER_LOG"
+if run_start >"$TMP_DIR/starting.out" 2>&1; then
+  echo 'starting health state unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'did not become healthy within 2s' "$TMP_DIR/starting.out"
+grep -qF 'recent logs (max 40 lines)' "$TMP_DIR/starting.out"
+
 echo 'cloud-start command contract: PASS'

--- a/ops/ci/test_cloud_start.sh
+++ b/ops/ci/test_cloud_start.sh
@@ -10,6 +10,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
 export FAKE_DOCKER_MODE=success
+unset HEALTH_TIMEOUT CONTAINER_HEALTH_TIMEOUT
 
 docker() {
   local command=${1:-}
@@ -64,7 +65,7 @@ docker() {
 export -f docker
 
 make_env_files() {
-  printf '%s\n' 'DATABASE_URL=postgresql://app:supersecret@db:5432/appdb' >"$TMP_DIR/api.env"
+  printf '%s\n' "DATABASE_URL='postgresql://app:supersecret@db:5432/appdb'" >"$TMP_DIR/api.env"
   printf '%s\n' 'NEXT_PUBLIC_WEB_API_BASE=https://api.example.com' >"$TMP_DIR/web.env"
 }
 
@@ -96,6 +97,19 @@ grep -qF -- '--publish 127.0.0.1:3000:3000' "$FAKE_DOCKER_LOG"
 grep -qF -- '--restart unless-stopped' "$FAKE_DOCKER_LOG"
 grep -qF -- '--volume '"$TMP_DIR"'/uploads:/app/uploads' "$FAKE_DOCKER_LOG"
 
+# The deploy wrapper owns integer curl wait seconds; cloud-start must not
+# reinterpret the inherited name as a Docker health duration.
+export HEALTH_TIMEOUT=120
+: >"$FAKE_DOCKER_LOG"
+run_start >"$TMP_DIR/inherited-health-timeout.out" 2>&1
+grep -qF -- '--health-timeout 5s' "$FAKE_DOCKER_LOG"
+! grep -qF -- '--health-timeout 120' "$FAKE_DOCKER_LOG"
+export CONTAINER_HEALTH_TIMEOUT=17s
+: >"$FAKE_DOCKER_LOG"
+run_start >"$TMP_DIR/container-health-timeout.out" 2>&1
+grep -qF -- '--health-timeout 17s' "$FAKE_DOCKER_LOG"
+unset HEALTH_TIMEOUT CONTAINER_HEALTH_TIMEOUT
+
 api_run_line=$(grep 'run .*--name d6-api' "$FAKE_DOCKER_LOG")
 web_run_line=$(grep 'run .*--name d6-web' "$FAKE_DOCKER_LOG")
 for run_line in "$api_run_line" "$web_run_line"; do
@@ -107,7 +121,7 @@ for run_line in "$api_run_line" "$web_run_line"; do
     '--security-opt no-new-privileges=true' \
     '--cap-drop ALL' \
     '--health-interval 10s' \
-    '--health-timeout 5s' \
+    '--health-timeout 17s' \
     '--health-retries 9' \
     '--health-start-period 15s'; do
     grep -qF -- "$shared_guard" <<<"$run_line"

--- a/ops/ci/test_deploy_vps.sh
+++ b/ops/ci/test_deploy_vps.sh
@@ -52,6 +52,12 @@ printf '%s\n' 'DATABASE_URL=postgresql://app:devpass@db:5432/appdb' >"$API_ENV"
 cat >"$WEB_ENV" <<EOF
 RUN_MARKER=\$(touch "$MARKER")
 NEXT_PUBLIC_WEB_API_BASE=https://api.example.com
+NEXT_PUBLIC_SITE_URL=https://www.example.com
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=test-public-vapid-key
+NEXT_PUBLIC_ANALYTICS_ID=G-D6TEST
+NEXT_PUBLIC_ENABLE_SW=1
+NEXT_PUBLIC_RELAX_CSP=1
+NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com
 EOF
 printf '%s\n' 'NEXT_PUBLIC_SITE_URL=https://www.example.com' >"$MISSING_WEB_ENV"
 
@@ -68,8 +74,30 @@ PNPM_VERSION=10.17.1 \
   --uploads "$TMP_DIR/uploads"
 
 grep -qF -- 'build --build-arg NEXT_PUBLIC_WEB_API_BASE=https://api.example.com' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_VAPID_PUBLIC_KEY=test-public-vapid-key' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_SITE_URL=https://www.example.com' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_ANALYTICS_ID=G-D6TEST' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_ENABLE_SW=1' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_RELAX_CSP=1' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com' "$FAKE_DOCKER_LOG"
 grep -qF -- 'network inspect sogecon_net' "$FAKE_DOCKER_LOG"
 grep -qF -- '--network sogecon_net' "$FAKE_DOCKER_LOG"
+[[ ! -e "$MARKER" ]]
+
+# An explicit API-base override wins only for that one key. Other allowlisted
+# public build values continue to come from the safely parsed file.
+: >"$FAKE_DOCKER_LOG"
+PNPM_VERSION=10.17.1 \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract-override \
+  --local-build \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$WEB_ENV" \
+  --web-api-base https://override.example.com \
+  --uploads "$TMP_DIR/override-uploads"
+grep -qF -- 'build --build-arg NEXT_PUBLIC_WEB_API_BASE=https://override.example.com' "$FAKE_DOCKER_LOG"
+grep -qF -- '--build-arg NEXT_PUBLIC_VAPID_PUBLIC_KEY=test-public-vapid-key' "$FAKE_DOCKER_LOG"
 [[ ! -e "$MARKER" ]]
 
 : >"$FAKE_DOCKER_LOG"

--- a/ops/ci/test_deploy_vps.sh
+++ b/ops/ci/test_deploy_vps.sh
@@ -47,6 +47,8 @@ chmod 755 "$FAKE_BIN/docker"
 API_ENV="$TMP_DIR/api.env"
 WEB_ENV="$TMP_DIR/web.env"
 MISSING_WEB_ENV="$TMP_DIR/missing-web.env"
+PARTIAL_WEB_ENV="$TMP_DIR/partial-web.env"
+EMPTY_BASE_WEB_ENV="$TMP_DIR/empty-base-web.env"
 MARKER="$TMP_DIR/should-not-exist"
 printf '%s\n' 'DATABASE_URL=postgresql://app:devpass@db:5432/appdb' >"$API_ENV"
 cat >"$WEB_ENV" <<EOF
@@ -60,6 +62,11 @@ NEXT_PUBLIC_RELAX_CSP=1
 NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com
 EOF
 printf '%s\n' 'NEXT_PUBLIC_SITE_URL=https://www.example.com' >"$MISSING_WEB_ENV"
+cat >"$PARTIAL_WEB_ENV" <<'EOF'
+NEXT_PUBLIC_WEB_API_BASE=https://api.partial.example.com
+NEXT_PUBLIC_RELAX_CSP=
+EOF
+printf '%s\n' 'NEXT_PUBLIC_WEB_API_BASE=' >"$EMPTY_BASE_WEB_ENV"
 
 export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
 export PATH="$FAKE_BIN:$PATH"
@@ -83,6 +90,55 @@ grep -qF -- '--build-arg NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com' "$FAKE_DOCKE
 grep -qF -- 'network inspect sogecon_net' "$FAKE_DOCKER_LOG"
 grep -qF -- '--network sogecon_net' "$FAKE_DOCKER_LOG"
 [[ ! -e "$MARKER" ]]
+
+# Allowlisted values from the parent shell must not leak into the artifact when
+# the file omits them or explicitly clears one. The file's API base remains the
+# authoritative value even when the parent exports a stale base.
+: >"$FAKE_DOCKER_LOG"
+NEXT_PUBLIC_WEB_API_BASE=https://stale-api.example.com \
+NEXT_PUBLIC_SITE_URL=https://stale-site.example.com \
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=stale-vapid \
+NEXT_PUBLIC_ANALYTICS_ID=stale-analytics \
+NEXT_PUBLIC_ENABLE_SW=stale-sw \
+NEXT_PUBLIC_RELAX_CSP=1 \
+NEXT_PUBLIC_IMAGE_DOMAINS=stale-images.example.com \
+PNPM_VERSION=10.17.1 \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract-parent-env \
+  --local-build \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$PARTIAL_WEB_ENV" \
+  --uploads "$TMP_DIR/parent-env-uploads"
+grep -qF -- 'build --build-arg NEXT_PUBLIC_WEB_API_BASE=https://api.partial.example.com' "$FAKE_DOCKER_LOG"
+if grep -qF -- 'stale' "$FAKE_DOCKER_LOG"; then
+  echo 'stale parent public build value leaked into Docker build args' >&2
+  exit 1
+fi
+if grep -qF -- '--build-arg NEXT_PUBLIC_RELAX_CSP=' "$FAKE_DOCKER_LOG"; then
+  echo 'explicit empty NEXT_PUBLIC_RELAX_CSP produced a Docker build arg' >&2
+  exit 1
+fi
+[[ ! -e "$MARKER" ]]
+
+: >"$FAKE_DOCKER_LOG"
+if NEXT_PUBLIC_WEB_API_BASE=https://stale-api.example.com \
+  PNPM_VERSION=10.17.1 \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract-empty-api \
+  --local-build \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$EMPTY_BASE_WEB_ENV" \
+  --uploads "$TMP_DIR/empty-api-uploads" >"$TMP_DIR/empty-api.out" 2>&1; then
+  echo 'explicit empty NEXT_PUBLIC_WEB_API_BASE unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'NEXT_PUBLIC_WEB_API_BASE is required for local Web image build' "$TMP_DIR/empty-api.out"
+if grep -qF -- 'build ' "$FAKE_DOCKER_LOG"; then
+  echo 'explicit empty NEXT_PUBLIC_WEB_API_BASE recorded a Docker build' >&2
+  exit 1
+fi
 
 # An explicit API-base override wins only for that one key. Other allowlisted
 # public build values continue to come from the safely parsed file.

--- a/ops/ci/test_deploy_vps.sh
+++ b/ops/ci/test_deploy_vps.sh
@@ -65,10 +65,11 @@ PNPM_VERSION=10.17.1 \
   --skip-migrate \
   --env "$API_ENV" \
   --web-env "$WEB_ENV" \
-  --uploads "$TMP_DIR/uploads" \
-  --network d6-contract-network
+  --uploads "$TMP_DIR/uploads"
 
 grep -qF -- 'build --build-arg NEXT_PUBLIC_WEB_API_BASE=https://api.example.com' "$FAKE_DOCKER_LOG"
+grep -qF -- 'network inspect sogecon_net' "$FAKE_DOCKER_LOG"
+grep -qF -- '--network sogecon_net' "$FAKE_DOCKER_LOG"
 [[ ! -e "$MARKER" ]]
 
 : >"$FAKE_DOCKER_LOG"

--- a/ops/ci/test_deploy_vps.sh
+++ b/ops/ci/test_deploy_vps.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command=${1:-}
+shift || true
+case "$command" in
+  build)
+    printf 'build %s\n' "$*" >>"$FAKE_DOCKER_LOG"
+    ;;
+  image|network)
+    printf '%s %s\n' "$command" "$*" >>"$FAKE_DOCKER_LOG"
+    ;;
+  ps)
+    ;;
+  run)
+    printf 'run %s\n' "$*" >>"$FAKE_DOCKER_LOG"
+    ;;
+  inspect)
+    format=${2:-}
+    printf 'inspect %s %s\n' "${3:-}" "$format" >>"$FAKE_DOCKER_LOG"
+    if [[ "$format" == *'.State.Status'* ]]; then
+      printf 'running\n'
+    elif [[ "$format" == *'.State.Health.Status'* ]]; then
+      printf 'healthy\n'
+    fi
+    ;;
+  logs)
+    ;;
+  *)
+    printf 'unexpected docker command: %s %s\n' "$command" "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 755 "$FAKE_BIN/docker"
+
+API_ENV="$TMP_DIR/api.env"
+WEB_ENV="$TMP_DIR/web.env"
+MISSING_WEB_ENV="$TMP_DIR/missing-web.env"
+MARKER="$TMP_DIR/should-not-exist"
+printf '%s\n' 'DATABASE_URL=postgresql://app:devpass@db:5432/appdb' >"$API_ENV"
+cat >"$WEB_ENV" <<EOF
+RUN_MARKER=\$(touch "$MARKER")
+NEXT_PUBLIC_WEB_API_BASE=https://api.example.com
+EOF
+printf '%s\n' 'NEXT_PUBLIC_SITE_URL=https://www.example.com' >"$MISSING_WEB_ENV"
+
+export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
+export PATH="$FAKE_BIN:$PATH"
+
+PNPM_VERSION=10.17.1 \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract \
+  --local-build \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$WEB_ENV" \
+  --uploads "$TMP_DIR/uploads" \
+  --network d6-contract-network
+
+grep -qF -- 'build --build-arg NEXT_PUBLIC_WEB_API_BASE=https://api.example.com' "$FAKE_DOCKER_LOG"
+[[ ! -e "$MARKER" ]]
+
+: >"$FAKE_DOCKER_LOG"
+if PNPM_VERSION=10.17.1 \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract-missing \
+  --local-build \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$MISSING_WEB_ENV" \
+  --uploads "$TMP_DIR/missing-uploads" \
+  --network d6-contract-network >"$TMP_DIR/missing.out" 2>&1; then
+  echo 'missing NEXT_PUBLIC_WEB_API_BASE unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'NEXT_PUBLIC_WEB_API_BASE is required for local Web image build' "$TMP_DIR/missing.out"
+! grep -qF 'build ' "$FAKE_DOCKER_LOG"
+
+if HEALTH_TIMEOUT=5s \
+  bash "$ROOT/scripts/deploy-vps.sh" \
+  --tag d6-contract-invalid-timeout \
+  --pull-images \
+  --skip-migrate \
+  --env "$API_ENV" \
+  --web-env "$WEB_ENV" \
+  --uploads "$TMP_DIR/invalid-timeout-uploads" \
+  --network d6-contract-network >"$TMP_DIR/invalid-timeout.out" 2>&1; then
+  echo 'non-integer HEALTH_TIMEOUT unexpectedly passed' >&2
+  exit 1
+fi
+grep -qF 'HEALTH_TIMEOUT must be a positive integer' "$TMP_DIR/invalid-timeout.out"
+
+echo 'deploy-vps command contract: PASS'

--- a/ops/ci/test_deploy_vps.sh
+++ b/ops/ci/test_deploy_vps.sh
@@ -170,7 +170,10 @@ if PNPM_VERSION=10.17.1 \
   exit 1
 fi
 grep -qF 'NEXT_PUBLIC_WEB_API_BASE is required for local Web image build' "$TMP_DIR/missing.out"
-! grep -qF 'build ' "$FAKE_DOCKER_LOG"
+if grep -qF 'build ' "$FAKE_DOCKER_LOG"; then
+  echo 'missing NEXT_PUBLIC_WEB_API_BASE unexpectedly triggered a Docker build' >&2
+  exit 1
+fi
 
 if HEALTH_TIMEOUT=5s \
   bash "$ROOT/scripts/deploy-vps.sh" \

--- a/ops/cloud-build.sh
+++ b/ops/cloud-build.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 #   PUSH_IMAGES      : 1이면 빌드 후 docker push 수행
 #   PNPM_VERSION     : Web 빌드에 사용할 pnpm 버전(미지정 시 자동 해석)
 #   NEXT_PUBLIC_*    : 웹 빌드 시 주입할 Next.js 공개 환경변수
+#   WEB_BUILD_ALLOW_INSECURE_LOCAL_API는 직접 로컬 Docker 빌드에서만 Dockerfile
+#   build-arg로 지정합니다. 이 운영 빌드 경로에서는 전달하지 않습니다.
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "${ROOT_DIR}"

--- a/ops/cloud-start.sh
+++ b/ops/cloud-start.sh
@@ -35,7 +35,7 @@ WEB_PIDS_LIMIT=${WEB_PIDS_LIMIT:-256}
 CONTAINER_LOG_MAX_SIZE=${CONTAINER_LOG_MAX_SIZE:-10m}
 CONTAINER_LOG_MAX_FILE=${CONTAINER_LOG_MAX_FILE:-5}
 HEALTH_INTERVAL=${HEALTH_INTERVAL:-10s}
-HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-5s}
+CONTAINER_HEALTH_TIMEOUT=${CONTAINER_HEALTH_TIMEOUT:-5s}
 HEALTH_RETRIES=${HEALTH_RETRIES:-9}
 HEALTH_START_PERIOD=${HEALTH_START_PERIOD:-15s}
 HEALTH_WAIT_TIMEOUT=${HEALTH_WAIT_TIMEOUT:-120}
@@ -93,8 +93,10 @@ redact_known_secrets() {
       key=${line%%=*}
       value=${line#*=}
       value=${value%$'\r'}
-      value=${value#\"}
-      value=${value%\"}
+      case "${value}" in
+        \"*\") value=${value:1:${#value}-2} ;;
+        \'*\') value=${value:1:${#value}-2} ;;
+      esac
       case "${key}" in
         *SECRET*|*PASSWORD*|*TOKEN*|*PRIVATE*|*KEY*|DATABASE_URL)
           [[ -n "${value}" ]] && text=${text//"${value}"/***}
@@ -158,7 +160,7 @@ run_api() {
     --security-opt no-new-privileges=true
     --cap-drop ALL
     --health-interval "${HEALTH_INTERVAL}"
-    --health-timeout "${HEALTH_TIMEOUT}"
+    --health-timeout "${CONTAINER_HEALTH_TIMEOUT}"
     --health-retries "${HEALTH_RETRIES}"
     --health-start-period "${HEALTH_START_PERIOD}"
   )
@@ -189,7 +191,7 @@ run_web() {
     --security-opt no-new-privileges=true
     --cap-drop ALL
     --health-interval "${HEALTH_INTERVAL}"
-    --health-timeout "${HEALTH_TIMEOUT}"
+    --health-timeout "${CONTAINER_HEALTH_TIMEOUT}"
     --health-retries "${HEALTH_RETRIES}"
     --health-start-period "${HEALTH_START_PERIOD}"
   )

--- a/ops/cloud-start.sh
+++ b/ops/cloud-start.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #
 # Required: API_IMAGE, WEB_IMAGE
 # Optional: API_ENV_FILE, WEB_ENV_FILE, API_CONTAINER, WEB_CONTAINER,
-# API_PORT, WEB_PORT, UPLOADS_DIR, DOCKER_NETWORK, RELEASE
+# API_PORT, WEB_PORT, UPLOADS_DIR, DOCKER_NETWORK(default: sogecon_net), RELEASE
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker 명령이 필요합니다." >&2
@@ -23,7 +23,7 @@ WEB_CONTAINER=${WEB_CONTAINER:-alumni-web}
 API_PORT=${API_PORT:-3001}
 WEB_PORT=${WEB_PORT:-3000}
 UPLOADS_DIR=${UPLOADS_DIR:-/var/lib/sogecon/uploads}
-DOCKER_NETWORK=${DOCKER_NETWORK:-bridge}
+DOCKER_NETWORK=${DOCKER_NETWORK:-sogecon_net}
 RELEASE=${RELEASE:-$(date +%Y%m%d%H%M%S)}
 
 API_MEMORY=${API_MEMORY:-768m}

--- a/ops/cloud-start.sh
+++ b/ops/cloud-start.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 컨테이너 시작/재시작 스크립트.
-# 환경변수
-#   API_IMAGE         : API 컨테이너 이미지 이름 (필수)
-#   WEB_IMAGE         : Web 컨테이너 이미지 이름 (필수)
-#   API_ENV_FILE      : API에서 사용할 env 파일 경로
-#   WEB_ENV_FILE      : Web에서 사용할 env 파일 경로
-#   API_CONTAINER     : API 컨테이너 이름 (기본 alumni-api)
-#   WEB_CONTAINER     : Web 컨테이너 이름 (기본 alumni-web)
-#   API_PORT          : 호스트에서 노출할 API 포트 (기본 3001, 127.0.0.1에 바인딩)
-#   WEB_PORT          : 호스트에서 노출할 Web 포트 (기본 3000, 127.0.0.1에 바인딩)
-#   UPLOADS_DIR       : API 업로드 볼륨 호스트 경로 (기본 /var/lib/sogecon/uploads)
-#   DOCKER_NETWORK    : 사용할 Docker 네트워크 이름 (기본 bridge)
-#   RELEASE           : 서비스 버전 정보 (기본 현재 시간)
+# Container start/restart entrypoint. Preflight is deliberately completed
+# before either existing service is stopped.
+#
+# Required: API_IMAGE, WEB_IMAGE
+# Optional: API_ENV_FILE, WEB_ENV_FILE, API_CONTAINER, WEB_CONTAINER,
+# API_PORT, WEB_PORT, UPLOADS_DIR, DOCKER_NETWORK, RELEASE
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker 명령이 필요합니다." >&2
@@ -33,8 +26,47 @@ UPLOADS_DIR=${UPLOADS_DIR:-/var/lib/sogecon/uploads}
 DOCKER_NETWORK=${DOCKER_NETWORK:-bridge}
 RELEASE=${RELEASE:-$(date +%Y%m%d%H%M%S)}
 
+API_MEMORY=${API_MEMORY:-768m}
+API_CPUS=${API_CPUS:-1.0}
+API_PIDS_LIMIT=${API_PIDS_LIMIT:-256}
+WEB_MEMORY=${WEB_MEMORY:-512m}
+WEB_CPUS=${WEB_CPUS:-1.0}
+WEB_PIDS_LIMIT=${WEB_PIDS_LIMIT:-256}
+CONTAINER_LOG_MAX_SIZE=${CONTAINER_LOG_MAX_SIZE:-10m}
+CONTAINER_LOG_MAX_FILE=${CONTAINER_LOG_MAX_FILE:-5}
+HEALTH_INTERVAL=${HEALTH_INTERVAL:-10s}
+HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-5s}
+HEALTH_RETRIES=${HEALTH_RETRIES:-9}
+HEALTH_START_PERIOD=${HEALTH_START_PERIOD:-15s}
+HEALTH_WAIT_TIMEOUT=${HEALTH_WAIT_TIMEOUT:-120}
+
+if ! [[ "${HEALTH_WAIT_TIMEOUT}" =~ ^[0-9]+$ ]] || (( HEALTH_WAIT_TIMEOUT < 1 )); then
+  echo "HEALTH_WAIT_TIMEOUT은 1 이상의 초여야 합니다." >&2
+  exit 1
+fi
+
+validate_env_file() {
+  local label=$1
+  local path=$2
+  if [[ ! -f "${path}" ]]; then
+    echo "${label} 경로(${path})가 존재하지 않습니다." >&2
+    exit 1
+  fi
+}
+
+# Do not inspect container configuration or print env-file contents here.
+# Image/env/network preflight must finish before any stop/rm operation.
+docker image inspect "${API_IMAGE}" >/dev/null
+docker image inspect "${WEB_IMAGE}" >/dev/null
+if [[ -n "${API_ENV_FILE:-}" ]]; then
+  validate_env_file API_ENV_FILE "${API_ENV_FILE}"
+fi
+if [[ -n "${WEB_ENV_FILE:-}" ]]; then
+  validate_env_file WEB_ENV_FILE "${WEB_ENV_FILE}"
+fi
+docker network inspect "${DOCKER_NETWORK}" >/dev/null
+
 mkdir -p "${UPLOADS_DIR}"
-# 컨테이너 비루트 유저(apiuser/webuser, 통상 UID 1000)에 맞춰 소유권을 시도
 chown 1000:1000 "${UPLOADS_DIR}" 2>/dev/null || echo "[warn] uploads ownership not changed (insufficient permission)"
 
 stop_container() {
@@ -46,38 +78,123 @@ stop_container() {
   fi
 }
 
-run_api() {
-  local args=(--detach --restart unless-stopped --name "${API_CONTAINER}")
-  args+=(--network "${DOCKER_NETWORK}")
-  args+=(--publish "127.0.0.1:${API_PORT}:3001")
-  args+=(-e "APP_ENV=${APP_ENV:-prod}")
-  args+=(-e "RELEASE=${RELEASE}")
-  if [[ -n "${API_ENV_FILE:-}" ]]; then
-    if [[ ! -f "${API_ENV_FILE}" ]]; then
-      echo "API_ENV_FILE 경로(${API_ENV_FILE})가 존재하지 않습니다." >&2
-      exit 1
+redact_known_secrets() {
+  local text=$1
+  local env_file line key value
+
+  if [[ -n "${DATABASE_URL:-}" ]]; then
+    text=${text//"${DATABASE_URL}"/***}
+  fi
+
+  for env_file in "${API_ENV_FILE:-}" "${WEB_ENV_FILE:-}"; do
+    [[ -n "${env_file}" && -f "${env_file}" ]] || continue
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      [[ "${line}" == *=* && "${line}" != \#* ]] || continue
+      key=${line%%=*}
+      value=${line#*=}
+      value=${value%$'\r'}
+      value=${value#\"}
+      value=${value%\"}
+      case "${key}" in
+        *SECRET*|*PASSWORD*|*TOKEN*|*PRIVATE*|*KEY*|DATABASE_URL)
+          [[ -n "${value}" ]] && text=${text//"${value}"/***}
+          ;;
+      esac
+    done <"${env_file}"
+  done
+
+  printf '%s\n' "${text}"
+}
+
+report_health_failure() {
+  local name=$1
+  local status health logs
+  status=$(docker inspect --format '{{.State.Status}}' "${name}" 2>/dev/null || printf 'unknown')
+  health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' "${name}" 2>/dev/null || printf 'missing')
+  echo "[health] ${name} failed: status=${status} health=${health}" >&2
+  logs=$(docker logs --tail 40 "${name}" 2>&1 || true)
+  if [[ -n "${logs}" ]]; then
+    echo "[health] ${name} recent logs (max 40 lines):" >&2
+    redact_known_secrets "${logs}" >&2
+  fi
+}
+
+wait_for_healthy() {
+  local name=$1
+  local elapsed=0 status health
+  while (( elapsed < HEALTH_WAIT_TIMEOUT )); do
+    status=$(docker inspect --format '{{.State.Status}}' "${name}" 2>/dev/null || printf 'unknown')
+    health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' "${name}" 2>/dev/null || printf 'missing')
+    if [[ "${status}" == "running" && "${health}" == "healthy" ]]; then
+      echo "[health] ${name}: healthy"
+      return 0
     fi
+    if [[ "${status}" == "exited" || "${status}" == "dead" || "${status}" == "unknown" || "${health}" == "missing" || "${health}" == "unhealthy" || "${health}" == "unknown" ]]; then
+      report_health_failure "${name}"
+      return 1
+    fi
+    sleep 1
+    ((elapsed += 1))
+  done
+
+  report_health_failure "${name}"
+  echo "[health] ${name} did not become healthy within ${HEALTH_WAIT_TIMEOUT}s." >&2
+  return 1
+}
+
+run_api() {
+  local args=(
+    --detach
+    --restart unless-stopped
+    --name "${API_CONTAINER}"
+    --network "${DOCKER_NETWORK}"
+    --publish "127.0.0.1:${API_PORT}:3001"
+    --memory "${API_MEMORY}"
+    --cpus "${API_CPUS}"
+    --pids-limit "${API_PIDS_LIMIT}"
+    --log-driver json-file
+    --log-opt "max-size=${CONTAINER_LOG_MAX_SIZE}"
+    --log-opt "max-file=${CONTAINER_LOG_MAX_FILE}"
+    --security-opt no-new-privileges=true
+    --cap-drop ALL
+    --health-interval "${HEALTH_INTERVAL}"
+    --health-timeout "${HEALTH_TIMEOUT}"
+    --health-retries "${HEALTH_RETRIES}"
+    --health-start-period "${HEALTH_START_PERIOD}"
+  )
+  args+=(-e "APP_ENV=${APP_ENV:-prod}" -e "RELEASE=${RELEASE}")
+  if [[ -n "${API_ENV_FILE:-}" ]]; then
     args+=(--env-file "${API_ENV_FILE}")
   fi
   if [[ -n "${DATABASE_URL:-}" ]]; then
     args+=(-e "DATABASE_URL=${DATABASE_URL}")
   fi
   args+=(--volume "${UPLOADS_DIR}:/app/uploads")
-
   docker run "${args[@]}" "${API_IMAGE}"
 }
 
 run_web() {
-  local args=(--detach --restart unless-stopped --name "${WEB_CONTAINER}")
-  args+=(--network "${DOCKER_NETWORK}")
-  args+=(--publish "127.0.0.1:${WEB_PORT}:3000")
-  args+=(-e "NODE_ENV=production")
-  args+=(-e "RELEASE=${RELEASE}")
+  local args=(
+    --detach
+    --restart unless-stopped
+    --name "${WEB_CONTAINER}"
+    --network "${DOCKER_NETWORK}"
+    --publish "127.0.0.1:${WEB_PORT}:3000"
+    --memory "${WEB_MEMORY}"
+    --cpus "${WEB_CPUS}"
+    --pids-limit "${WEB_PIDS_LIMIT}"
+    --log-driver json-file
+    --log-opt "max-size=${CONTAINER_LOG_MAX_SIZE}"
+    --log-opt "max-file=${CONTAINER_LOG_MAX_FILE}"
+    --security-opt no-new-privileges=true
+    --cap-drop ALL
+    --health-interval "${HEALTH_INTERVAL}"
+    --health-timeout "${HEALTH_TIMEOUT}"
+    --health-retries "${HEALTH_RETRIES}"
+    --health-start-period "${HEALTH_START_PERIOD}"
+  )
+  args+=(-e "NODE_ENV=production" -e "RELEASE=${RELEASE}")
   if [[ -n "${WEB_ENV_FILE:-}" ]]; then
-    if [[ ! -f "${WEB_ENV_FILE}" ]]; then
-      echo "WEB_ENV_FILE 경로(${WEB_ENV_FILE})가 존재하지 않습니다." >&2
-      exit 1
-    fi
     args+=(--env-file "${WEB_ENV_FILE}")
   fi
   docker run "${args[@]}" "${WEB_IMAGE}"
@@ -85,8 +202,10 @@ run_web() {
 
 stop_container "${API_CONTAINER}"
 run_api
+wait_for_healthy "${API_CONTAINER}"
 
 stop_container "${WEB_CONTAINER}"
 run_web
+wait_for_healthy "${WEB_CONTAINER}"
 
-echo "API(${API_CONTAINER})와 Web(${WEB_CONTAINER}) 컨테이너를 재기동했습니다."
+echo "API(${API_CONTAINER})와 Web(${WEB_CONTAINER}) 컨테이너가 모두 healthy입니다."

--- a/ops/deploy_api.md
+++ b/ops/deploy_api.md
@@ -46,7 +46,8 @@
 3. DB 마이그레이션 적용: `API_IMAGE=registry/alumni-api:<태그> ENV_FILE=/etc/secrets/api.env ./ops/cloud-migrate.sh`
 4. (선택) 관리자 bootstrap 시드: `API_IMAGE=registry/alumni-api:<태그> ENV_FILE=/etc/secrets/api.env ./ops/cloud-seed-admin.sh`
 5. 서비스 재시작: `API_IMAGE=... WEB_IMAGE=registry/alumni-web:<태그> API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env ./ops/cloud-start.sh`
-6. 프로빙: `curl https://api.sogangeconomics.com/healthz` 응답 확인, 주요 엔드포인트 스팟 체크
+   - 기본 resource/log/health 값과 `127.0.0.1` publication은 script가 적용한다. API가 healthy가 되기 전에는 Web을 시작하지 않는다.
+6. `cloud-start.sh` 성공 후 프로빙: `curl https://api.sogangeconomics.com/healthz` 응답 확인, 주요 엔드포인트 스팟 체크
 
 > 참고: `API_ENV_FILE`에는 `DATABASE_URL`, `JWT_SECRET`, `PUSH_*`, `SENTRY_*` 등 필수 시크릿을 포함한다. 컨테이너 업로드 볼륨은 `UPLOADS_DIR=/var/lib/sogecon/uploads` 로 기본 설정되어 있으며, 필요 시 커스터마이즈한다.
 > 관리자 bootstrap 시드를 실행할 경우 `SEED_PROD_ADMIN001_VALUE`를 `.env.api`에 설정해야 한다.
@@ -57,7 +58,8 @@
 - 향후 `/__health` 라우트 추가 시, DB/외부 의존성 체크 포함 예정 (후속 작업)
 
 ## 6. 롤백 전략
-- `ops/rollback.md` 문서를 참조하여 이전 이미지/커밋으로 즉시 배포 전환
+- 정확히 알고 있는 이전 API/Web 이미지 태그를 `API_IMAGE`/`WEB_IMAGE`에 넣고 같은 `ops/cloud-start.sh`를 다시 실행한다. 두 이미지가 모두 healthy라는 성공 결과가 rollback의 권위 있는 완료 증거다.
+- 자동 데이터베이스 rollback이나 기존 컨테이너의 silent restore는 수행하지 않는다.
 - DB 마이그레이션 롤백이 필요한 경우 `alembic downgrade <revision>` 실행 (사전 백업 필수)
 - 실패 원인: `journalctl -u alumni-api`, 애플리케이션 로그, Sentry 등으로 분석
 

--- a/ops/deploy_api.md
+++ b/ops/deploy_api.md
@@ -4,6 +4,13 @@
 - FastAPI 백엔드(`apps/api`)를 프로덕션 환경에 안전하게 배포하고, 실패 시 빠르게 롤백하기 위한 표준 운영 문서를 정의한다.
 - 데이터베이스는 PostgreSQL 16만 지원한다(루트 `compose.yaml`). 모든 환경에서 `postgresql+psycopg://` 스킴을 사용한다.
 
+Operator-confirmed current state is API `alumni-api` and PostgreSQL
+`sogecon-db` in Docker with Web on the `sogecon-web` systemd standalone
+release until cutover. The accepted near-term target is full Docker for API,
+Web, and PostgreSQL using the existing D6 `ops/cloud-start.sh` guards.
+`compose.yaml` remains local dev/test only. The standalone release is retained
+as the Web rollback fallback during migration.
+
 ## 2. 필수 환경 변수
 - `APP_ENV`: `dev` / `test` / `staging` / `prod` (빈 값·그 외 값은 기동 실패)
 - `DATABASE_URL`: SQLAlchemy 접속 문자열 (예: `postgresql+psycopg://user:pass@host:5432/db`)
@@ -39,18 +46,35 @@
 5. 다른 터미널에서 헬스 체크: `curl -I http://localhost:3001/healthz` → `200 OK`
 6. 종료 후 해당 일자의 `docs/dev_log_YYMMDD.md`에 검증 결과 기록
 
-## 4. 배포 절차 (예시)
+## 4. Target full-Docker 배포 절차 (예시)
 1. `main` 병합 → CI에서 `pytest`, `pyright`, `ruff` 성공 확인
-2. 컨테이너 이미지 빌드: `IMAGE_PREFIX=registry/alumni PUSH_IMAGES=1 ./ops/cloud-build.sh`
+2. API/Web 이미지 빌드/게시: `IMAGE_PREFIX=registry/alumni NEXT_PUBLIC_WEB_API_BASE=https://api.example.com PUSH_IMAGES=1 ./ops/cloud-build.sh`
    - (로컬/CI가 ARM이고 서버가 AMD64면) `PLATFORMS=linux/amd64 USE_BUILDX=1`를 함께 지정
 3. DB 마이그레이션 적용: `API_IMAGE=registry/alumni-api:<태그> ENV_FILE=/etc/secrets/api.env ./ops/cloud-migrate.sh`
 4. (선택) 관리자 bootstrap 시드: `API_IMAGE=registry/alumni-api:<태그> ENV_FILE=/etc/secrets/api.env ./ops/cloud-seed-admin.sh`
-5. 서비스 재시작: `API_IMAGE=... WEB_IMAGE=registry/alumni-web:<태그> API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env ./ops/cloud-start.sh`
-   - 기본 resource/log/health 값과 `127.0.0.1` publication은 script가 적용한다. API가 healthy가 되기 전에는 Web을 시작하지 않는다.
-6. `cloud-start.sh` 성공 후 프로빙: `curl https://api.sogangeconomics.com/healthz` 응답 확인, 주요 엔드포인트 스팟 체크
+5. API/Web env file과 Docker network를 준비하고 `.env.web`에
+   `API_INTERNAL_URL=http://alumni-api:3001` 같은 network runtime 값을 설정한다.
+6. `docker image inspect`로 정확한 API/Web image를 확인하고, env-file 존재와 network를 먼저 검사한다.
+7. preflight 이후 cutover 시점에만 `sudo systemctl stop sogecon-web && sudo systemctl disable sogecon-web`을 실행한다.
+8. 다음 full-container entry point로 API→Web 순서와 health guard를 적용한다.
+
+   ```bash
+   API_IMAGE=registry/alumni-api:<태그> WEB_IMAGE=registry/alumni-web:<태그> \
+     API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env \
+     DOCKER_NETWORK=sogecon_net \
+     ./ops/cloud-start.sh
+   ```
+
+9. API/Web health endpoint와 representative browser flow를 readback한다. 이 PR에서는 production migration/readback을 실행하지 않는다.
 
 > 참고: `API_ENV_FILE`에는 `DATABASE_URL`, `JWT_SECRET`, `PUSH_*`, `SENTRY_*` 등 필수 시크릿을 포함한다. 컨테이너 업로드 볼륨은 `UPLOADS_DIR=/var/lib/sogecon/uploads` 로 기본 설정되어 있으며, 필요 시 커스터마이즈한다.
 > 관리자 bootstrap 시드를 실행할 경우 `SEED_PROD_ADMIN001_VALUE`를 `.env.api`에 설정해야 한다.
+
+`API_INTERNAL_URL`은 Web server fetch 전용 runtime 값이며
+`NEXT_PUBLIC_WEB_API_BASE`를 대체하지 않는다. Web rollback 시에는 Web
+container를 stop/rm하고 보존한 `/srv/www/sogecon/current` symlink/release를
+복구한 뒤 `systemctl enable --now sogecon-web`으로 standalone fallback을
+재활성화한다.
 
 ## 5. 모니터링 & 알림
 - 구조화 로그(JSON Lines) 수집 시스템에 배포 버전 태그
@@ -58,7 +82,14 @@
 - 향후 `/__health` 라우트 추가 시, DB/외부 의존성 체크 포함 예정 (후속 작업)
 
 ## 6. 롤백 전략
-- 정확히 알고 있는 이전 API/Web 이미지 태그를 `API_IMAGE`/`WEB_IMAGE`에 넣고 같은 `ops/cloud-start.sh`를 다시 실행한다. 두 이미지가 모두 healthy라는 성공 결과가 rollback의 권위 있는 완료 증거다.
+- D6+ HEALTHCHECK가 포함된 정확한 이전 API/Web 이미지 태그는 현재
+  `ops/cloud-start.sh`로 다시 실행한다. 이미지와 스크립트는 matched release
+  set이어야 하며, pre-D6 HEALTHCHECK 없는 이미지로 롤백할 때는 해당 pre-D6
+  deployment script/release checkout을 함께 사용한다. 두 이미지가 모두
+  healthy라는 성공 결과가 rollback의 권위 있는 완료 증거다.
+- Web rollback은 Web container를 stop/rm하고 `ops/web-rollback.sh`로 이전
+  standalone release symlink를 복구한 뒤 `systemctl enable --now sogecon-web`로
+  systemd fallback을 재활성화한다.
 - 자동 데이터베이스 rollback이나 기존 컨테이너의 silent restore는 수행하지 않는다.
 - DB 마이그레이션 롤백이 필요한 경우 `alembic downgrade <revision>` 실행 (사전 백업 필수)
 - 실패 원인: `journalctl -u alumni-api`, 애플리케이션 로그, Sentry 등으로 분석
@@ -78,7 +109,7 @@
    - 쿠키: `COOKIE_SAMESITE=lax`(기본), `COOKIE_SECURE=true`
 3) 마이그레이션/기동
    - `API_IMAGE=... ENV_FILE=.env.api ./ops/cloud-migrate.sh`
-   - `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web ./ops/cloud-start.sh`
+   - `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=.env.api WEB_ENV_FILE=.env.web DOCKER_NETWORK=sogecon_net ./ops/cloud-start.sh`로 full-container를 기동하고 `/healthz`를 확인
 4) 프록시: `api.sogangeconomics.com` → `127.0.0.1:3001`(예시 Nginx는 `ops/nginx-examples/` 참고). `TRUSTED_PROXY_IPS`에 해당 hop을 반드시 등록
 5) 헬스체크: `GET https://api.sogangeconomics.com/healthz` → 200
 

--- a/ops/deploy_web.md
+++ b/ops/deploy_web.md
@@ -4,6 +4,12 @@
 - Next.js 웹 애플리케이션을 Vercel/Fly/자체 호스팅 등 Node 24.x 환경에 배포할 때 필요한 준비·검증·롤백 절차를 정리한다.
 - 릴리스는 항상 `apps/web` 기준 `pnpm` 워크스페이스에서 수행하며, 배포 전후 로그는 해당 일자의 `docs/dev_log_YYMMDD.md`에 기록한다.
 
+Operator-confirmed current state is a standalone `sogecon-web` systemd release
+with Docker API/PostgreSQL until cutover. The accepted near-term target is full
+Docker Web using the existing D6 `ops/cloud-start.sh` guards. The standalone
+release remains available as the Web rollback fallback, and `compose.yaml` is
+local dev/test only.
+
 ## 2. 사전 준비
 - **필수 환경 변수**
   - `NEXT_PUBLIC_WEB_API_BASE`: API 베이스 URL (예: `https://api.sogangeconomics.com`)
@@ -12,7 +18,7 @@
   - `NEXT_PUBLIC_ANALYTICS_ID`: 분석 도구 ID (없으면 unset)
   - `NEXT_PUBLIC_ENABLE_SW`: 서비스 워커 사용 여부 (`1` 또는 unset)
   - (배포 환경이 CSP 완화가 필요할 경우) `NEXT_PUBLIC_RELAX_CSP=1`
-  - `API_INTERNAL_URL`: Next 서버 전용 Docker 내부 API URL(선택; 브라우저에 노출하지 않음)
+  - `API_INTERNAL_URL`: full-Docker target에서 Web server fetch에 필요한 Docker 내부 API URL(standalone fallback에서는 불필요; 브라우저에 노출하지 않음)
 - **Node 런타임**: `node 24.12.0`, `pnpm 10.x (>=10.17.1 <11)` (CI는 범위 검사).
 - **CI 시크릿**: 위 환경 변수는 CI/CD 공급자의 시크릿 저장소에 사전 등록한다.
 
@@ -23,20 +29,43 @@
 
 ## 3. 로컬 검증 (필수)
 1. 의존성 설치: `pnpm install`
-2. 빌드 확인: `pnpm -C apps/web build`
+2. 빌드 확인: `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`
 3. 런타임 확인: `pnpm -C apps/web start`
    - 다른 터미널에서 `curl -I http://localhost:3000/` 로 200 응답 확인
    - 검증 완료 후 `Ctrl+C` 로 종료
 4. 로컬 production artifact가 loopback API를 의도적으로 사용할 때만 `NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001 WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 pnpm -C apps/web build`를 사용한다. `next dev`에는 escape hatch가 필요 없다.
 
-## 4. 배포 절차 (예시: 수동/온박스)
-1. `main` 반영 후 로컬 또는 VPS에서 `pnpm -C apps/web build` 성공 여부 확인
-2. 이미지 빌드: `IMAGE_PREFIX=local/sogecon NEXT_PUBLIC_WEB_API_BASE=https://api... NEXT_PUBLIC_SITE_URL=https://alumni... PUSH_IMAGES=0 ./ops/cloud-build.sh`
-3. 런타임 재시작: `API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<태그> API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env ./ops/cloud-start.sh`
-4. `cloud-start.sh`가 API healthy 후 Web healthy까지 확인하므로 성공 메시지를 받은 뒤 `/` 또는 주요 페이지를 추가 확인한다.
-5. CDN/리버스 프록시 캐시 무효화 (필요 시)
+## 4. Target full-Docker 배포 절차
+1. `main` 반영 후 `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web install` 및 `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`를 실행한다.
+2. `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com`을 build arg로 사용해 Web image를 build하거나 정확한 release-tagged Web image를 pull한다.
+3. API/Web env file과 Docker network를 준비하고 Web env file에
+   `API_INTERNAL_URL=http://alumni-api:3001`을 runtime 값으로 설정한다.
+4. `docker image inspect`, env-file 존재 확인, `docker network inspect`를 먼저 실행한다.
+5. preflight가 통과한 cutover 시점에만 `sudo systemctl stop sogecon-web && sudo systemctl disable sogecon-web`을 실행한다.
+6. `API_IMAGE=... WEB_IMAGE=... API_ENV_FILE=... WEB_ENV_FILE=... DOCKER_NETWORK=sogecon_net ./ops/cloud-start.sh`로 full-container를 기동한다. Web 컨테이너가 읽는 `API_INTERNAL_URL`은 3단계에서 준비한 `WEB_ENV_FILE`에 둔다.
+7. API/Web health endpoint와 representative browser flow를 확인한다. 이 PR에서는 production migration/readback을 실행하지 않는다.
+
+### 4.1 Full-Docker image command
+
+```bash
+IMAGE_PREFIX=local/sogecon \
+NEXT_PUBLIC_WEB_API_BASE=https://api.example.com \
+NEXT_PUBLIC_SITE_URL=https://www.example.com \
+PUSH_IMAGES=0 ./ops/cloud-build.sh
+API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<태그> \
+  API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env \
+  ./ops/cloud-start.sh
+```
 
 > 참고: `WEB_ENV_FILE`에는 `API_INTERNAL_URL`과 런타임에 필요한 추가 값(예: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`)을 주입한다. `NEXT_PUBLIC_*` public API 값은 build-time이다. Nginx는 127.0.0.1:${WEB_PORT}로 프록시하며, HTTPS/TLS는 기존 서버 설정을 활용한다.
+
+### 4.2 Current standalone / rollback fallback
+
+cutover 전 operator-confirmed 상태를 보존하거나 rollback할 때는
+`NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build` →
+`ops/web-deploy.sh` → `/srv/www/sogecon/current` symlink 및
+`systemctl is-active --quiet sogecon-web` 흐름을 사용한다. 이 경로는 full-Docker
+target의 rollback fallback이며 target primary가 아니다.
 
 ## 5. 헬스체크
 - 기본 확인 경로: `GET /` (홈) 또는 SSR 페이지 응답 시간 측정
@@ -44,11 +73,20 @@
 - 에러 로깅/모니터링 도구에 신규 릴리스 태깅
 
 ## 6. 롤백 전략
-- 최신 성공 배포의 API/Web 이미지 태그를 정확히 지정해 `ops/cloud-start.sh`를 다시 실행한다. 같은 preflight와 두 이미지 health wait가 끝난 성공 메시지가 rollback 완료의 권위 있는 증거다.
+- D6+ HEALTHCHECK가 포함된 최신 성공 API/Web 이미지 태그는 현재 D6+
+  `ops/cloud-start.sh`로 다시 실행한다. 이미지와 스크립트는 matched release
+  set이어야 하며, pre-D6 HEALTHCHECK 없는 이미지로 롤백할 때는 해당 pre-D6
+  deployment script/release checkout을 함께 사용한다. 같은 preflight와 두
+  이미지 health wait가 끝난 성공 메시지가 rollback 완료의 권위 있는 증거다.
 - 배포 실패 시:
   1. `cloud-start.sh`가 출력한 제한된 inspect state/recent logs를 확인한다.
   2. 자동 DB rollback이나 조용한 기존 컨테이너 복구를 수행하지 않는다.
-  3. 이전 태그를 정확히 넣어 같은 script를 다시 실행한다.
+  3. D6+ 이전 태그는 현재 D6+ script로, pre-D6 태그는 해당 pre-D6 release
+     script로 정확히 다시 실행한다.
+
+Web rollback은 Web container를 stop/rm하고 `ops/web-rollback.sh`로 이전
+standalone release symlink를 복구한 뒤 `systemctl enable --now sogecon-web`로
+systemd fallback을 재활성화한다.
 
 ## 7. 추후 보강 항목
 - 배포 대상별 구체 명령 (Vercel CLI, Flyctl 등) 템플릿화
@@ -65,4 +103,7 @@ PUSH_IMAGES=0 \
 ./ops/cloud-build.sh
 ```
 
-> 참고: 레포 루트의 `.env.web.example`을 참고해 필요한 `NEXT_PUBLIC_*` 키를 정리하세요.
+위 명령은 target Docker Web image build 예시다. current-state 보존이나
+rollback fallback은 `NEXT_PUBLIC_WEB_API_BASE`를 지정한 standalone build와
+`ops/web-deploy.sh`를 사용한다. 레포 루트의 `.env.web.example`은 필요한
+`NEXT_PUBLIC_*` 키를 정리할 때 참고한다.

--- a/ops/deploy_web.md
+++ b/ops/deploy_web.md
@@ -30,7 +30,7 @@ local dev/test only.
 ## 3. 로컬 검증 (필수)
 1. 의존성 설치: `pnpm install`
 2. 빌드 확인: `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web build`
-3. 런타임 확인: `pnpm -C apps/web start`
+3. 런타임 확인: `NEXT_PUBLIC_WEB_API_BASE=https://api.example.com pnpm -C apps/web start`
    - 다른 터미널에서 `curl -I http://localhost:3000/` 로 200 응답 확인
    - 검증 완료 후 `Ctrl+C` 로 종료
 4. 로컬 production artifact가 loopback API를 의도적으로 사용할 때만 `NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001 WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 pnpm -C apps/web build`를 사용한다. `next dev`에는 escape hatch가 필요 없다.

--- a/ops/deploy_web.md
+++ b/ops/deploy_web.md
@@ -12,10 +12,12 @@
   - `NEXT_PUBLIC_ANALYTICS_ID`: 분석 도구 ID (없으면 unset)
   - `NEXT_PUBLIC_ENABLE_SW`: 서비스 워커 사용 여부 (`1` 또는 unset)
   - (배포 환경이 CSP 완화가 필요할 경우) `NEXT_PUBLIC_RELAX_CSP=1`
+  - `API_INTERNAL_URL`: Next 서버 전용 Docker 내부 API URL(선택; 브라우저에 노출하지 않음)
 - **Node 런타임**: `node 24.12.0`, `pnpm 10.x (>=10.17.1 <11)` (CI는 범위 검사).
 - **CI 시크릿**: 위 환경 변수는 CI/CD 공급자의 시크릿 저장소에 사전 등록한다.
 
 > 참고 1: `NEXT_PUBLIC_*` 값은 "빌드타임"에 고정됩니다. `WEB_ENV_FILE`로 런타임에 넣어도 값이 바뀌지 않습니다. 도메인을 교체할 때는 반드시 재빌드가 필요합니다.
+> 참고 1-1: production Web build는 HTTPS public API URL이 필수입니다. `WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1`은 loopback HTTP를 쓰는 직접 local/test build에만 사용하며, 일반 `ops/cloud-build.sh`에는 전달하지 않습니다.
 > 
 > 참고 2(맥/ARM 환경): 로컬/CI가 ARM이고 서버가 AMD64라면 `PLATFORMS=linux/amd64 USE_BUILDX=1`를 함께 지정해 빌드하세요.
 
@@ -25,16 +27,16 @@
 3. 런타임 확인: `pnpm -C apps/web start`
    - 다른 터미널에서 `curl -I http://localhost:3000/` 로 200 응답 확인
    - 검증 완료 후 `Ctrl+C` 로 종료
-4. 프리뷰에서 CSP 완화가 필요한 경우 `.env.local` 에 `NEXT_PUBLIC_RELAX_CSP=1` 설정 후 HMR 동작 확인
+4. 로컬 production artifact가 loopback API를 의도적으로 사용할 때만 `NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001 WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1 pnpm -C apps/web build`를 사용한다. `next dev`에는 escape hatch가 필요 없다.
 
 ## 4. 배포 절차 (예시: 수동/온박스)
 1. `main` 반영 후 로컬 또는 VPS에서 `pnpm -C apps/web build` 성공 여부 확인
 2. 이미지 빌드: `IMAGE_PREFIX=local/sogecon NEXT_PUBLIC_WEB_API_BASE=https://api... NEXT_PUBLIC_SITE_URL=https://alumni... PUSH_IMAGES=0 ./ops/cloud-build.sh`
-3. 런타임 재시작: `API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<태그> WEB_ENV_FILE=/etc/secrets/web.env ./ops/cloud-start.sh`
-4. `/` 또는 주요 페이지에 대한 헬스체크 수행
+3. 런타임 재시작: `API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<태그> API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env ./ops/cloud-start.sh`
+4. `cloud-start.sh`가 API healthy 후 Web healthy까지 확인하므로 성공 메시지를 받은 뒤 `/` 또는 주요 페이지를 추가 확인한다.
 5. CDN/리버스 프록시 캐시 무효화 (필요 시)
 
-> 참고: `WEB_ENV_FILE`에는 런타임에 필요한 `NEXT_PUBLIC_*` 값과 추가 시크릿(예: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`)을 주입한다. Nginx는 127.0.0.1:${WEB_PORT}로 프록시하며, HTTPS/TLS는 기존 서버 설정을 활용한다.
+> 참고: `WEB_ENV_FILE`에는 `API_INTERNAL_URL`과 런타임에 필요한 추가 값(예: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`)을 주입한다. `NEXT_PUBLIC_*` public API 값은 build-time이다. Nginx는 127.0.0.1:${WEB_PORT}로 프록시하며, HTTPS/TLS는 기존 서버 설정을 활용한다.
 
 ## 5. 헬스체크
 - 기본 확인 경로: `GET /` (홈) 또는 SSR 페이지 응답 시간 측정
@@ -42,11 +44,11 @@
 - 에러 로깅/모니터링 도구에 신규 릴리스 태깅
 
 ## 6. 롤백 전략
-- 최신 성공 배포 태그/버전을 `ops/rollback.md` 절차에 따라 복구
+- 최신 성공 배포의 API/Web 이미지 태그를 정확히 지정해 `ops/cloud-start.sh`를 다시 실행한다. 같은 preflight와 두 이미지 health wait가 끝난 성공 메시지가 rollback 완료의 권위 있는 증거다.
 - 배포 실패 시:
-  1. 트래픽을 이전 버전 인스턴스로 즉시 전환 (blue/green 또는 previous deployment)
-  2. 실패 원인 로그 수집 (`pnpm -C apps/web build` 실패 로그, 런타임 에러 스택)
-  3. `docs/dev_log_YYMMDD.md` 에 실패 기록 & 재배포 일정 공유
+  1. `cloud-start.sh`가 출력한 제한된 inspect state/recent logs를 확인한다.
+  2. 자동 DB rollback이나 조용한 기존 컨테이너 복구를 수행하지 않는다.
+  3. 이전 태그를 정확히 넣어 같은 script를 다시 실행한다.
 
 ## 7. 추후 보강 항목
 - 배포 대상별 구체 명령 (Vercel CLI, Flyctl 등) 템플릿화

--- a/ops/deploy_web.md
+++ b/ops/deploy_web.md
@@ -58,7 +58,7 @@ API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<
   ./ops/cloud-start.sh
 ```
 
-> 참고: `WEB_ENV_FILE`에는 `API_INTERNAL_URL`과 런타임에 필요한 추가 값(예: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`)을 주입한다. `NEXT_PUBLIC_*` public API 값은 build-time이다. Nginx는 127.0.0.1:${WEB_PORT}로 프록시하며, HTTPS/TLS는 기존 서버 설정을 활용한다.
+> 참고: `WEB_ENV_FILE`에는 `API_INTERNAL_URL`처럼 서버 전용 runtime 값만 둔다. `NEXT_PUBLIC_VAPID_PUBLIC_KEY`를 포함한 모든 `NEXT_PUBLIC_*` 값은 build-time에 고정되며, local-build에서는 `deploy-vps.sh`가 allowlist만 안전하게 읽어 `cloud-build.sh`로 전달한다. Nginx는 127.0.0.1:${WEB_PORT}로 프록시하며, HTTPS/TLS는 기존 서버 설정을 활용한다.
 
 ### 4.2 Current standalone / rollback fallback
 

--- a/ops/deploy_web.md
+++ b/ops/deploy_web.md
@@ -54,6 +54,7 @@ NEXT_PUBLIC_SITE_URL=https://www.example.com \
 PUSH_IMAGES=0 ./ops/cloud-build.sh
 API_IMAGE=local/sogecon/alumni-api:<태그> WEB_IMAGE=local/sogecon/alumni-web:<태그> \
   API_ENV_FILE=/etc/secrets/api.env WEB_ENV_FILE=/etc/secrets/web.env \
+  DOCKER_NETWORK=sogecon_net \
   ./ops/cloud-start.sh
 ```
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -149,6 +149,13 @@ else
     value=${WEB_BUILD_PUBLIC_ENV[$key]:-}
     [[ -n "$value" ]] && WEB_BUILD_ENV+=("$key=$value")
   done
+
+  # The supplied .env.web (plus the explicit API-base option) is authoritative
+  # for these build-time values. Remove every allowlisted key before invoking
+  # cloud-build so stale values from the parent shell cannot become build args.
+  for key in "${WEB_BUILD_PUBLIC_KEYS[@]}"; do
+    unset "$key"
+  done
   env "${WEB_BUILD_ENV[@]}" bash "$ROOT_DIR/ops/cloud-build.sh"
 fi
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -30,6 +30,20 @@ WEB_API_BASE_OVERRIDE=0
 HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-60}
 PULL_IMAGES=0
 
+# Keep this list in lockstep with ops/cloud-build.sh. These values are public
+# build configuration, but .env.web is parsed as data: it is never sourced or
+# evaluated by this deploy wrapper.
+WEB_BUILD_PUBLIC_KEYS=(
+  NEXT_PUBLIC_WEB_API_BASE
+  NEXT_PUBLIC_SITE_URL
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  NEXT_PUBLIC_ANALYTICS_ID
+  NEXT_PUBLIC_ENABLE_SW
+  NEXT_PUBLIC_RELAX_CSP
+  NEXT_PUBLIC_IMAGE_DOMAINS
+)
+declare -A WEB_BUILD_PUBLIC_ENV=()
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -t|--tag)
@@ -70,7 +84,7 @@ if [[ ! "${HEALTH_TIMEOUT}" =~ ^[0-9]+$ || "${HEALTH_TIMEOUT}" =~ ^0+$ ]]; then
   exit 1
 fi
 
-extract_web_api_base() {
+extract_web_build_env() {
   local line key value
   [[ -f "$WEB_ENV_FILE" ]] || return 0
 
@@ -78,7 +92,10 @@ extract_web_api_base() {
     line=${line%$'\r'}
     if [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
       key=${BASH_REMATCH[2]}
-      [[ "$key" == NEXT_PUBLIC_WEB_API_BASE ]] || continue
+      case "$key" in
+        NEXT_PUBLIC_WEB_API_BASE|NEXT_PUBLIC_SITE_URL|NEXT_PUBLIC_VAPID_PUBLIC_KEY|NEXT_PUBLIC_ANALYTICS_ID|NEXT_PUBLIC_ENABLE_SW|NEXT_PUBLIC_RELAX_CSP|NEXT_PUBLIC_IMAGE_DOMAINS) ;;
+        *) continue ;;
+      esac
       value=${BASH_REMATCH[3]}
       value="${value#"${value%%[![:space:]]*}"}"
       value="${value%"${value##*[![:space:]]}"}"
@@ -86,9 +103,13 @@ extract_web_api_base() {
         \"*\") value=${value:1:${#value}-2} ;;
         \'*\') value=${value:1:${#value}-2} ;;
       esac
-      WEB_API_BASE="$value"
+      WEB_BUILD_PUBLIC_ENV["$key"]="$value"
     fi
   done <"$WEB_ENV_FILE"
+
+  if [[ "$WEB_API_BASE_OVERRIDE" -eq 0 ]]; then
+    WEB_API_BASE=${WEB_BUILD_PUBLIC_ENV[NEXT_PUBLIC_WEB_API_BASE]:-}
+  fi
 }
 
 if [[ -z "$TAG" ]]; then
@@ -112,16 +133,23 @@ if [[ "$PULL_IMAGES" -eq 1 ]]; then
   docker pull "$WEB_IMAGE"
 else
   echo "[deploy] Build images on VPS (no registry)"
-  if [[ "$WEB_API_BASE_OVERRIDE" -eq 0 ]]; then
-    extract_web_api_base
-  fi
+  extract_web_build_env
   if [[ -z "$WEB_API_BASE" ]]; then
     echo "NEXT_PUBLIC_WEB_API_BASE is required for local Web image build; set it in ${WEB_ENV_FILE} or pass --web-api-base <https-url>." >&2
     exit 1
   fi
-  IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" \
-    NEXT_PUBLIC_WEB_API_BASE="$WEB_API_BASE" PUSH_IMAGES=0 \
-    bash "$ROOT_DIR/ops/cloud-build.sh"
+  WEB_BUILD_ENV=(
+    "IMAGE_TAG=$TAG"
+    "IMAGE_PREFIX=$IMAGE_PREFIX"
+    "PUSH_IMAGES=0"
+    "NEXT_PUBLIC_WEB_API_BASE=$WEB_API_BASE"
+  )
+  for key in "${WEB_BUILD_PUBLIC_KEYS[@]}"; do
+    [[ "$key" == NEXT_PUBLIC_WEB_API_BASE ]] && continue
+    value=${WEB_BUILD_PUBLIC_ENV[$key]:-}
+    [[ -n "$value" ]] && WEB_BUILD_ENV+=("$key=$value")
+  done
+  env "${WEB_BUILD_ENV[@]}" bash "$ROOT_DIR/ops/cloud-build.sh"
 fi
 
 if [[ -n "$NET_NAME" ]]; then

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #       [--env .env.api] [--web-env .env.web] \
 #       [--web-api-base https://api.example.com] \
 #       [--skip-migrate] [--seed-admin] [--uploads /var/lib/sogecon/uploads] \
-#       [--api-health URL] [--web-health URL]
+#       [--network sogecon_net] [--api-health URL] [--web-health URL]
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
@@ -20,7 +20,7 @@ IMAGE_PREFIX="${IMAGE_PREFIX_DEFAULT}"
 ENV_FILE=".env.api"
 WEB_ENV_FILE=".env.web"
 UPLOADS_DIR="/var/lib/sogecon/uploads"
-NET_NAME=""
+NET_NAME="sogecon_net"
 DO_MIGRATE=1
 DO_SEED_ADMIN=0
 API_HEALTH=""

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Usage:
 #   bash scripts/deploy-vps.sh -t <tag> [--prefix local/sogecon] [--local-build|--pull-images] \
 #       [--env .env.api] [--web-env .env.web] \
+#       [--web-api-base https://api.example.com] \
 #       [--skip-migrate] [--seed-admin] [--uploads /var/lib/sogecon/uploads] \
 #       [--api-health URL] [--web-health URL]
 
@@ -24,6 +25,8 @@ DO_MIGRATE=1
 DO_SEED_ADMIN=0
 API_HEALTH=""
 WEB_HEALTH=""
+WEB_API_BASE=""
+WEB_API_BASE_OVERRIDE=0
 HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-60}
 PULL_IMAGES=0
 
@@ -41,6 +44,8 @@ while [[ $# -gt 0 ]]; do
       ENV_FILE="$2"; shift 2;;
     -w|--web-env)
       WEB_ENV_FILE="$2"; shift 2;;
+    --web-api-base)
+      WEB_API_BASE="$2"; WEB_API_BASE_OVERRIDE=1; shift 2;;
     --uploads)
       UPLOADS_DIR="$2"; shift 2;;
     --network)
@@ -59,6 +64,32 @@ while [[ $# -gt 0 ]]; do
       echo "Unknown arg: $1" >&2; exit 1;;
   esac
 done
+
+if [[ ! "${HEALTH_TIMEOUT}" =~ ^[0-9]+$ || "${HEALTH_TIMEOUT}" =~ ^0+$ ]]; then
+  echo "HEALTH_TIMEOUT must be a positive integer number of seconds." >&2
+  exit 1
+fi
+
+extract_web_api_base() {
+  local line key value
+  [[ -f "$WEB_ENV_FILE" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=${line%$'\r'}
+    if [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=(.*)$ ]]; then
+      key=${BASH_REMATCH[2]}
+      [[ "$key" == NEXT_PUBLIC_WEB_API_BASE ]] || continue
+      value=${BASH_REMATCH[3]}
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
+      case "${value}" in
+        \"*\") value=${value:1:${#value}-2} ;;
+        \'*\') value=${value:1:${#value}-2} ;;
+      esac
+      WEB_API_BASE="$value"
+    fi
+  done <"$WEB_ENV_FILE"
+}
 
 if [[ -z "$TAG" ]]; then
   echo "-t|--tag <tag> is required (e.g., a commit SHA)" >&2
@@ -81,7 +112,15 @@ if [[ "$PULL_IMAGES" -eq 1 ]]; then
   docker pull "$WEB_IMAGE"
 else
   echo "[deploy] Build images on VPS (no registry)"
-  IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" PUSH_IMAGES=0 \
+  if [[ "$WEB_API_BASE_OVERRIDE" -eq 0 ]]; then
+    extract_web_api_base
+  fi
+  if [[ -z "$WEB_API_BASE" ]]; then
+    echo "NEXT_PUBLIC_WEB_API_BASE is required for local Web image build; set it in ${WEB_ENV_FILE} or pass --web-api-base <https-url>." >&2
+    exit 1
+  fi
+  IMAGE_TAG="$TAG" IMAGE_PREFIX="$IMAGE_PREFIX" \
+    NEXT_PUBLIC_WEB_API_BASE="$WEB_API_BASE" PUSH_IMAGES=0 \
     bash "$ROOT_DIR/ops/cloud-build.sh"
 fi
 

--- a/scripts/lhci-debug.sh
+++ b/scripts/lhci-debug.sh
@@ -12,7 +12,6 @@ URL=http://localhost:3000/
 export NEXT_PUBLIC_RELAX_CSP=1
 export NEXT_PUBLIC_ENABLE_SW=0
 export NEXT_PUBLIC_WEB_API_BASE=http://localhost:3000
-export WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1
 
 # Start server if not running
 if ! curl -sSf http://localhost:3000 >/dev/null 2>&1; then

--- a/scripts/lhci-debug.sh
+++ b/scripts/lhci-debug.sh
@@ -12,6 +12,7 @@ URL=http://localhost:3000/
 export NEXT_PUBLIC_RELAX_CSP=1
 export NEXT_PUBLIC_ENABLE_SW=0
 export NEXT_PUBLIC_WEB_API_BASE=http://localhost:3000
+export WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1
 
 # Start server if not running
 if ! curl -sSf http://localhost:3000 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Enforce the production Web API-base contract from every real `next build` entry point.
- Add server-only `API_INTERNAL_URL`, image healthchecks, non-root filesystem/runtime guards, and API-before-Web health sequencing.
- Add deterministic cloud-start command-contract regressions, CI gates, runbook/architecture updates, and D6 evidence records.

## Verification

- Focused Web validator/resolver tests: 20 passed.
- Managed mock API + production Web automatic E2E: 5 files / 11 tests passed.
- API/Web static gates and disposable PostgreSQL/container/TLS/browser readback recorded in `docs/plan_d6_prod_build_container_guards_260802.md` and `docs/dev_log_260802.md`.
- Visible push CTA is recorded INCONCLUSIVE because Chrome incognito rejected Push API registration after explicit notification permission grant.

Closes #253
Closes #257