### PR TITLE
fix(web): 게시글 React Query key authority 보정 (#263)

### DIFF
--- a/apps/web/__tests__/query-keys.test.ts
+++ b/apps/web/__tests__/query-keys.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { adminPostKeys, normalizeListPostsParams, postKeys } from '../lib/query-keys';
+
+describe('normalizeListPostsParams', () => {
+  it('uses categories array for multi-category list requests', () => {
+    expect(
+      normalizeListPostsParams({
+        limit: 20,
+        categories: ['news', 'notice'],
+      }),
+    ).toEqual({
+      limit: 20,
+      categories: ['news', 'notice'],
+    });
+  });
+
+  it('treats identical API params the same regardless of caller screen', () => {
+    const home = normalizeListPostsParams({ category: 'notice', limit: 5 });
+    const feed = normalizeListPostsParams({ category: 'notice', limit: 5 });
+    expect(home).toEqual(feed);
+    expect(postKeys.list({ category: 'notice', limit: 5 })).toEqual(
+      postKeys.list({ category: 'notice', limit: 5 }),
+    );
+  });
+
+  it('does not encode UI-only category=all when API uses categories', () => {
+    const boardAll = normalizeListPostsParams({
+      limit: 10,
+      categories: ['congrats', 'discussion', 'question', 'share'],
+    });
+    expect(boardAll).toEqual({
+      limit: 10,
+      categories: ['congrats', 'discussion', 'question', 'share'],
+    });
+    expect(boardAll).not.toHaveProperty('category');
+  });
+});
+
+describe('postKeys authority boundaries', () => {
+  it('separates public detail from admin preview keys', () => {
+    expect(postKeys.publicDetail(42)).toEqual(['posts', 'detail', 'public', 42]);
+    expect(adminPostKeys.preview(42)).toEqual(['admin-posts', 'preview', 42]);
+    expect(postKeys.publicDetail(42)).not.toEqual(adminPostKeys.preview(42));
+  });
+
+  it('uses API params for infinite list keys without page offset', () => {
+    expect(
+      postKeys.infiniteList({
+        limit: 10,
+        categories: ['congrats', 'discussion', 'question', 'share'],
+        q: 'hello',
+      }),
+    ).toEqual([
+      'posts',
+      'infinite-list',
+      {
+        limit: 10,
+        q: 'hello',
+        categories: ['congrats', 'discussion', 'question', 'share'],
+      },
+    ]);
+  });
+});

--- a/apps/web/app/admin/posts/[id]/edit/page.tsx
+++ b/apps/web/app/admin/posts/[id]/edit/page.tsx
@@ -43,7 +43,7 @@ export default function EditPostPage() {
   });
 
   const { data: post, isLoading, isError } = useQuery({
-    queryKey: postKeys.detail(postId),
+    queryKey: adminPostKeys.preview(postId),
     queryFn: () => getAdminPostPreview(postId),
     enabled: canLoadPost(canManagePosts, postId),
   });

--- a/apps/web/app/admin/posts/[id]/preview/page.tsx
+++ b/apps/web/app/admin/posts/[id]/preview/page.tsx
@@ -7,13 +7,13 @@ import { AdminAuthState } from '../../../../../components/admin-auth-state';
 import { PostDetailContent } from '../../../../../components/post-detail-content';
 import { useAuth } from '../../../../../hooks/useAuth';
 import { ApiError } from '../../../../../lib/api';
-import { postKeys } from '../../../../../lib/query-keys';
+import { adminPostKeys } from '../../../../../lib/query-keys';
 import { hasPermissionSession } from '../../../../../lib/rbac';
 import { getAdminPostPreview } from '../../../../../services/posts';
 
 function PreviewBody({ postId, showAdminActions }: { postId: number; showAdminActions: boolean }) {
   const query = useQuery({
-    queryKey: postKeys.detail(postId),
+    queryKey: adminPostKeys.preview(postId),
     queryFn: () => getAdminPostPreview(postId),
     enabled: Number.isFinite(postId),
     retry: false,

--- a/apps/web/app/board/[id]/edit/page.tsx
+++ b/apps/web/app/board/[id]/edit/page.tsx
@@ -52,7 +52,7 @@ export default function BoardEditPage() {
   const postId = Number(params.id);
 
   const { data: post, isLoading, isError } = useQuery({
-    queryKey: postKeys.detail(postId),
+    queryKey: postKeys.publicDetail(postId),
     queryFn: () => getPost(postId),
     enabled: !Number.isNaN(postId),
   });

--- a/apps/web/app/board/page.tsx
+++ b/apps/web/app/board/page.tsx
@@ -259,8 +259,18 @@ function BoardPageInner() {
     return () => window.clearTimeout(handle);
   }, [search]);
 
+  const listParams = useMemo(() => {
+    const baseParams = {
+      limit: PAGE_SIZE,
+      ...(debouncedSearch ? { q: debouncedSearch.slice(0, 100) } : {}),
+    };
+    return category === 'all'
+      ? { ...baseParams, categories: [...BOARD_POST_CATEGORIES] }
+      : { ...baseParams, category };
+  }, [category, debouncedSearch]);
+
   const query = useInfiniteQuery<Post[]>({
-    queryKey: postKeys.list('board', { category, q: debouncedSearch || undefined }),
+    queryKey: postKeys.infiniteList(listParams),
     initialPageParam: 0,
     queryFn: ({ pageParam }) => {
       const baseParams = {

--- a/apps/web/app/posts/page.tsx
+++ b/apps/web/app/posts/page.tsx
@@ -129,8 +129,19 @@ export default function PostsPage() {
     setCategory(urlCategory);
   }, [urlCategory]);
 
+  const listParams = useMemo(() => {
+    const base = {
+      limit: 20,
+      offset: 0,
+    } as const;
+    if (category === 'all') {
+      return { ...base, categories: ['notice', 'news'] as const };
+    }
+    return { ...base, category };
+  }, [category]);
+
   const query = useQuery<Post[]>({
-    queryKey: postKeys.list('feed', { limit: 20, offset: 0, category }),
+    queryKey: postKeys.list(listParams),
     queryFn: () => {
       if (category === 'all') {
         return listPosts({ limit: 20, categories: ['notice', 'news'] });

--- a/apps/web/components/home/desktop-cards.tsx
+++ b/apps/web/components/home/desktop-cards.tsx
@@ -202,14 +202,14 @@ function NewsColumn({ query }: { query: ReturnType<typeof useNewsQuery> }) {
 
 function useNoticeQuery() {
   return useQuery<Post[]>({
-    queryKey: postKeys.list('home', { category: 'notice', limit: NOTICE_LIMIT }),
+    queryKey: postKeys.list({ category: 'notice', limit: NOTICE_LIMIT }),
     queryFn: () => listPosts({ category: 'notice', limit: NOTICE_LIMIT }),
   });
 }
 
 function useNewsQuery() {
   return useQuery<Post[]>({
-    queryKey: postKeys.list('home', { category: 'news', limit: NEWS_LIMIT }),
+    queryKey: postKeys.list({ category: 'news', limit: NEWS_LIMIT }),
     queryFn: () => listPosts({ category: 'news', limit: NEWS_LIMIT }),
   });
 }

--- a/apps/web/components/home/notice-list.tsx
+++ b/apps/web/components/home/notice-list.tsx
@@ -29,7 +29,7 @@ function formatDate(dateStr: string): string {
 
 export function HomeNoticeList() {
   const { data: posts, isLoading, isError } = useQuery<Post[]>({
-    queryKey: postKeys.list('home', { category: 'notice', limit: 5 }),
+    queryKey: postKeys.list({ category: 'notice', limit: 5 }),
     queryFn: () => listPosts({ category: 'notice', limit: 5 })
   });
 

--- a/apps/web/lib/query-keys.ts
+++ b/apps/web/lib/query-keys.ts
@@ -1,17 +1,48 @@
-/** 게시글 React Query key authority (D4 #263). */
+/** 게시글 React Query key authority (#263). */
+
+import type { ListPostsParams } from '../services/posts';
+
+export function normalizeListPostsParams(
+  params: ListPostsParams,
+): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
+
+  if (params.limit != null) {
+    normalized.limit = params.limit;
+  }
+  if (params.offset != null) {
+    normalized.offset = params.offset;
+  }
+
+  const query = params.q?.trim();
+  if (query) {
+    normalized.q = query;
+  }
+
+  if (params.categories && params.categories.length > 0) {
+    normalized.categories = [...params.categories].sort();
+  } else if (params.category) {
+    normalized.category = params.category;
+  }
+
+  return normalized;
+}
 
 export const postKeys = {
   all: ['posts'] as const,
   lists: () => [...postKeys.all, 'list'] as const,
-  list: (
-    scope: 'home' | 'feed' | 'board',
-    params: Record<string, unknown>,
-  ) => [...postKeys.lists(), scope, params] as const,
+  list: (params: ListPostsParams) =>
+    [...postKeys.lists(), normalizeListPostsParams(params)] as const,
+  infiniteLists: () => [...postKeys.all, 'infinite-list'] as const,
+  infiniteList: (params: ListPostsParams) =>
+    [...postKeys.infiniteLists(), normalizeListPostsParams(params)] as const,
   details: () => [...postKeys.all, 'detail'] as const,
-  detail: (id: number) => [...postKeys.details(), id] as const,
+  publicDetail: (id: number) => [...postKeys.details(), 'public', id] as const,
 };
 
 export const adminPostKeys = {
   all: ['admin-posts'] as const,
   list: (params: unknown) => [...adminPostKeys.all, 'list', params] as const,
+  previews: () => [...adminPostKeys.all, 'preview'] as const,
+  preview: (id: number) => [...adminPostKeys.previews(), id] as const,
 };

--- a/apps/web/services/posts.ts
+++ b/apps/web/services/posts.ts
@@ -9,7 +9,7 @@ export type ListPostsParams = {
   limit?: number;
   offset?: number;
   category?: string;
-  categories?: string[];
+  categories?: readonly string[];
   q?: string;
 };
 

--- a/docs/dev_log_260811.md
+++ b/docs/dev_log_260811.md
@@ -1,4 +1,5 @@
 # 2026-08-11
 
 - Changed: 게시글 React Query key를 API 요청 shape 기준으로 정규화하고 public detail/admin preview authority 분리 (#263)
+- Changed: `ListPostsParams.categories`를 `readonly string[]`로 정리해 posts 페이지 key 타입 오류 제거 (#263)
 - Ops: #245 D4/D7 closeout, #258/#262 이슈 정리 (#263은 잔존 결함 보정 전까지 OPEN 유지)

--- a/docs/dev_log_260811.md
+++ b/docs/dev_log_260811.md
@@ -1,0 +1,4 @@
+# 2026-08-11
+
+- Changed: 게시글 React Query key를 API 요청 shape 기준으로 정규화하고 public detail/admin preview authority 분리 (#263)
+- Ops: #245 D4/D7 closeout, #258/#262 이슈 정리 (#263은 잔존 결함 보정 전까지 OPEN 유지)


### PR DESCRIPTION
## Summary

D4 #263 잔존 결함 보정: React Query cache identity를 **화면 scope**가 아니라 **API 요청 shape** 기준으로 정규화한다.

- `normalizeListPostsParams()` + `postKeys.list()` / `postKeys.infiniteList()`
- 공개 상세 `postKeys.publicDetail(id)` ↔ 관리자 preview `adminPostKeys.preview(id)` 분리
- `/posts`·`/board` 목록 key가 실제 `listPosts()` 인자(`categories` vs UI `all`)와 일치

## Related

- Parent: #245 D4
- Closes #263
- #258 / #262는 별도 closeout 완료 (이 PR은 #263만 대상)

## Test plan

- [x] `pnpm -C apps/web test` (313 passed)
- [x] `apps/web/__tests__/query-keys.test.ts` — 동일 API params 동일 key, public/admin detail 분리
- [x] `admin-post-preview`, `board-edit`, `admin-post-edit` 회귀


Made with [Cursor](https://cursor.com)