### PR TITLE
feat: D9 API 레이어·에러 계약·signup 검색

### DIFF
--- a/apps/api/error_messages.py
+++ b/apps/api/error_messages.py
@@ -13,6 +13,17 @@ USER_FACING_DETAILS: dict[str, str] = {
     "super_admin_required": "최고 운영자 권한이 필요합니다.",
     "member_required": "회원 권한이 필요합니다.",
     "member_not_found": "회원 정보를 찾을 수 없습니다.",
+    "member_not_active": (
+        "아직 이용할 수 없는 계정입니다. 문의가 필요하면 사무국에 연락해 주세요."
+    ),
+    "member_pending_approval": (
+        "동문회 사무국에서 가입 신청을 확인 중입니다. "
+        "승인 안내를 받은 뒤 활성화를 진행해 주세요."
+    ),
+    "invalid_or_expired_activation_token": (
+        "활성화 링크가 올바르지 않거나 만료되었습니다."
+    ),
+    "activation_already_used": "이미 사용된 활성화 링크입니다.",
     "post_not_found": "게시글을 찾을 수 없습니다.",
     "event_not_found": "행사를 찾을 수 없습니다.",
     "validation_error": "입력값을 확인해 주세요.",

--- a/apps/api/error_messages.py
+++ b/apps/api/error_messages.py
@@ -1,0 +1,72 @@
+"""API 오류 code → 사용자 노출 detail (Web error-map과 정렬)."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+# machine-readable code → 사용자에게 보여도 되는 한국어 detail
+USER_FACING_DETAILS: dict[str, str] = {
+    "login_failed": "학번 또는 비밀번호가 올바르지 않습니다.",
+    "unauthorized": "로그인이 필요합니다.",
+    "admin_permission_required": "이 작업을 수행할 운영 권한이 없습니다.",
+    "admin_required": "운영자 권한이 필요합니다.",
+    "super_admin_required": "최고 운영자 권한이 필요합니다.",
+    "member_required": "회원 권한이 필요합니다.",
+    "member_not_found": "회원 정보를 찾을 수 없습니다.",
+    "post_not_found": "게시글을 찾을 수 없습니다.",
+    "event_not_found": "행사를 찾을 수 없습니다.",
+    "validation_error": "입력값을 확인해 주세요.",
+    "rate_limit_exceeded": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+    "not_found": "요청한 경로를 찾을 수 없습니다.",
+    "method_not_allowed": "허용되지 않은 요청 방식입니다.",
+    "internal_error": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    "http_error": "요청을 처리하지 못했습니다.",
+}
+
+_FRAMEWORK_DETAIL_CODES: dict[str, tuple[str, str]] = {
+    "not found": ("not_found", USER_FACING_DETAILS["not_found"]),
+    "method not allowed": (
+        "method_not_allowed",
+        USER_FACING_DETAILS["method_not_allowed"],
+    ),
+}
+
+
+def looks_like_stable_code(text: str) -> bool:
+    return " " not in text and text.replace("_", "").isalnum()
+
+
+_STATUS_FALLBACK_CODES: dict[int, str] = {
+    HTTPStatus.NOT_FOUND.value: "not_found",
+    HTTPStatus.METHOD_NOT_ALLOWED.value: "method_not_allowed",
+    HTTPStatus.TOO_MANY_REQUESTS.value: "rate_limit_exceeded",
+    HTTPStatus.UNPROCESSABLE_ENTITY.value: "validation_error",
+}
+
+
+def user_detail_for_code(code: str, *, status: int) -> str:
+    if code in USER_FACING_DETAILS:
+        return USER_FACING_DETAILS[code]
+    status_code = _STATUS_FALLBACK_CODES.get(status)
+    if status_code is not None:
+        return USER_FACING_DETAILS[status_code]
+    if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return USER_FACING_DETAILS["internal_error"]
+    return USER_FACING_DETAILS["http_error"]
+
+
+def code_and_detail_from_http_detail(
+    detail: object,
+    *,
+    status: int,
+) -> tuple[str, str]:
+    if isinstance(detail, str) and detail.strip():
+        text = detail.strip()
+        lowered = text.lower()
+        framework = _FRAMEWORK_DETAIL_CODES.get(lowered)
+        if framework is not None:
+            return framework
+        if looks_like_stable_code(text):
+            return text, user_detail_for_code(text, status=status)
+        return "http_error", text
+    return "http_error", user_detail_for_code("http_error", status=status)

--- a/apps/api/error_messages.py
+++ b/apps/api/error_messages.py
@@ -55,11 +55,30 @@ def user_detail_for_code(code: str, *, status: int) -> str:
     return USER_FACING_DETAILS["http_error"]
 
 
+def public_problem_code_and_detail(
+    *,
+    status: int,
+    code: str,
+    detail: str | None = None,
+) -> tuple[str, str]:
+    """외부 Problem Details용 code/detail. 5xx는 항상 internal_error로 통일한다."""
+    if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return "internal_error", USER_FACING_DETAILS["internal_error"]
+    resolved_detail = (
+        detail
+        if detail and detail != code
+        else user_detail_for_code(code, status=status)
+    )
+    return code, resolved_detail
+
+
 def code_and_detail_from_http_detail(
     detail: object,
     *,
     status: int,
 ) -> tuple[str, str]:
+    if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return public_problem_code_and_detail(status=status, code="internal_error")
     if isinstance(detail, str) and detail.strip():
         text = detail.strip()
         lowered = text.lower()
@@ -67,6 +86,14 @@ def code_and_detail_from_http_detail(
         if framework is not None:
             return framework
         if looks_like_stable_code(text):
-            return text, user_detail_for_code(text, status=status)
-        return "http_error", text
-    return "http_error", user_detail_for_code("http_error", status=status)
+            return public_problem_code_and_detail(
+                status=status,
+                code=text,
+                detail=user_detail_for_code(text, status=status),
+            )
+        return public_problem_code_and_detail(
+            status=status,
+            code="http_error",
+            detail=text,
+        )
+    return public_problem_code_and_detail(status=status, code="http_error")

--- a/apps/api/error_messages.py
+++ b/apps/api/error_messages.py
@@ -21,7 +21,7 @@ USER_FACING_DETAILS: dict[str, str] = {
         "승인 안내를 받은 뒤 활성화를 진행해 주세요."
     ),
     "invalid_or_expired_activation_token": (
-        "활성화 링크가 올바르지 않거나 만료되었습니다."
+        "활성화 링크가 올바르지 않거나 만료되었습니다."  # nosec B105
     ),
     "activation_already_used": "이미 사용된 활성화 링크입니다.",
     "post_not_found": "게시글을 찾을 수 없습니다.",

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
 from fastapi import FastAPI, Request
@@ -85,6 +85,49 @@ HTTP_STATUS_SERVER_ERROR = 500
 HTTP_STATUS_TOO_MANY_REQUESTS = 429
 HTTP_STATUS_UNPROCESSABLE_ENTITY = 422
 
+_PROBLEM_ERROR_RESPONSE_REF: dict[str, str] = {
+    "$ref": "#/components/responses/ProblemDetailsError",
+}
+_PROBLEM_ERROR_STATUSES = frozenset(
+    {"400", "401", "403", "404", "409", "422", "429", "500"}
+)
+_OPENAPI_HTTP_METHODS = frozenset(
+    {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+)
+_LEGACY_OPENAPI_ERROR_SCHEMAS = frozenset(
+    {"HTTPValidationError", "ValidationError"}
+)
+
+
+def _wire_operation_problem_responses(schema: dict[str, object]) -> None:
+    paths = cast(dict[str, Any], schema.get("paths"))
+    if not paths:
+        return
+    for path_item_any in paths.values():
+        path_item = cast(dict[str, Any], path_item_any)
+        for method, operation_any in path_item.items():
+            if method not in _OPENAPI_HTTP_METHODS:
+                continue
+            operation = cast(dict[str, Any], operation_any)
+            responses_obj = operation.get("responses")
+            if not isinstance(responses_obj, dict):
+                responses_obj = {}
+                operation["responses"] = responses_obj
+            responses = cast(dict[str, Any], responses_obj)
+            for status in sorted(_PROBLEM_ERROR_STATUSES):
+                responses[status] = dict(_PROBLEM_ERROR_RESPONSE_REF)
+
+
+def _prune_legacy_openapi_error_schemas(schema: dict[str, object]) -> None:
+    components = cast(dict[str, Any], schema.get("components"))
+    if not components:
+        return
+    schemas = cast(dict[str, Any], components.get("schemas"))
+    if not schemas:
+        return
+    for name in _LEGACY_OPENAPI_ERROR_SCHEMAS:
+        schemas.pop(name, None)
+
 
 def _problem_json_response(
     request: Request,
@@ -142,6 +185,8 @@ def _install_openapi_problem_details() -> None:
                 }
             },
         }
+        _wire_operation_problem_responses(schema)
+        _prune_legacy_openapi_error_schemas(schema)
         app.openapi_schema = schema
         return schema
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -26,6 +26,7 @@ from .config import get_settings
 from .db import dispose_engine
 from .error_messages import (
     code_and_detail_from_http_detail,
+    public_problem_code_and_detail,
     user_detail_for_code,
 )
 from .errors import ApiError
@@ -354,16 +355,17 @@ def _status_for(exc: ApiError) -> int:
 @app.exception_handler(ApiError)
 async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
     status = _status_for(exc)
-    detail = (
-        exc.detail
-        if exc.detail and exc.detail != exc.code
-        else user_detail_for_code(exc.code, status=status)
+    internal_detail = exc.detail or exc.code
+    public_code, public_detail = public_problem_code_and_detail(
+        status=status,
+        code=exc.code,
+        detail=internal_detail if internal_detail != exc.code else None,
     )
     request_id = getattr(request.state, "request_id", None)
     body = problem_details_body(
         status=status,
-        code=exc.code,
-        detail=detail,
+        code=public_code,
+        detail=public_detail,
         request_id=request_id,
     )
     level = (
@@ -379,7 +381,7 @@ async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
         http_status=status,
         method=request.method,
         path=request.url.path,
-        detail=body["detail"],
+        detail=internal_detail,
         request_id=request_id,
     )
     if status >= HTTP_STATUS_SERVER_ERROR:
@@ -390,7 +392,7 @@ async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
                 "path": request.url.path,
                 "method": request.method,
                 "request_id": request_id,
-                "detail": body["detail"],
+                "detail": internal_detail,
                 "level": "error",
             }
         )
@@ -421,13 +423,38 @@ async def _handle_http_exception(
         exc.detail,
         status=exc.status_code,
     )
+    request_id = getattr(request.state, "request_id", None)
+    if exc.status_code >= HTTP_STATUS_SERVER_ERROR:
+        internal_detail = str(exc.detail)
+        log_json(
+            error_logger,
+            logging.ERROR,
+            "http_exception",
+            code=code,
+            http_status=exc.status_code,
+            method=request.method,
+            path=request.url.path,
+            detail=internal_detail,
+            request_id=request_id,
+        )
+        emit_error_event(
+            {
+                "code": code,
+                "status": exc.status_code,
+                "path": request.url.path,
+                "method": request.method,
+                "request_id": request_id,
+                "detail": internal_detail,
+                "level": "error",
+            }
+        )
     return _problem_json_response(
         request,
         problem_details_body(
             status=exc.status_code,
             code=code,
             detail=detail,
-            request_id=getattr(request.state, "request_id", None),
+            request_id=request_id,
         ),
         status=exc.status_code,
         headers=_http_exception_headers(exc),

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,14 +7,15 @@ from pathlib import Path
 from typing import Literal, cast
 from urllib.parse import urlsplit
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 from sentry_sdk import get_current_scope
-from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -23,10 +24,19 @@ from starlette.types import ASGIApp
 
 from .config import get_settings
 from .db import dispose_engine
+from .error_messages import (
+    code_and_detail_from_http_detail,
+    user_detail_for_code,
+)
 from .errors import ApiError
 from .logging_utils import emit_error_event, log_json, reset_request_id, set_request_id
 from .observability import init_sentry
-from .problem_details import code_from_http_detail, problem_details_body
+from .problem_details import (
+    ProblemDetailsResponse,
+    ValidationErrorItem,
+    problem_details_body,
+    validation_problem,
+)
 from .ratelimit import create_limiter
 from .routers import (
     admin_events,
@@ -72,6 +82,71 @@ request_logger = logging.getLogger("apps.api.request")
 error_logger = logging.getLogger("apps.api.error")
 
 HTTP_STATUS_SERVER_ERROR = 500
+HTTP_STATUS_TOO_MANY_REQUESTS = 429
+HTTP_STATUS_UNPROCESSABLE_ENTITY = 422
+
+
+def _problem_json_response(
+    request: Request,
+    body: dict[str, object],
+    *,
+    status: int,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    request_id = getattr(request.state, "request_id", None)
+    if request_id and "request_id" not in body:
+        body = {**body, "request_id": request_id}
+    response = JSONResponse(body, status_code=status, headers=headers)
+    if request_id:
+        response.headers.setdefault("X-Request-Id", request_id)
+    return response
+
+
+def _install_openapi_problem_details() -> None:
+    def custom_openapi() -> dict[str, object]:
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            routes=app.routes,
+        )
+        components = schema.setdefault("components", {})
+        schemas = components.setdefault("schemas", {})
+        validation_item_schema = ValidationErrorItem.model_json_schema(
+            ref_template="#/components/schemas/{model}",
+        )
+        validation_item_schema.pop("$defs", None)
+        schemas["ValidationErrorItem"] = validation_item_schema
+        problem_schema = ProblemDetailsResponse.model_json_schema(
+            ref_template="#/components/schemas/{model}",
+        )
+        problem_schema.pop("$defs", None)
+        errors_prop = cast(
+            dict[str, object],
+            problem_schema.get("properties", {}).get("errors", {}),
+        )
+        any_of = errors_prop.get("anyOf")
+        if isinstance(any_of, list) and any_of:
+            array_schema = cast(dict[str, object], any_of[0])
+            array_schema["items"] = {
+                "$ref": "#/components/schemas/ValidationErrorItem",
+            }
+        schemas["ProblemDetails"] = problem_schema
+        responses = components.setdefault("responses", {})
+        responses["ProblemDetailsError"] = {
+            "description": "Problem Details error response",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ProblemDetails"},
+                }
+            },
+        }
+        app.openapi_schema = schema
+        return schema
+
+    setattr(app, "openapi", custom_openapi)
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -174,29 +249,12 @@ app.add_middleware(SecurityHeadersMiddleware)
 limiter = create_limiter(settings)
 app.state.limiter = limiter
 def _rl_handler(request: Request, exc: Exception) -> Response:
-    if isinstance(exc, RateLimitExceeded):
-        response = _rate_limit_exceeded_handler(request, exc)
-        request_id = getattr(request.state, "request_id", None)
-        if request_id:
-            response.headers.setdefault("X-Request-Id", request_id)
-        log_json(
-            error_logger,
-            logging.WARNING,
-            "rate_limit_exceeded",
-            code="rate_limit_exceeded",
-            http_status=response.status_code,
-            method=request.method,
-            path=request.url.path,
-            detail=str(exc),
-            request_id=request_id,
-        )
-        return response
     request_id = getattr(request.state, "request_id", None)
     status = HTTP_STATUS_SERVER_ERROR
     body = problem_details_body(
         status=status,
         code="internal_error",
-        detail="Unhandled error",
+        detail=user_detail_for_code("internal_error", status=status),
         request_id=request_id,
     )
     log_json(
@@ -251,11 +309,16 @@ def _status_for(exc: ApiError) -> int:
 @app.exception_handler(ApiError)
 async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
     status = _status_for(exc)
+    detail = (
+        exc.detail
+        if exc.detail and exc.detail != exc.code
+        else user_detail_for_code(exc.code, status=status)
+    )
     request_id = getattr(request.state, "request_id", None)
     body = problem_details_body(
         status=status,
         code=exc.code,
-        detail=str(exc) or exc.code,
+        detail=detail,
         request_id=request_id,
     )
     level = (
@@ -291,27 +354,39 @@ async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
         response.headers.setdefault("X-Request-Id", request_id)
     return response
 
+
 # Keep a reference for static analyzers (decorator registers this handler)
 _ = _handle_api_error
 
 
-@app.exception_handler(HTTPException)
+def _http_exception_headers(
+    exc: StarletteHTTPException,
+) -> dict[str, str] | None:
+    if not exc.headers:
+        return None
+    return {str(key): str(value) for key, value in exc.headers.items()}
+
+
+@app.exception_handler(StarletteHTTPException)
 async def _handle_http_exception(
     request: Request,
-    exc: HTTPException,
+    exc: StarletteHTTPException,
 ) -> JSONResponse:
-    request_id = getattr(request.state, "request_id", None)
-    code, detail = code_from_http_detail(exc.detail)
-    body = problem_details_body(
+    code, detail = code_and_detail_from_http_detail(
+        exc.detail,
         status=exc.status_code,
-        code=code,
-        detail=detail,
-        request_id=request_id,
     )
-    response = JSONResponse(body, status_code=exc.status_code)
-    if request_id:
-        response.headers.setdefault("X-Request-Id", request_id)
-    return response
+    return _problem_json_response(
+        request,
+        problem_details_body(
+            status=exc.status_code,
+            code=code,
+            detail=detail,
+            request_id=getattr(request.state, "request_id", None),
+        ),
+        status=exc.status_code,
+        headers=_http_exception_headers(exc),
+    )
 
 
 @app.exception_handler(RequestValidationError)
@@ -320,22 +395,46 @@ async def _handle_validation_error(
     exc: RequestValidationError,
 ) -> JSONResponse:
     request_id = getattr(request.state, "request_id", None)
-    status = 422
-    body = problem_details_body(
-        status=status,
-        code="validation_error",
-        detail="validation failed",
-        request_id=request_id,
-    )
-    body["detail"] = exc.errors()
-    response = JSONResponse(body, status_code=status)
+    body = validation_problem(errors=list(exc.errors()), request_id=request_id)
+    response = JSONResponse(body, status_code=HTTP_STATUS_UNPROCESSABLE_ENTITY)
     if request_id:
         response.headers.setdefault("X-Request-Id", request_id)
     return response
 
 
+@app.exception_handler(RateLimitExceeded)
+async def _handle_rate_limit(
+    request: Request,
+    exc: RateLimitExceeded,
+) -> JSONResponse:
+    request_id = getattr(request.state, "request_id", None)
+    status = HTTP_STATUS_TOO_MANY_REQUESTS
+    log_json(
+        error_logger,
+        logging.WARNING,
+        "rate_limit_exceeded",
+        code="rate_limit_exceeded",
+        http_status=status,
+        method=request.method,
+        path=request.url.path,
+        detail=str(exc),
+        request_id=request_id,
+    )
+    return _problem_json_response(
+        request,
+        problem_details_body(
+            status=status,
+            code="rate_limit_exceeded",
+            detail=user_detail_for_code("rate_limit_exceeded", status=status),
+            request_id=request_id,
+        ),
+        status=status,
+    )
+
+
 _ = _handle_http_exception
 _ = _handle_validation_error
+_ = _handle_rate_limit
 
 
 app.include_router(members.router)
@@ -357,3 +456,5 @@ app.include_router(admin_hero.router)
 app.include_router(admin_members.router)
 app.include_router(admin_signup_requests.router)
 app.include_router(admin_profile_changes.router)
+
+_install_openapi_problem_details()

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Literal, cast
 from urllib.parse import urlsplit
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from sentry_sdk import get_current_scope
@@ -25,6 +26,7 @@ from .db import dispose_engine
 from .errors import ApiError
 from .logging_utils import emit_error_event, log_json, reset_request_id, set_request_id
 from .observability import init_sentry
+from .problem_details import code_from_http_detail, problem_details_body
 from .ratelimit import create_limiter
 from .routers import (
     admin_events,
@@ -191,9 +193,12 @@ def _rl_handler(request: Request, exc: Exception) -> Response:
         return response
     request_id = getattr(request.state, "request_id", None)
     status = HTTP_STATUS_SERVER_ERROR
-    body = {"detail": "Unhandled error", "code": "internal_error"}
-    if request_id:
-        body["request_id"] = request_id
+    body = problem_details_body(
+        status=status,
+        code="internal_error",
+        detail="Unhandled error",
+        request_id=request_id,
+    )
     log_json(
         error_logger,
         logging.ERROR,
@@ -247,15 +252,12 @@ def _status_for(exc: ApiError) -> int:
 async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
     status = _status_for(exc)
     request_id = getattr(request.state, "request_id", None)
-    body = {
-        "type": "about:blank",  # RFC7807 최소 구현
-        "title": "",
-        "status": status,
-        "detail": str(exc) or exc.code,
-        "code": exc.code,
-    }
-    if request_id:
-        body["request_id"] = request_id
+    body = problem_details_body(
+        status=status,
+        code=exc.code,
+        detail=str(exc) or exc.code,
+        request_id=request_id,
+    )
     level = (
         logging.ERROR
         if status >= HTTP_STATUS_SERVER_ERROR
@@ -291,6 +293,49 @@ async def _handle_api_error(request: Request, exc: ApiError) -> JSONResponse:
 
 # Keep a reference for static analyzers (decorator registers this handler)
 _ = _handle_api_error
+
+
+@app.exception_handler(HTTPException)
+async def _handle_http_exception(
+    request: Request,
+    exc: HTTPException,
+) -> JSONResponse:
+    request_id = getattr(request.state, "request_id", None)
+    code, detail = code_from_http_detail(exc.detail)
+    body = problem_details_body(
+        status=exc.status_code,
+        code=code,
+        detail=detail,
+        request_id=request_id,
+    )
+    response = JSONResponse(body, status_code=exc.status_code)
+    if request_id:
+        response.headers.setdefault("X-Request-Id", request_id)
+    return response
+
+
+@app.exception_handler(RequestValidationError)
+async def _handle_validation_error(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    request_id = getattr(request.state, "request_id", None)
+    status = 422
+    body = problem_details_body(
+        status=status,
+        code="validation_error",
+        detail="validation failed",
+        request_id=request_id,
+    )
+    body["detail"] = exc.errors()
+    response = JSONResponse(body, status_code=status)
+    if request_id:
+        response.headers.setdefault("X-Request-Id", request_id)
+    return response
+
+
+_ = _handle_http_exception
+_ = _handle_validation_error
 
 
 app.include_router(members.router)

--- a/apps/api/post_query_filters.py
+++ b/apps/api/post_query_filters.py
@@ -1,0 +1,18 @@
+"""게시글 목록 필터 TypedDict — repository·service·router 공용."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypedDict
+
+
+class AdminPostFilters(TypedDict, total=False):
+    category: str | None
+    status: str | None
+    q: str | None
+
+
+class PublicPostFilters(TypedDict, total=False):
+    category: str | None
+    categories: Sequence[str] | None
+    q: str | None

--- a/apps/api/problem_details.py
+++ b/apps/api/problem_details.py
@@ -1,6 +1,30 @@
-"""RFC7807-lite Problem Details 응답 body helper."""
+"""RFC7807-lite Problem Details 모델·응답 helper."""
 
 from __future__ import annotations
+
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from .error_messages import user_detail_for_code
+
+
+class ValidationErrorItem(BaseModel):
+    type: str
+    loc: list[str | int]
+    msg: str
+    input: Any | None = None
+    ctx: dict[str, str] | None = None
+
+
+class ProblemDetailsResponse(BaseModel):
+    type: str = "about:blank"
+    title: str = ""
+    status: int
+    detail: str
+    code: str
+    request_id: str | None = None
+    errors: list[ValidationErrorItem] | None = None
 
 
 def problem_details_body(
@@ -9,6 +33,7 @@ def problem_details_body(
     code: str,
     detail: str,
     request_id: str | None = None,
+    errors: list[dict[str, Any]] | None = None,
 ) -> dict[str, object]:
     body: dict[str, object] = {
         "type": "about:blank",
@@ -19,14 +44,34 @@ def problem_details_body(
     }
     if request_id:
         body["request_id"] = request_id
+    if errors is not None:
+        body["errors"] = errors
     return body
 
 
-def code_from_http_detail(detail: object) -> tuple[str, str]:
-    """HTTPException detail을 (code, user_detail)로 정규화한다."""
-    if isinstance(detail, str) and detail.strip():
-        text = detail.strip()
-        if " " not in text and text.replace("_", "").isalnum():
-            return text, text
-        return "http_error", text
-    return "http_error", "request failed"
+def json_safe_validation_errors(
+    errors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    safe: list[dict[str, Any]] = []
+    for raw in errors:
+        item = dict(raw)
+        ctx = item.get("ctx")
+        if isinstance(ctx, dict):
+            ctx_map = cast(dict[Any, Any], ctx)
+            item["ctx"] = {str(key): str(value) for key, value in ctx_map.items()}
+        safe.append(item)
+    return safe
+
+
+def validation_problem(
+    *,
+    errors: list[dict[str, Any]],
+    request_id: str | None = None,
+) -> dict[str, object]:
+    return problem_details_body(
+        status=422,
+        code="validation_error",
+        detail=user_detail_for_code("validation_error", status=422),
+        request_id=request_id,
+        errors=json_safe_validation_errors(errors),
+    )

--- a/apps/api/problem_details.py
+++ b/apps/api/problem_details.py
@@ -1,0 +1,32 @@
+"""RFC7807-lite Problem Details 응답 body helper."""
+
+from __future__ import annotations
+
+
+def problem_details_body(
+    *,
+    status: int,
+    code: str,
+    detail: str,
+    request_id: str | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "type": "about:blank",
+        "title": "",
+        "status": status,
+        "detail": detail,
+        "code": code,
+    }
+    if request_id:
+        body["request_id"] = request_id
+    return body
+
+
+def code_from_http_detail(detail: object) -> tuple[str, str]:
+    """HTTPException detail을 (code, user_detail)로 정규화한다."""
+    if isinstance(detail, str) and detail.strip():
+        text = detail.strip()
+        if " " not in text and text.replace("_", "").isalnum():
+            return text, text
+        return "http_error", text
+    return "http_error", "request failed"

--- a/apps/api/repositories/posts.py
+++ b/apps/api/repositories/posts.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypedDict
 
 from sqlalchemy import ColumnElement, and_, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,28 +8,13 @@ from sqlalchemy.orm import selectinload
 
 from .. import models, schemas
 from ..errors import NotFoundError
+from ..post_query_filters import AdminPostFilters, PublicPostFilters
 from ..post_visibility import (
     BOARD_POST_CATEGORIES,
     is_post_public,
     public_visibility_clause,
 )
 from . import escape_like
-
-
-class AdminPostFilters(TypedDict, total=False):
-    """관리자 게시물 목록 필터."""
-
-    category: str | None
-    status: str | None  # 'published' | 'scheduled' | 'draft' | None (all)
-    q: str | None
-
-
-class PublicPostFilters(TypedDict, total=False):
-    """공개 게시물 목록 필터."""
-
-    category: str | None
-    categories: Sequence[str] | None
-    q: str | None
 
 
 def _admin_non_board_category_clause() -> ColumnElement[bool]:

--- a/apps/api/repositories/signup_requests.py
+++ b/apps/api/repositories/signup_requests.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
 from .. import models, schemas
+from . import escape_like
 
 
 def _build_conditions(
@@ -17,14 +18,16 @@ def _build_conditions(
 
     q = filters.get("q")
     if q:
-        like = f"%{q.strip()}%"
-        conditions.append(
-            or_(
-                models.SignupRequest.student_id.ilike(like),
-                models.SignupRequest.name.ilike(like),
-                models.SignupRequest.email.ilike(like),
+        qv = q.strip()
+        if qv:
+            like = f"%{escape_like(qv)}%"
+            conditions.append(
+                or_(
+                    models.SignupRequest.student_id.ilike(like, escape="\\"),
+                    models.SignupRequest.name.ilike(like, escape="\\"),
+                    models.SignupRequest.email.ilike(like, escape="\\"),
+                )
             )
-        )
 
     status = filters.get("status")
     if status is not None:

--- a/apps/api/routers/admin_posts.py
+++ b/apps/api/routers/admin_posts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
@@ -11,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import schemas
 from ..db import get_db
-from ..repositories import posts as posts_repo
+from ..post_query_filters import AdminPostFilters
 from ..services import posts_service
 from .auth import CurrentUser, require_any_permission, require_permission
 
@@ -58,7 +57,7 @@ async def list_admin_posts(
     ),
 ) -> AdminPostListResponse:
     """관리자용 게시물 목록 (비공개 포함)."""
-    filters: posts_repo.AdminPostFilters = {
+    filters: AdminPostFilters = {
         "category": params.category,
         "status": params.status,
         "q": params.q,
@@ -66,15 +65,7 @@ async def list_admin_posts(
     posts, total = await posts_service.list_admin_posts_with_total(
         db, limit=params.limit, offset=params.offset, filters=filters
     )
-    # N+1 방지: 배치로 댓글 수 조회
-    post_ids = [cast(int, p.id) for p in posts]
-    comment_counts = await posts_repo.get_comment_counts_batch(db, post_ids)
-    items: list[schemas.PostRead] = []
-    for post in posts:
-        post_read = schemas.PostRead.model_validate(post)
-        post_read.author_name = post.author.name if post.author else None
-        post_read.comment_count = comment_counts.get(cast(int, post.id), 0)
-        items.append(post_read)
+    items = await posts_service.list_admin_post_reads(db, posts)
     return AdminPostListResponse(items=items, total=total)
 
 
@@ -89,8 +80,4 @@ async def preview_admin_post(
     ),
 ) -> schemas.PostRead:
     """관리자 게시물 미리보기 (게시물 또는 hero 읽기 권한)."""
-    post = await posts_service.get_post(db, post_id)
-    post_read = schemas.PostRead.model_validate(post)
-    post_read.author_name = post.author.name if post.author else None
-    post_read.comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
-    return post_read
+    return await posts_service.get_admin_post_read(db, post_id)

--- a/apps/api/routers/board_posts.py
+++ b/apps/api/routers/board_posts.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-from typing import cast
-
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import schemas
 from ..db import get_db
+from ..errors import ApiError
 from ..post_owner_schemas import PostOwnerUpdate
-from ..repositories import posts as posts_repo
 from ..services import posts_service
 from .auth import CurrentMember, require_member
 
@@ -19,7 +17,11 @@ router = APIRouter(prefix="/board/posts", tags=["board-posts"])
 
 def _member_id(member: CurrentMember) -> int:
     if member.id is None:
-        raise HTTPException(status_code=500, detail="member_id_missing")
+        raise ApiError(
+            code="member_id_missing",
+            detail="member_id_missing",
+            status=500,
+        )
     return member.id
 
 
@@ -37,10 +39,7 @@ async def update_board_post(
         payload,
         member_id=_member_id(member),
     )
-    post_read = schemas.PostRead.model_validate(post)
-    post_read.author_name = post.author.name if post.author else None
-    post_read.comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
-    return post_read
+    return await posts_service.post_read_after_mutation(db, post)
 
 
 @router.delete("/{post_id}")

--- a/apps/api/routers/notifications.py
+++ b/apps/api/routers/notifications.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, HttpUrl
 from slowapi import Limiter
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apps.api.config import get_settings
-from apps.api.crypto_utils import is_push_encryption_effective
 from apps.api.db import get_db
+from apps.api.errors import ApiError
 from apps.api.ratelimit import consume_limit, get_client_ip_for_rate_limit
-from apps.api.repositories import notifications as subs_repo
-from apps.api.repositories import send_logs as logs_repo
 from apps.api.routers.auth import (
     CurrentMember,
     CurrentUser,
@@ -138,19 +136,18 @@ async def get_send_logs(
     limit: int = 50,
     db: AsyncSession = Depends(get_db),
 ) -> list[SendLogRead]:
-    rows = await logs_repo.list_recent(db, limit=min(max(limit, 1), 200))
-    out: list[SendLogRead] = []
-    for r in rows:
-        created_dt = cast(datetime | None, r.created_at)
-        out.append(
-            SendLogRead(
-                created_at=created_dt.isoformat() if created_dt else "",
-                ok=bool(cast(int, r.ok)),
-                status_code=cast(int | None, r.status_code),
-                endpoint_tail=cast(str | None, r.endpoint_tail),
-            )
+    rows = await notif_svc.list_recent_send_logs(
+        db, limit=min(max(limit, 1), 200)
+    )
+    return [
+        SendLogRead(
+            created_at=row.created_at,
+            ok=row.ok,
+            status_code=row.status_code,
+            endpoint_tail=row.endpoint_tail,
         )
-    return out
+        for row in rows
+    ]
 
 
 class NotificationStats(BaseModel):
@@ -184,19 +181,21 @@ async def get_stats(
     )
     cutoff = datetime.now(UTC_TZ) - delta
 
-    active = await subs_repo.count_active_subscriptions(db)
-    agg = await logs_repo.aggregate_since(db, cutoff=cutoff)
-    settings = get_settings()
+    stats = await notif_svc.get_notification_stats(
+        db,
+        range_label=r,
+        cutoff=cutoff,
+    )
 
     return NotificationStats(
-        active_subscriptions=active,
-        recent_accepted=agg.accepted,
-        recent_failed=agg.failed,
-        encryption_enabled=is_push_encryption_effective(settings),
-        range=r,
-        failed_404=agg.failed_404,
-        failed_410=agg.failed_410,
-        failed_other=agg.failed_other,
+        active_subscriptions=stats.active_subscriptions,
+        recent_accepted=stats.recent_accepted,
+        recent_failed=stats.recent_failed,
+        encryption_enabled=stats.encryption_enabled,
+        range=stats.range_label,
+        failed_404=stats.failed_404,
+        failed_410=stats.failed_410,
+        failed_other=stats.failed_other,
     )
 
 
@@ -214,7 +213,7 @@ async def prune_logs(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, int | str]:
     days = max(1, int(payload.older_than_days))
-    n = await logs_repo.prune_older_than_days(db, days=days)
+    n = await notif_svc.prune_notification_logs(db, days=days)
     before = datetime.now(UTC_TZ) - timedelta(days=days)
     return {"deleted": n, "before": before.isoformat(), "older_than_days": days}
 
@@ -243,9 +242,12 @@ async def trigger_scheduled_notifications(
         try:
             target = date.fromisoformat(payload.target_date)
         except ValueError as e:
-            raise HTTPException(
-                status_code=400,
-                detail=f"잘못된 날짜 형식: {payload.target_date} (YYYY-MM-DD 필요)",
+            raise ApiError(
+                code="invalid_date_format",
+                detail=(
+                    f"잘못된 날짜 형식: {payload.target_date} (YYYY-MM-DD 필요)"
+                ),
+                status=400,
             ) from e
     else:
         target = datetime.now(KST).date()

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -4,17 +4,16 @@ import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .. import models, schemas
+from .. import schemas
 from ..config import get_settings
 from ..db import get_db
 from ..errors import ApiError
+from ..post_query_filters import PublicPostFilters
 from ..ratelimit import get_client_ip_for_rate_limit, should_skip_rate_limit
-from ..repositories import posts as posts_repo
 from ..services import posts_service
 from ..services.auth_service import has_any_permission, is_admin
 from .auth import (
@@ -76,7 +75,7 @@ def _enforce_member_post_limit(request: Request, limit_value: str) -> None:
     while bucket and now - bucket[0] > window:
         bucket.popleft()
     if len(bucket) >= amount:
-        raise HTTPException(status_code=429, detail="rate_limited")
+        raise ApiError(code="rate_limited", detail="rate_limited", status=429)
     bucket.append(now)
 
 
@@ -88,25 +87,29 @@ async def _create_member_post_for_request(
     payload: schemas.PostCreate,
     request: Request,
     db: AsyncSession,
-) -> models.Post:
+) -> schemas.PostRead:
     """현재 세션을 일반 회원 게시판 작성 경로로 처리한다."""
     try:
         member = await require_member(request, db)
     except HTTPException as exc_member:
-        # 기존 비회원 계약을 유지한다. 관리자 검사에서 403이 난 뒤에도
-        # 회원 fallback을 시도하므로, 여기서만 인증 실패를 401로 정규화한다.
-        raise HTTPException(status_code=401, detail="unauthorized") from exc_member
+        if exc_member.status_code in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.FORBIDDEN,
+        ):
+            raise HTTPException(status_code=401, detail="unauthorized") from exc_member
+        raise
 
     settings = get_settings()
     _enforce_member_post_limit(request, settings.rate_limit_post_create)
 
     sanitized = payload.model_copy(update={"pinned": False, "published_at": None})
-    return await posts_service.create_member_post(
+    post = await posts_service.create_member_post(
         db,
         sanitized,
         member_student_id=member.student_id,
         member_id=member.id,
     )
+    return schemas.PostRead.model_validate(post)
 
 
 @dataclass
@@ -147,26 +150,17 @@ async def list_posts(
             detail="category and categories cannot be used together",
             status=400,
         )
-    posts = await posts_service.list_posts(
+    filters: PublicPostFilters = {
+        "category": params.category,
+        "categories": params.categories,
+        "q": params.q,
+    }
+    return await posts_service.list_public_post_reads(
         db,
         limit=params.limit,
         offset=params.offset,
-        filters={
-            "category": params.category,
-            "categories": params.categories,
-            "q": params.q,
-        },
+        filters=filters,
     )
-    # N+1 쿼리 방지: 배치로 댓글 수 조회
-    post_ids = [cast(int, p.id) for p in posts]
-    comment_counts = await posts_repo.get_comment_counts_batch(db, post_ids)
-    result: list[schemas.PostRead] = []
-    for post in posts:
-        post_read = schemas.PostRead.model_validate(post)
-        post_read.author_name = post.author.name if post.author else None
-        post_read.comment_count = comment_counts.get(cast(int, post.id), 0)
-        result.append(post_read)
-    return result
 
 
 @router.get("/{post_id}", response_model=schemas.PostRead)
@@ -175,15 +169,12 @@ async def get_post(
     post_id: int,
     db: AsyncSession = Depends(get_db),
 ) -> schemas.PostRead:
-    post = await posts_service.get_public_post(db, post_id)
-    # 관리자 확인은 사용자 조회수 통계를 왜곡하지 않도록 집계하지 않는다.
-    if not await is_admin(db, request):
-        await posts_repo.increment_view_count(db, post_id)
-        await db.refresh(post)
-    post_read = schemas.PostRead.model_validate(post)
-    post_read.author_name = post.author.name if post.author else None
-    post_read.comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
-    return post_read
+    record_view = not await is_admin(db, request)
+    return await posts_service.get_public_post_read(
+        db,
+        post_id,
+        record_view=record_view,
+    )
 
 
 @router.post("/", response_model=schemas.PostRead, status_code=201)
@@ -201,31 +192,28 @@ async def create_post(
             HTTPStatus.FORBIDDEN,
         ):
             raise
-        post = await _create_member_post_for_request(payload, request, db)
+        return await _create_member_post_for_request(payload, request, db)
+
+    if await has_any_permission(db, request, ("admin_posts",)):
+        post = await posts_service.create_admin_post(
+            db,
+            payload,
+            admin_student_id=admin.student_id,
+            actor_member_id=admin.id,
+        )
     else:
-        if await has_any_permission(db, request, ("admin_posts",)):
-            # 보안: 클라이언트가 보낸 author_id를 무시하고 서버에서 강제 주입
-            # student_id로 member를 조회하여 author_id 결정 (레거시 세션 호환)
-            # 관리자는 pinned, published_at 등 관리자 권한 필드 설정 가능
-            post = await posts_service.create_admin_post(
-                db,
-                payload,
-                admin_student_id=admin.student_id,
-                actor_member_id=admin.id,
-            )
-        else:
-            # admin 등급은 게시물 관리 권한을 자동 상속하지 않는다. 다만
-            # admin_hero 같은 제한 관리자는 일반 회원으로서 board 글을 쓸 수
-            # 있으므로, notice/news 관리 권한을 부여하지 않은 채 member 경로를
-            # 사용한다. 이 경로는 board 카테고리와 비공개 상태를 강제한다.
-            post = await _create_member_post_for_request(payload, request, db)
+        return await _create_member_post_for_request(payload, request, db)
 
     return schemas.PostRead.model_validate(post)
 
 
 def _actor_member_id(user: CurrentUser) -> int:
     if user.id is None:
-        raise HTTPException(status_code=500, detail="member_id_missing")
+        raise ApiError(
+            code="member_id_missing",
+            detail="member_id_missing",
+            status=500,
+        )
     return user.id
 
 
@@ -240,10 +228,7 @@ async def update_post(
     post = await posts_service.update_admin_post(
         db, post_id, payload, actor_member_id=_actor_member_id(admin)
     )
-    post_read = schemas.PostRead.model_validate(post)
-    post_read.author_name = post.author.name if post.author else None
-    post_read.comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
-    return post_read
+    return await posts_service.post_read_after_mutation(db, post)
 
 
 @router.delete("/{post_id}")

--- a/apps/api/routers/support.py
+++ b/apps/api/routers/support.py
@@ -7,20 +7,19 @@ import time
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
 from ..db import get_db
 from ..errors import ApiError
 from ..ratelimit import consume_limit, get_client_ip_for_rate_limit
-from ..repositories import support_tickets as tickets_repo
 from ..routers.auth import (
     CurrentMember,
     CurrentUser,
     require_member,
     require_permission,
 )
+from ..services import support_service
 
 router = APIRouter(prefix="/support", tags=["support"])
 limiter = Limiter(key_func=get_client_ip_for_rate_limit)
@@ -106,24 +105,24 @@ async def contact(
     if _is_duplicate_submission(ident, digest, now):
         return {"status": "accepted"}
 
-    client_ip = get_client_ip_for_rate_limit(request)
-    try:
-        await tickets_repo.create_ticket(
-            db,
-            {
-                "member_email": member.email,
-                "subject": payload.subject,
-                "body": payload.body,
-                "contact": payload.contact,
-                "client_ip": client_ip if client_ip != "unknown" else None,
-            },
-        )
-    except SQLAlchemyError:
+    if not member.email:
         raise ApiError(
-            code="support_ticket_persist_failed",
-            detail="문의 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+            code="member_email_missing",
+            detail="member_email_missing",
             status=500,
-        ) from None
+        )
+
+    client_ip = get_client_ip_for_rate_limit(request)
+    await support_service.create_contact_ticket(
+        db,
+        support_service.ContactTicketInput(
+            member_email=member.email,
+            subject=payload.subject,
+            body=payload.body,
+            contact=payload.contact,
+            client_ip=client_ip if client_ip != "unknown" else None,
+        ),
+    )
     _record_successful_submission(ident, digest, time.monotonic())
     return {"status": "accepted"}
 
@@ -146,17 +145,18 @@ async def list_tickets(
     db: AsyncSession = Depends(get_db),
     limit: int = Query(50, ge=1, le=200),
 ) -> list[TicketRead]:
-    rows = await tickets_repo.list_recent(db, limit=limit)
+    rows = await support_service.list_recent_tickets(db, limit=limit)
     out: list[TicketRead] = []
-    for r in rows:
-        created = getattr(r, 'created_at', None)
-        out.append(TicketRead(
-            id=getattr(r, 'id', 0),
-            created_at=(created.isoformat() if created else ''),
-            member_email=getattr(r, 'member_email', None),
-            subject=getattr(r, 'subject', ''),
-            body=getattr(r, 'body', ''),
-            contact=getattr(r, 'contact', None),
-            client_ip=getattr(r, 'client_ip', None),
-        ))
+    for row in rows:
+        out.append(
+            TicketRead(
+                id=getattr(row, "id", 0),
+                created_at=support_service.ticket_created_at_iso(row),
+                member_email=getattr(row, "member_email", None),
+                subject=getattr(row, "subject", ""),
+                body=getattr(row, "body", ""),
+                contact=getattr(row, "contact", None),
+                client_ip=getattr(row, "client_ip", None),
+            )
+        )
     return out

--- a/apps/api/services/notifications_service.py
+++ b/apps/api/services/notifications_service.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Protocol, cast
 
 from pywebpush import WebPushException, webpush
@@ -11,7 +12,7 @@ from requests.exceptions import RequestException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import get_settings
-from ..crypto_utils import CryptoError, decrypt_str
+from ..crypto_utils import CryptoError, decrypt_str, is_push_encryption_effective
 from ..errors import ApiError
 from ..models import PushSubscription
 from ..repositories import notifications as repo
@@ -158,3 +159,68 @@ async def send_to_all(
     await send_logs.create_logs_batch(db, log_items)
     await repo.remove_by_endpoint_hashes(db, expired_hashes)
     return SendResult(accepted=accepted, failed=failed)
+
+
+@dataclass
+class SendLogReadData:
+    created_at: str
+    ok: bool
+    status_code: int | None
+    endpoint_tail: str | None
+
+
+@dataclass
+class NotificationStatsData:
+    active_subscriptions: int
+    recent_accepted: int
+    recent_failed: int
+    encryption_enabled: bool
+    range_label: str
+    failed_404: int | None
+    failed_410: int | None
+    failed_other: int | None
+
+
+async def list_recent_send_logs(
+    db: AsyncSession,
+    *,
+    limit: int,
+) -> list[SendLogReadData]:
+    rows = await send_logs.list_recent(db, limit=limit)
+    out: list[SendLogReadData] = []
+    for row in rows:
+        created_dt = cast(datetime | None, row.created_at)
+        out.append(
+            SendLogReadData(
+                created_at=created_dt.isoformat() if created_dt else "",
+                ok=bool(cast(int, row.ok)),
+                status_code=cast(int | None, row.status_code),
+                endpoint_tail=cast(str | None, row.endpoint_tail),
+            )
+        )
+    return out
+
+
+async def get_notification_stats(
+    db: AsyncSession,
+    *,
+    range_label: str,
+    cutoff: datetime,
+) -> NotificationStatsData:
+    active = await repo.count_active_subscriptions(db)
+    agg = await send_logs.aggregate_since(db, cutoff=cutoff)
+    settings = get_settings()
+    return NotificationStatsData(
+        active_subscriptions=active,
+        recent_accepted=agg.accepted,
+        recent_failed=agg.failed,
+        encryption_enabled=is_push_encryption_effective(settings),
+        range_label=range_label,
+        failed_404=agg.failed_404,
+        failed_410=agg.failed_410,
+        failed_other=agg.failed_other,
+    )
+
+
+async def prune_notification_logs(db: AsyncSession, *, days: int) -> int:
+    return await send_logs.prune_older_than_days(db, days=days)

--- a/apps/api/services/posts_service.py
+++ b/apps/api/services/posts_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import models, schemas
 from ..errors import ApiError
 from ..post_owner_schemas import PostOwnerUpdate
+from ..post_query_filters import AdminPostFilters, PublicPostFilters
 from ..post_visibility import BOARD_POST_CATEGORIES
 from ..repositories import members as members_repo
 from ..repositories import posts as posts_repo
@@ -103,7 +104,7 @@ async def list_posts(
     *,
     limit: int,
     offset: int,
-    filters: posts_repo.PublicPostFilters | None = None,
+    filters: PublicPostFilters | None = None,
 ) -> Sequence[models.Post]:
     return await posts_repo.list_posts(
         db,
@@ -303,7 +304,7 @@ async def list_admin_posts_with_total(
     *,
     limit: int,
     offset: int,
-    filters: posts_repo.AdminPostFilters | None = None,
+    filters: AdminPostFilters | None = None,
 ) -> tuple[Sequence[models.Post], int]:
     """관리자용 게시물 목록 + 총 개수를 반환."""
     posts = await posts_repo.list_admin_posts(
@@ -311,3 +312,72 @@ async def list_admin_posts_with_total(
     )
     total = await posts_repo.count_posts(db, filters=filters)
     return posts, total
+
+
+def _post_read_from_model(post: models.Post, comment_count: int) -> schemas.PostRead:
+    post_read = schemas.PostRead.model_validate(post)
+    post_read.author_name = post.author.name if post.author else None
+    post_read.comment_count = comment_count
+    return post_read
+
+
+async def list_public_post_reads(
+    db: AsyncSession,
+    *,
+    limit: int,
+    offset: int,
+    filters: PublicPostFilters | None = None,
+) -> list[schemas.PostRead]:
+    posts = await list_posts(db, limit=limit, offset=offset, filters=filters)
+    post_ids = [cast(int, post.id) for post in posts]
+    comment_counts = await posts_repo.get_comment_counts_batch(db, post_ids)
+    return [
+        _post_read_from_model(
+            post,
+            comment_counts.get(cast(int, post.id), 0),
+        )
+        for post in posts
+    ]
+
+
+async def get_public_post_read(
+    db: AsyncSession,
+    post_id: int,
+    *,
+    record_view: bool,
+) -> schemas.PostRead:
+    post = await get_public_post(db, post_id)
+    if record_view:
+        await posts_repo.increment_view_count(db, post_id)
+        await db.refresh(post)
+    comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
+    return _post_read_from_model(post, comment_count)
+
+
+async def list_admin_post_reads(
+    db: AsyncSession,
+    posts: Sequence[models.Post],
+) -> list[schemas.PostRead]:
+    post_ids = [cast(int, post.id) for post in posts]
+    comment_counts = await posts_repo.get_comment_counts_batch(db, post_ids)
+    return [
+        _post_read_from_model(
+            post,
+            comment_counts.get(cast(int, post.id), 0),
+        )
+        for post in posts
+    ]
+
+
+async def get_admin_post_read(db: AsyncSession, post_id: int) -> schemas.PostRead:
+    post = await get_post(db, post_id)
+    comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
+    return _post_read_from_model(post, comment_count)
+
+
+async def post_read_after_mutation(
+    db: AsyncSession,
+    post: models.Post,
+) -> schemas.PostRead:
+    comment_count = await posts_repo.get_comment_count(db, cast(int, post.id))
+    return _post_read_from_model(post, comment_count)

--- a/apps/api/services/support_service.py
+++ b/apps/api/services/support_service.py
@@ -1,0 +1,61 @@
+"""지원문의 서비스 레이어."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..errors import ApiError
+from ..models_support import SupportTicket
+from ..repositories import support_tickets as tickets_repo
+
+
+@dataclass
+class ContactTicketInput:
+    member_email: str
+    subject: str
+    body: str
+    contact: str | None
+    client_ip: str | None
+
+
+async def create_contact_ticket(
+    db: AsyncSession,
+    payload: ContactTicketInput,
+) -> None:
+    try:
+        await tickets_repo.create_ticket(
+            db,
+            {
+                "member_email": payload.member_email,
+                "subject": payload.subject,
+                "body": payload.body,
+                "contact": payload.contact,
+                "client_ip": payload.client_ip,
+            },
+        )
+    except SQLAlchemyError as exc:
+        raise ApiError(
+            code="support_ticket_persist_failed",
+            detail="문의 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+            status=500,
+        ) from exc
+
+
+async def list_recent_tickets(
+    db: AsyncSession,
+    *,
+    limit: int,
+) -> Sequence[SupportTicket]:
+    return await tickets_repo.list_recent(db, limit=limit)
+
+
+def ticket_created_at_iso(ticket: SupportTicket) -> str:
+    created = getattr(ticket, "created_at", None)
+    if isinstance(created, datetime):
+        return created.isoformat()
+    return ""

--- a/apps/web/__tests__/api.test.ts
+++ b/apps/web/__tests__/api.test.ts
@@ -7,13 +7,38 @@ describe('apiFetch 오류 정규화', () => {
     vi.unstubAllGlobals();
   });
 
-  it('Pydantic 422 detail 배열을 사용자 메시지로 변환한다', async () => {
+  it('Problem Details의 detail 문자열과 code를 사용한다', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
-            detail: [
+            type: 'about:blank',
+            status: 403,
+            code: 'admin_permission_required',
+            detail: '이 작업을 수행할 운영 권한이 없습니다.',
+          }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+
+    await expect(apiFetch('/admin/signup-requests')).rejects.toEqual(
+      new ApiError(403, '이 작업을 수행할 운영 권한이 없습니다.', 'admin_permission_required')
+    );
+  });
+
+  it('422는 detail 문자열을 우선하고 errors extension은 파싱에 쓰지 않는다', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            type: 'about:blank',
+            status: 422,
+            code: 'validation_error',
+            detail: '입력값을 확인해 주세요.',
+            errors: [
               {
                 type: 'value_error',
                 loc: ['body', 'password'],
@@ -27,7 +52,7 @@ describe('apiFetch 오류 정규화', () => {
     );
 
     await expect(apiFetch('/auth/member/activate')).rejects.toEqual(
-      new ApiError(422, '비밀번호는 UTF-8 기준 72바이트 이하여야 합니다.')
+      new ApiError(422, '입력값을 확인해 주세요.', 'validation_error')
     );
   });
 

--- a/apps/web/e2e/admin-preview.spec.ts
+++ b/apps/web/e2e/admin-preview.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import puppeteer, { Browser, HTTPRequest, Page } from 'puppeteer';
 
-import { WEB_BASE_URL } from './utils/env';
+import { WEB_BASE_URL, isApiUrl } from './utils/env';
 import { setLocalMockSession, setupDirectoryMocks } from './utils/mockApi';
 import { configureMockServer } from './utils/mockServer';
 
@@ -166,7 +166,7 @@ describe('Admin post preview (CDP E2E)', () => {
     let patchBody: Record<string, unknown> | null = null;
     const recordRequest = (request: HTTPRequest) => {
       const url = new URL(request.url());
-      if (url.port === '3001' && request.method() === 'PATCH' && url.pathname === '/posts/44') {
+      if (isApiUrl(url) && request.method() === 'PATCH' && url.pathname === '/posts/44') {
         patchBody = JSON.parse(request.postData() ?? '{}') as Record<string, unknown>;
       }
     };
@@ -192,7 +192,7 @@ describe('Admin post preview (CDP E2E)', () => {
 
     const previewResponse = page.waitForResponse((response) => {
       const url = new URL(response.url());
-      return url.port === '3001'
+      return isApiUrl(url)
         && url.pathname === '/admin/posts/44/preview'
         && response.request().method() === 'GET';
     });
@@ -212,7 +212,7 @@ describe('Admin post preview (CDP E2E)', () => {
     let patchBody: Record<string, unknown> | null = null;
     const recordRequest = (request: HTTPRequest) => {
       const url = new URL(request.url());
-      if (url.port === '3001' && request.method() === 'PATCH' && url.pathname === '/posts/44') {
+      if (isApiUrl(url) && request.method() === 'PATCH' && url.pathname === '/posts/44') {
         patchBody = JSON.parse(request.postData() ?? '{}') as Record<string, unknown>;
       }
     };
@@ -242,7 +242,7 @@ describe('Admin post preview (CDP E2E)', () => {
 
       const previewResponse = page.waitForResponse((response) => {
         const url = new URL(response.url());
-        return url.port === '3001'
+        return isApiUrl(url)
           && url.pathname === '/admin/posts/44/preview'
           && response.request().method() === 'GET';
       });

--- a/apps/web/e2e/board-owner-mutation.spec.ts
+++ b/apps/web/e2e/board-owner-mutation.spec.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import puppeteer, { Browser, HTTPRequest, Page } from 'puppeteer';
 
-import { WEB_BASE_URL } from './utils/env';
+import { WEB_BASE_URL, isApiUrl } from './utils/env';
 import { setLocalMockSession, setupDirectoryMocks } from './utils/mockApi';
 import { configureMockServer } from './utils/mockServer';
 
@@ -71,7 +71,7 @@ describe('Board post owner mutation (CDP E2E)', () => {
     const requests: Array<{ method: string; pathname: string }> = [];
     const recordRequest = (request: HTTPRequest) => {
       const url = new URL(request.url());
-      if (url.port === '3001') {
+      if (isApiUrl(url)) {
         requests.push({ method: request.method(), pathname: url.pathname });
       }
     };

--- a/apps/web/e2e/env.example
+++ b/apps/web/e2e/env.example
@@ -1,0 +1,20 @@
+# Mock regression E2E (CI parity)
+# Usage:
+#   set -a && source apps/web/e2e/env.example && set +a
+#   bash ops/ci/run_mock_e2e_local.sh
+#
+# Specs match API traffic via NEXT_PUBLIC_WEB_API_BASE / E2E_MOCK_API_CONTROL_URL
+# (see e2e/utils/env.ts — no hardcoded :3001 in request assertions).
+
+WEB_BASE_URL=http://127.0.0.1:3000
+NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3001
+E2E_MOCK_API_CONTROL_URL=http://127.0.0.1:3001
+E2E_MOCK_API_PORT=3001
+WEB_BUILD_ALLOW_INSECURE_LOCAL_API=1
+PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+
+# --- When :3001 is already taken (e.g. WSL / Windows host) ---
+# Pick any free port; mock server, Web build, and specs must agree.
+# E2E_MOCK_API_PORT=3011
+# NEXT_PUBLIC_WEB_API_BASE=http://127.0.0.1:3011
+# E2E_MOCK_API_CONTROL_URL=http://127.0.0.1:3011

--- a/apps/web/e2e/onboarding-happy-path.spec.ts
+++ b/apps/web/e2e/onboarding-happy-path.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import puppeteer, { Browser, Page, HTTPRequest } from 'puppeteer';
-import { WEB_BASE_URL } from './utils/env';
+import { WEB_BASE_URL, isApiUrl } from './utils/env';
 import { configureMockServer } from './utils/mockServer';
 
 let browser: Browser | null = null;
@@ -164,7 +164,7 @@ async function respondOnboardingApiRequest(
   routeResponders: Record<string, () => ReturnType<typeof jsonResponse>>
 ) {
   const url = new URL(request.url());
-  if (url.port !== '3001') return false;
+  if (!isApiUrl(url)) return false;
 
   if (request.method() === 'OPTIONS') {
     await request.respond({

--- a/apps/web/e2e/utils/env.ts
+++ b/apps/web/e2e/utils/env.ts
@@ -1,1 +1,19 @@
 export const WEB_BASE_URL: string = process.env.WEB_BASE_URL ?? 'http://localhost:3000';
+
+function resolveApiBaseUrl(): string {
+  const raw =
+    process.env.NEXT_PUBLIC_WEB_API_BASE ??
+    process.env.E2E_MOCK_API_CONTROL_URL ??
+    'http://127.0.0.1:3001';
+  return raw.replace(/\/$/, '');
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();
+
+const API_ORIGIN = new URL(API_BASE_URL).origin;
+
+/** E2E mock/real API 요청 여부 — 포트 하드코딩 대신 빌드·실행 env를 따른다. */
+export function isApiUrl(url: URL | string): boolean {
+  const parsed = typeof url === 'string' ? new URL(url) : url;
+  return parsed.origin === API_ORIGIN;
+}

--- a/apps/web/e2e/utils/mockApi.ts
+++ b/apps/web/e2e/utils/mockApi.ts
@@ -1,6 +1,6 @@
 import type { Page, HTTPRequest } from 'puppeteer';
 
-import { WEB_BASE_URL } from './env';
+import { WEB_BASE_URL, isApiUrl } from './env';
 
 type LocalMockSession = 'anonymous' | 'member' | 'admin' | 'admin_hero';
 let localMockSession: LocalMockSession = 'member';
@@ -15,7 +15,7 @@ const corsHeaders = {
 };
 
 async function respondCorsPreflight(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'OPTIONS') return false;
+  if (!isApiUrl(url) || request.method() !== 'OPTIONS') return false;
   await request.respond({
     status: 204,
     headers: {
@@ -225,7 +225,7 @@ function isLocalBoardPostsList(url: URL): boolean {
 }
 
 async function respondOwnerPostDetailApi(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'GET' || url.pathname !== '/posts/45') {
+  if (!isApiUrl(url) || request.method() !== 'GET' || url.pathname !== '/posts/45') {
     return false;
   }
   await request.respond({
@@ -240,7 +240,7 @@ async function respondOwnerPostDetailApi(request: HTTPRequest, url: URL): Promis
 }
 
 async function respondOwnerPostListApi(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'GET' || url.pathname !== '/posts/') {
+  if (!isApiUrl(url) || request.method() !== 'GET' || url.pathname !== '/posts/') {
     return false;
   }
   const body = localOwnerPostDeleted || !isLocalBoardPostsList(url)
@@ -261,7 +261,7 @@ async function respondOwnerPostReadApi(request: HTTPRequest, url: URL): Promise<
 }
 
 async function respondOwnerPostPatchApi(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'PATCH' || url.pathname !== '/board/posts/45') {
+  if (!isApiUrl(url) || request.method() !== 'PATCH' || url.pathname !== '/board/posts/45') {
     return false;
   }
   const body = JSON.parse(request.postData() ?? '{}') as Record<string, unknown>;
@@ -283,7 +283,7 @@ async function respondOwnerPostPatchApi(request: HTTPRequest, url: URL): Promise
 }
 
 async function respondOwnerPostDeleteApi(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'DELETE' || url.pathname !== '/board/posts/45') {
+  if (!isApiUrl(url) || request.method() !== 'DELETE' || url.pathname !== '/board/posts/45') {
     return false;
   }
   localOwnerPostDeleted = true;
@@ -314,7 +314,7 @@ function applyAdminBoardPostPatchBody(body: Record<string, unknown>): void {
 }
 
 async function respondAdminBoardPostPatchApi(request: HTTPRequest, url: URL): Promise<boolean> {
-  if (url.port !== '3001' || request.method() !== 'PATCH' || url.pathname !== '/posts/44') {
+  if (!isApiUrl(url) || request.method() !== 'PATCH' || url.pathname !== '/posts/44') {
     return false;
   }
   const body = JSON.parse(request.postData() ?? '{}') as Record<string, unknown>;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,4 @@
-// 공통 API 클라이언트 래퍼
+import { apiErrorToMessage } from './error-map';
 // - fetch 옵션 통일, 에러 포맷 처리, BASE_URL 주입
 
 const DEV_LIKE_ENVS = new Set(['development', 'test']);
@@ -92,12 +92,21 @@ export function resolveApiAssetUrl(value: string, options: ApiBaseResolutionOpti
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
+export type ValidationErrorItem = {
+  type: string;
+  loc: (string | number)[];
+  msg: string;
+  ctx?: Record<string, string>;
+};
+
 export type ProblemDetails = {
   type?: string;
   title?: string;
   status: number;
-  detail?: unknown;
+  detail: string;
   code?: string;
+  request_id?: string;
+  errors?: ValidationErrorItem[];
 };
 
 export class ApiError extends Error {
@@ -110,30 +119,17 @@ export class ApiError extends Error {
 async function parseError(res: Response): Promise<never> {
   try {
     const problem = (await res.json()) as ProblemDetails;
-    const msg = detailToMessage(problem.detail) ?? problem.title ?? `HTTP ${res.status}`;
+    const msg =
+      (typeof problem.detail === 'string' && problem.detail) ||
+      apiErrorToMessage(problem.code) ||
+      problem.title ||
+      `HTTP ${res.status}`;
     throw new ApiError(problem.status ?? res.status, msg, problem.code);
   } catch (e) {
     if (e instanceof ApiError) throw e;
     const text = await res.text().catch(() => '');
     throw new ApiError(res.status, text || `HTTP ${res.status}`);
   }
-}
-
-function detailToMessage(detail: unknown): string | undefined {
-  if (typeof detail === 'string' && detail) return detail;
-  if (!Array.isArray(detail)) return undefined;
-
-  for (const item of detail) {
-    if (!isRecord(item)) continue;
-    const message = item['msg'];
-    if (typeof message !== 'string' || !message) continue;
-    return message.replace(/^Value error,\s*/, '');
-  }
-  return undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value != null;
 }
 
 async function parseOk<T>(res: Response): Promise<T | void> {

--- a/docs/dev_log_260812.md
+++ b/docs/dev_log_260812.md
@@ -9,3 +9,6 @@
 - Web(D9): `api.ts` Problem Details 파서·`api.test.ts` regression, legacy `detail[]` 제거
 - Ops: `router_layer_guard` 상대 import·models·DB mutation 검출 확대, `run_mock_e2e_local.sh` owner-aware restore
 - Test: D9 errors·signup 검색·guard negative fixture 보강; mock regression E2E 11/11 PASS
+- E2E(live): `playwright-cli` real dev Web+API로 401/403/422 Problem Details·관리자 signup `100%_exact` literal 검색 PASS
+- API(D9): OpenAPI operation responses를 `ProblemDetailsError`로 연결, legacy `HTTPValidationError` 제거
+- Test: signup 검색 `\` literal 케이스·OpenAPI operation error contract regression 추가

--- a/docs/dev_log_260812.md
+++ b/docs/dev_log_260812.md
@@ -13,3 +13,4 @@
 - API(D9): OpenAPI operation responses를 `ProblemDetailsError`로 연결, legacy `HTTPValidationError` 제거
 - Test: signup 검색 `\` literal 케이스·OpenAPI operation error contract regression 추가
 - API(D9): 5xx 응답을 외부 `internal_error`+안전 detail로 통일, 내부 code/detail은 로그/Sentry만
+- Test(D9): Problem Details 계약에 맞게 API 테스트 assertion 보정, `problem_assertions` helper·누락 error code 메시지 추가

--- a/docs/dev_log_260812.md
+++ b/docs/dev_log_260812.md
@@ -5,3 +5,7 @@
 - Docs: `docs/agents_base_kr.md`, `docs/ci_quality_gates.md`에 runbook 라우팅 추가
 - Docs: E2E runbook §3.1/§5.2에 `:3000` owner-aware suspend/restore 추가 (live→mock EADDRINUSE 방지)
 - API(D9): Problem Details 통합 핸들러(#259), router→service 레이어 복구·AST guard(#261), signup 검색 `escape_like`(#274)
+- API(D9 보정): 429/422/Starlette 404 Problem Details wire, code·detail 분리(`error_messages.py`), OpenAPI `ProblemDetails`·DTO 재생성
+- Web(D9): `api.ts` Problem Details 파서·`api.test.ts` regression, legacy `detail[]` 제거
+- Ops: `router_layer_guard` 상대 import·models·DB mutation 검출 확대, `run_mock_e2e_local.sh` owner-aware restore
+- Test: D9 errors·signup 검색·guard negative fixture 보강; mock regression E2E 11/11 PASS

--- a/docs/dev_log_260812.md
+++ b/docs/dev_log_260812.md
@@ -12,3 +12,4 @@
 - E2E(live): `playwright-cli` real dev Web+API로 401/403/422 Problem Details·관리자 signup `100%_exact` literal 검색 PASS
 - API(D9): OpenAPI operation responses를 `ProblemDetailsError`로 연결, legacy `HTTPValidationError` 제거
 - Test: signup 검색 `\` literal 케이스·OpenAPI operation error contract regression 추가
+- API(D9): 5xx 응답을 외부 `internal_error`+안전 detail로 통일, 내부 code/detail은 로그/Sentry만

--- a/docs/dev_log_260812.md
+++ b/docs/dev_log_260812.md
@@ -4,3 +4,4 @@
 - Docs: `.agents/skills/playwright-cli`는 upstream/tool copy로 유지하고 repository-specific E2E 정책은 runbook으로 분리
 - Docs: `docs/agents_base_kr.md`, `docs/ci_quality_gates.md`에 runbook 라우팅 추가
 - Docs: E2E runbook §3.1/§5.2에 `:3000` owner-aware suspend/restore 추가 (live→mock EADDRINUSE 방지)
+- API(D9): Problem Details 통합 핸들러(#259), router→service 레이어 복구·AST guard(#261), signup 검색 `escape_like`(#274)

--- a/ops/ci/guards.py
+++ b/ops/ci/guards.py
@@ -241,10 +241,25 @@ def check_workflow_policies() -> list[str]:
     return []
 
 
+def check_router_layer_guard() -> list[str]:
+    script = ROOT / "ops/ci/router_layer_guard.py"
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return []
+    output = proc.stdout.strip() or proc.stderr.strip()
+    return [output] if output else ["router_layer_guard failed"]
+
+
 def main() -> int:
     all_violations = check_agent_harness()
     all_violations.extend(check_no_tracked_runtime_logs())
     all_violations.extend(check_workflow_policies())
+    all_violations.extend(check_router_layer_guard())
     for path in iter_code_files():
         all_violations.extend(check_banned_comments(path))
         all_violations.extend(check_max_lines(path))

--- a/ops/ci/router_layer_guard.py
+++ b/ops/ci/router_layer_guard.py
@@ -1,0 +1,70 @@
+"""Router 계층이 repository·ORM에 직접 접근하지 않도록 AST 검사."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ROUTERS_DIR = ROOT / "apps/api/routers"
+
+
+def _is_forbidden_repo_module(module: str | None) -> bool:
+    if not module:
+        return False
+    return module.endswith("repositories") or ".repositories." in module
+
+
+def _is_forbidden_models_module(module: str | None) -> bool:
+    if not module:
+        return False
+    return module in {"..models", "apps.api.models"} or module.endswith(".models")
+
+
+def check_router_file(path: Path) -> list[str]:
+    violations: list[str] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if _is_forbidden_repo_module(node.module):
+                violations.append(
+                    f"{path}:{node.lineno}: router must not import repositories"
+                )
+            if _is_forbidden_models_module(node.module):
+                violations.append(
+                    f"{path}:{node.lineno}: router must not import models"
+                )
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "refresh" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id == "db":
+                    violations.append(
+                        f"{path}:{node.lineno}: router must not call db.refresh"
+                    )
+    return violations
+
+
+def check_router_layer() -> list[str]:
+    if not ROUTERS_DIR.is_dir():
+        return [f"{ROUTERS_DIR}: routers directory is missing"]
+    violations: list[str] = []
+    for path in sorted(ROUTERS_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        violations.extend(check_router_file(path))
+    return violations
+
+
+def main() -> int:
+    violations = check_router_layer()
+    if violations:
+        print(
+            "[router-layer-guard] Violations detected:\n"
+            + "\n".join(sorted(violations))
+        )
+        return 1
+    print("[router-layer-guard] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/ci/router_layer_guard.py
+++ b/ops/ci/router_layer_guard.py
@@ -8,17 +8,34 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 ROUTERS_DIR = ROOT / "apps/api/routers"
 
+_FORBIDDEN_DB_ATTRS = frozenset(
+    {"execute", "commit", "rollback", "delete", "flush", "merge", "add", "refresh"}
+)
 
-def _is_forbidden_repo_module(module: str | None) -> bool:
+
+def _module_mentions_repositories(module: str | None, *, level: int = 0) -> bool:
     if not module:
         return False
+    if module == "repositories" or module.startswith("repositories."):
+        return level >= 1
     return module.endswith("repositories") or ".repositories." in module
 
 
-def _is_forbidden_models_module(module: str | None) -> bool:
-    if not module:
-        return False
-    return module in {"..models", "apps.api.models"} or module.endswith(".models")
+def _import_from_mentions_models(node: ast.ImportFrom) -> bool:
+    module = node.module
+    if module and (
+        module == "models"
+        or module.endswith(".models")
+        or module in {"apps.api.models"}
+    ):
+        if module == "models":
+            return node.level >= 1
+        return True
+    return any(alias.name == "models" for alias in node.names)
+
+
+def _import_mentions_repositories(node: ast.Import) -> bool:
+    return any("repositories" in alias.name for alias in node.names)
 
 
 def check_router_file(path: Path) -> list[str]:
@@ -26,19 +43,24 @@ def check_router_file(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if _is_forbidden_repo_module(node.module):
+            if _module_mentions_repositories(node.module, level=node.level):
                 violations.append(
                     f"{path}:{node.lineno}: router must not import repositories"
                 )
-            if _is_forbidden_models_module(node.module):
+            if _import_from_mentions_models(node):
                 violations.append(
                     f"{path}:{node.lineno}: router must not import models"
                 )
+        if isinstance(node, ast.Import) and _import_mentions_repositories(node):
+            violations.append(
+                f"{path}:{node.lineno}: router must not import repositories"
+            )
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if node.func.attr == "refresh" and isinstance(node.func.value, ast.Name):
-                if node.func.value.id == "db":
+            if isinstance(node.func.value, ast.Name) and node.func.value.id == "db":
+                if node.func.attr in _FORBIDDEN_DB_ATTRS:
                     violations.append(
-                        f"{path}:{node.lineno}: router must not call db.refresh"
+                        f"{path}:{node.lineno}: router must not call db."
+                        f"{node.func.attr}"
                     )
     return violations
 

--- a/ops/ci/run_mock_e2e_local.sh
+++ b/ops/ci/run_mock_e2e_local.sh
@@ -1,26 +1,37 @@
 #!/usr/bin/env bash
-# Local mock regression E2E (CI-parity). Optional env: apps/web/e2e/env.example
+# Local mock regression E2E (CI-parity). See apps/web/e2e/env.example
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 MOCK_PORT="${E2E_MOCK_API_PORT:-3001}"
 API_BASE="${NEXT_PUBLIC_WEB_API_BASE:-http://127.0.0.1:${MOCK_PORT}}"
 CONTROL_URL="${E2E_MOCK_API_CONTROL_URL:-${API_BASE}}"
+WEB_BASE="${WEB_BASE_URL:-http://127.0.0.1:3000}"
 
-pkill -f 'mock-api-server.mjs' 2>/dev/null || true
-pkill -f 'next start -p 3000' 2>/dev/null || true
-fuser -k 3000/tcp "${MOCK_PORT}"/tcp 2>/dev/null || true
-sleep 2
-
+HOST_WEB_BEFORE="no"
+HOST_API_BEFORE="no"
 MOCK_PID=""
 WEB_PID=""
+
+if ss -ltn 2>/dev/null | grep -q ':3000 '; then
+  if [ -f apps/web/.web-dev.pid ]; then HOST_WEB_BEFORE="yes"; fi
+fi
+if ss -ltn 2>/dev/null | grep -q ':3001 '; then
+  if [ -f .api-dev.pid ]; then HOST_API_BEFORE="yes"; fi
+fi
+
 cleanup() {
   if [ -n "${WEB_PID}" ]; then kill "${WEB_PID}" 2>/dev/null || true; wait "${WEB_PID}" 2>/dev/null || true; fi
   if [ -n "${MOCK_PID}" ]; then kill "${MOCK_PID}" 2>/dev/null || true; wait "${MOCK_PID}" 2>/dev/null || true; fi
+  if [ "${HOST_WEB_BEFORE}" = "yes" ]; then make web-start >/dev/null 2>&1 || true; fi
+  if [ "${HOST_API_BEFORE}" = "yes" ]; then make api-start >/dev/null 2>&1 || true; fi
 }
 trap cleanup EXIT INT TERM
 
-export WEB_BASE_URL="${WEB_BASE_URL:-http://127.0.0.1:3000}"
+if [ "${HOST_WEB_BEFORE}" = "yes" ]; then make web-stop >/dev/null 2>&1 || true; fi
+if [ "${HOST_API_BEFORE}" = "yes" ]; then make api-stop >/dev/null 2>&1 || true; fi
+
+export WEB_BASE_URL="${WEB_BASE}"
 export NEXT_PUBLIC_WEB_API_BASE="${API_BASE}"
 export WEB_BUILD_ALLOW_INSECURE_LOCAL_API="${WEB_BUILD_ALLOW_INSECURE_LOCAL_API:-1}"
 export E2E_MOCK_API_CONTROL_URL="${CONTROL_URL}"

--- a/ops/ci/run_mock_e2e_local.sh
+++ b/ops/ci/run_mock_e2e_local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Local mock regression E2E (CI-parity). Optional env: apps/web/e2e/env.example
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+MOCK_PORT="${E2E_MOCK_API_PORT:-3001}"
+API_BASE="${NEXT_PUBLIC_WEB_API_BASE:-http://127.0.0.1:${MOCK_PORT}}"
+CONTROL_URL="${E2E_MOCK_API_CONTROL_URL:-${API_BASE}}"
+
+pkill -f 'mock-api-server.mjs' 2>/dev/null || true
+pkill -f 'next start -p 3000' 2>/dev/null || true
+fuser -k 3000/tcp "${MOCK_PORT}"/tcp 2>/dev/null || true
+sleep 2
+
+MOCK_PID=""
+WEB_PID=""
+cleanup() {
+  if [ -n "${WEB_PID}" ]; then kill "${WEB_PID}" 2>/dev/null || true; wait "${WEB_PID}" 2>/dev/null || true; fi
+  if [ -n "${MOCK_PID}" ]; then kill "${MOCK_PID}" 2>/dev/null || true; wait "${MOCK_PID}" 2>/dev/null || true; fi
+}
+trap cleanup EXIT INT TERM
+
+export WEB_BASE_URL="${WEB_BASE_URL:-http://127.0.0.1:3000}"
+export NEXT_PUBLIC_WEB_API_BASE="${API_BASE}"
+export WEB_BUILD_ALLOW_INSECURE_LOCAL_API="${WEB_BUILD_ALLOW_INSECURE_LOCAL_API:-1}"
+export E2E_MOCK_API_CONTROL_URL="${CONTROL_URL}"
+export E2E_MOCK_API_PORT="${MOCK_PORT}"
+
+echo "[e2e] api=${NEXT_PUBLIC_WEB_API_BASE} web=${WEB_BASE_URL}"
+
+echo "[e2e] build"
+pnpm -C apps/web build
+
+echo "[e2e] mock :${MOCK_PORT}"
+node apps/web/e2e/mock-api-server.mjs > /tmp/mock-api.log 2>&1 &
+MOCK_PID=$!
+sleep 1
+kill -0 "${MOCK_PID}"
+curl -fsS "${NEXT_PUBLIC_WEB_API_BASE}/healthz" | grep -q '"ok":true'
+
+echo "[e2e] web"
+pnpm -C apps/web start > /tmp/web-start.log 2>&1 &
+WEB_PID=$!
+for _ in $(seq 1 60); do
+  curl -fsS "${WEB_BASE_URL}/" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -fsS "${WEB_BASE_URL}/" >/dev/null
+
+echo "[e2e] tests"
+PUPPETEER_EXECUTABLE_PATH="${PUPPETEER_EXECUTABLE_PATH:-/usr/bin/google-chrome-stable}" \
+  pnpm -C apps/web e2e

--- a/packages/schemas/index.d.ts
+++ b/packages/schemas/index.d.ts
@@ -2228,8 +2228,68 @@ export interface components {
              */
             ts?: number | null;
         };
+        /** ValidationErrorItem */
+        ValidationErrorItem: {
+            /** Type */
+            type: string;
+            /** Loc */
+            loc: (string | number)[];
+            /** Msg */
+            msg: string;
+            /**
+             * Input
+             * @default null
+             */
+            input: unknown | null;
+            /**
+             * Ctx
+             * @default null
+             */
+            ctx: {
+                [key: string]: string;
+            } | null;
+        };
+        /** ProblemDetailsResponse */
+        ProblemDetails: {
+            /**
+             * Type
+             * @default about:blank
+             */
+            type: string;
+            /**
+             * Title
+             * @default
+             */
+            title: string;
+            /** Status */
+            status: number;
+            /** Detail */
+            detail: string;
+            /** Code */
+            code: string;
+            /**
+             * Request Id
+             * @default null
+             */
+            request_id: string | null;
+            /**
+             * Errors
+             * @default null
+             */
+            errors: components["schemas"]["ValidationErrorItem"][] | null;
+        };
     };
-    responses: never;
+    responses: {
+        /** @description Problem Details error response */
+        ProblemDetailsError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ProblemDetails"];
+            };
+        };
+    };
     parameters: never;
     requestBodies: never;
     headers: never;

--- a/packages/schemas/index.d.ts
+++ b/packages/schemas/index.d.ts
@@ -1421,11 +1421,6 @@ export interface components {
             /** Capacity */
             capacity?: number | null;
         };
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
         /** HeroItemCreate */
         HeroItemCreate: {
             /**
@@ -2161,19 +2156,6 @@ export interface components {
              */
             endpoint: string;
         };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
-        };
         /** WebVitalEvent */
         WebVitalEvent: {
             /**
@@ -2317,6 +2299,14 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_members_members__get: {
@@ -2348,15 +2338,14 @@ export interface operations {
                     "application/json": components["schemas"]["DirectoryMemberRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     count_members_members_count_get: {
@@ -2388,15 +2377,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberCount"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_member_members__member_id__get: {
@@ -2419,15 +2407,14 @@ export interface operations {
                     "application/json": components["schemas"]["DirectoryMemberRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_posts_posts__get: {
@@ -2454,15 +2441,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_post_posts__post: {
@@ -2487,15 +2473,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_post_posts__post_id__get: {
@@ -2518,15 +2503,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_post_posts__post_id__delete: {
@@ -2551,15 +2535,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_post_posts__post_id__patch: {
@@ -2586,15 +2569,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_board_post_board_posts__post_id__delete: {
@@ -2619,15 +2601,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_board_post_board_posts__post_id__patch: {
@@ -2654,15 +2635,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_comments_comments__get: {
@@ -2685,15 +2665,14 @@ export interface operations {
                     "application/json": components["schemas"]["CommentRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_comment_comments__post: {
@@ -2718,15 +2697,14 @@ export interface operations {
                     "application/json": components["schemas"]["CommentRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_comment_comments__comment_id__delete: {
@@ -2747,15 +2725,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_events_events__get: {
@@ -2779,15 +2756,14 @@ export interface operations {
                     "application/json": components["schemas"]["EventRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_event_events__post: {
@@ -2812,15 +2788,14 @@ export interface operations {
                     "application/json": components["schemas"]["EventRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_event_events__event_id__get: {
@@ -2843,15 +2818,14 @@ export interface operations {
                     "application/json": components["schemas"]["EventRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_rsvp_events__event_id__rsvp_post: {
@@ -2878,15 +2852,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_rsvps_rsvps__get: {
@@ -2910,15 +2883,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_rsvp_rsvps__post: {
@@ -2943,15 +2915,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_rsvp_rsvps__member_id___event_id__get: {
@@ -2975,15 +2946,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     login_auth_login_post: {
@@ -3010,15 +2980,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     logout_endpoint_auth_logout_post: {
@@ -3037,6 +3006,14 @@ export interface operations {
                 };
                 content?: never;
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     me_auth_me_get: {
@@ -3059,6 +3036,14 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     member_login_auth_member_login_post: {
@@ -3085,15 +3070,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     member_signup_auth_member_signup_post: {
@@ -3118,15 +3102,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupRequestRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     member_logout_auth_member_logout_post: {
@@ -3145,6 +3128,14 @@ export interface operations {
                 };
                 content?: never;
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     member_me_auth_member_me_get: {
@@ -3167,6 +3158,14 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     member_activate_endpoint_auth_member_activate_post: {
@@ -3193,15 +3192,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     change_password_auth_member_change_password_post: {
@@ -3228,15 +3226,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     session_auth_session_get: {
@@ -3259,6 +3256,14 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_hero_slides_hero__get: {
@@ -3282,15 +3287,14 @@ export interface operations {
                     "application/json": components["schemas"]["HeroSlide"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     save_subscription_notifications_subscriptions_post: {
@@ -3313,15 +3317,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_subscription_notifications_subscriptions_delete: {
@@ -3344,15 +3347,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     send_push_notifications_admin_notifications_send_post: {
@@ -3379,15 +3381,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_send_logs_notifications_admin_notifications_logs_get: {
@@ -3410,15 +3411,14 @@ export interface operations {
                     "application/json": components["schemas"]["SendLogRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_stats_notifications_admin_notifications_stats_get: {
@@ -3441,15 +3441,14 @@ export interface operations {
                     "application/json": components["schemas"]["NotificationStats"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     prune_logs_notifications_admin_notifications_prune_logs_post: {
@@ -3476,15 +3475,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     trigger_scheduled_notifications_notifications_admin_notifications_trigger_scheduled_post: {
@@ -3511,15 +3509,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_scheduled_logs_notifications_admin_notifications_scheduled_logs_get: {
@@ -3542,15 +3539,14 @@ export interface operations {
                     "application/json": components["schemas"]["ScheduledLogRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     contact_support_contact_post: {
@@ -3577,15 +3573,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_tickets_support_admin_tickets_get: {
@@ -3608,15 +3603,14 @@ export interface operations {
                     "application/json": components["schemas"]["TicketRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_me_me__get: {
@@ -3637,6 +3631,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"];
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_me_me__put: {
@@ -3661,15 +3663,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     upload_avatar_me_avatar_post: {
@@ -3694,15 +3695,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_my_change_requests_me_change_requests_get: {
@@ -3723,6 +3723,14 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileChangeRequestRead"][];
                 };
             };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_change_request_me_change_requests_post: {
@@ -3747,15 +3755,14 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileChangeRequestRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     ingest_vitals_rum_vitals_post: {
@@ -3782,15 +3789,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     upload_image_uploads_images_post: {
@@ -3815,15 +3821,14 @@ export interface operations {
                     "application/json": components["schemas"]["ImageUploadResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_image_uploads_images__filename__delete: {
@@ -3844,15 +3849,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_admin_posts_admin_posts__get: {
@@ -3879,15 +3883,14 @@ export interface operations {
                     "application/json": components["schemas"]["AdminPostListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     preview_admin_post_admin_posts__post_id__preview_get: {
@@ -3910,15 +3913,14 @@ export interface operations {
                     "application/json": components["schemas"]["PostRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_admin_events_admin_events__get: {
@@ -3946,15 +3948,14 @@ export interface operations {
                     "application/json": components["schemas"]["AdminEventListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_admin_event_admin_events__event_id__delete: {
@@ -3975,15 +3976,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_admin_event_admin_events__event_id__patch: {
@@ -4010,15 +4010,14 @@ export interface operations {
                     "application/json": components["schemas"]["EventRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_member_rsvp_admin_events__event_id__rsvps__member_id__get: {
@@ -4042,15 +4041,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     upsert_member_rsvp_admin_events__event_id__rsvps__member_id__post: {
@@ -4078,15 +4076,14 @@ export interface operations {
                     "application/json": components["schemas"]["RSVPRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_admin_hero_items_admin_hero__get: {
@@ -4110,15 +4107,14 @@ export interface operations {
                     "application/json": components["schemas"]["AdminHeroListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_admin_hero_item_admin_hero__post: {
@@ -4143,15 +4139,14 @@ export interface operations {
                     "application/json": components["schemas"]["HeroItemRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     lookup_admin_hero_items_admin_hero_lookup_post: {
@@ -4176,15 +4171,14 @@ export interface operations {
                     "application/json": components["schemas"]["HeroTargetLookupResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_admin_hero_item_admin_hero__hero_item_id__get: {
@@ -4207,15 +4201,14 @@ export interface operations {
                     "application/json": components["schemas"]["HeroItemRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     delete_admin_hero_item_admin_hero__hero_item_id__delete: {
@@ -4240,15 +4233,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_admin_hero_item_admin_hero__hero_item_id__patch: {
@@ -4275,15 +4267,14 @@ export interface operations {
                     "application/json": components["schemas"]["HeroItemRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_members_admin_admin_members__get: {
@@ -4310,15 +4301,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"][];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     create_member_direct_admin_members__post: {
@@ -4343,15 +4333,14 @@ export interface operations {
                     "application/json": components["schemas"]["DirectMemberCreateResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     count_members_admin_admin_members_count_get: {
@@ -4377,15 +4366,14 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     get_member_admin_admin_members__member_id__get: {
@@ -4408,15 +4396,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_member_admin_admin_members__member_id__patch: {
@@ -4443,15 +4430,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     update_member_roles_admin_members__member_id__roles_patch: {
@@ -4478,15 +4464,14 @@ export interface operations {
                     "application/json": components["schemas"]["MemberRolesUpdateResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_signup_requests_admin_signup_requests__get: {
@@ -4512,15 +4497,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupRequestListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     approve_signup_request_admin_signup_requests__signup_request_id__approve_post: {
@@ -4543,15 +4527,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupActivationIssueResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     reissue_signup_activation_token_admin_signup_requests__signup_request_id__reissue_token_post: {
@@ -4574,15 +4557,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupActivationIssueResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_signup_activation_token_logs_admin_signup_requests__signup_request_id__activation_token_logs_get: {
@@ -4607,15 +4589,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupActivationIssueLogListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     reject_signup_request_admin_signup_requests__signup_request_id__reject_post: {
@@ -4642,15 +4623,14 @@ export interface operations {
                     "application/json": components["schemas"]["SignupRequestRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     list_profile_change_requests_admin_profile_change_requests__get: {
@@ -4676,15 +4656,14 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileChangeRequestListResponse"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     approve_profile_change_request_admin_profile_change_requests__request_id__approve_post: {
@@ -4707,15 +4686,14 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileChangeRequestRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
     reject_profile_change_request_admin_profile_change_requests__request_id__reject_post: {
@@ -4742,15 +4720,14 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileChangeRequestRead"];
                 };
             };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+            400: components["responses"]["ProblemDetailsError"];
+            401: components["responses"]["ProblemDetailsError"];
+            403: components["responses"]["ProblemDetailsError"];
+            404: components["responses"]["ProblemDetailsError"];
+            409: components["responses"]["ProblemDetailsError"];
+            422: components["responses"]["ProblemDetailsError"];
+            429: components["responses"]["ProblemDetailsError"];
+            500: components["responses"]["ProblemDetailsError"];
         };
     };
 }

--- a/packages/schemas/openapi.json
+++ b/packages/schemas/openapi.json
@@ -7218,6 +7218,136 @@
           "value"
         ],
         "title": "WebVitalEvent"
+      },
+      "ValidationErrorItem": {
+        "properties": {
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Loc",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Msg",
+            "type": "string"
+          },
+          "input": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Input"
+          },
+          "ctx": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ctx"
+          }
+        },
+        "required": [
+          "type",
+          "loc",
+          "msg"
+        ],
+        "title": "ValidationErrorItem",
+        "type": "object"
+      },
+      "ProblemDetails": {
+        "properties": {
+          "type": {
+            "default": "about:blank",
+            "title": "Type",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "integer"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Request Id"
+          },
+          "errors": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ValidationErrorItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Errors"
+          }
+        },
+        "required": [
+          "status",
+          "detail",
+          "code"
+        ],
+        "title": "ProblemDetailsResponse",
+        "type": "object"
+      }
+    },
+    "responses": {
+      "ProblemDetailsError": {
+        "description": "Problem Details error response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ProblemDetails"
+            }
+          }
+        }
       }
     }
   }

--- a/packages/schemas/openapi.json
+++ b/packages/schemas/openapi.json
@@ -23,6 +23,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -203,14 +227,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -387,14 +425,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -429,14 +481,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -541,14 +607,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -580,14 +660,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -622,14 +716,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -673,14 +781,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -725,14 +847,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -778,14 +914,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -830,14 +980,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -877,14 +1041,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -917,14 +1095,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -953,14 +1145,28 @@
             "description": "Successful Response"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1013,14 +1219,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -1052,14 +1272,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1094,14 +1328,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1146,14 +1394,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1206,14 +1468,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -1245,14 +1521,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1296,14 +1586,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1342,14 +1646,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1365,6 +1683,30 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1398,6 +1740,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1436,14 +1802,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1478,14 +1858,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1501,6 +1895,30 @@
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1527,6 +1945,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1565,14 +2007,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1611,14 +2067,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1643,6 +2113,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1694,14 +2188,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1729,14 +2237,28 @@
             "description": "Successful Response"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -1761,14 +2283,28 @@
             "description": "Successful Response"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1806,14 +2342,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1853,14 +2403,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1896,14 +2460,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -1948,14 +2526,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2001,14 +2593,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2049,14 +2655,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2094,14 +2714,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2143,14 +2777,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2172,6 +2820,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -2203,14 +2875,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2244,14 +2930,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2277,6 +2977,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "422": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -2308,14 +3032,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2354,14 +3092,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2396,14 +3148,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2432,14 +3198,28 @@
             "description": "Successful Response"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2539,14 +3319,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2582,14 +3376,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2711,14 +3519,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2763,14 +3585,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -2796,14 +3632,28 @@
             "description": "Successful Response"
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2858,14 +3708,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -2908,14 +3772,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -2964,14 +3842,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -3003,14 +3895,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3045,14 +3951,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3087,14 +4007,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -3137,14 +4071,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -3188,14 +4136,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3297,14 +4259,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -3337,14 +4313,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3407,14 +4397,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3450,14 +4454,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       },
@@ -3501,14 +4519,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3554,14 +4586,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3650,14 +4696,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3692,14 +4752,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3734,14 +4808,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3788,14 +4876,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3840,14 +4942,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3933,14 +5049,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -3975,14 +5105,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -4027,14 +5171,28 @@
             }
           },
           "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "400": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "401": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "404": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "429": {
+            "$ref": "#/components/responses/ProblemDetailsError"
+          },
+          "500": {
+            "$ref": "#/components/responses/ProblemDetailsError"
           }
         }
       }
@@ -4909,19 +6067,6 @@
         },
         "type": "object",
         "title": "EventUpdate"
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
       },
       "HeroItemCreate": {
         "properties": {
@@ -7048,46 +8193,6 @@
           "endpoint"
         ],
         "title": "UnsubscribePayload"
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
-          }
-        },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
       },
       "WebVitalEvent": {
         "properties": {

--- a/tests/api/problem_assertions.py
+++ b/tests/api/problem_assertions.py
@@ -1,0 +1,15 @@
+"""Problem Details 응답 assertion helper."""
+
+from __future__ import annotations
+
+from apps.api.error_messages import USER_FACING_DETAILS
+
+
+def assert_problem_code(body: dict[str, object], code: str) -> None:
+    assert body["code"] == code
+    expected_detail = USER_FACING_DETAILS.get(code)
+    assert isinstance(body["detail"], str)
+    if expected_detail is not None:
+        assert body["detail"] == expected_detail
+    else:
+        assert body["detail"] != code

--- a/tests/api/test_abc_phase1.py
+++ b/tests/api/test_abc_phase1.py
@@ -14,6 +14,7 @@ from apps.api import models
 from apps.api.db import get_db
 from apps.api.main import app
 from apps.api.services.activation_service import create_member_activation_token
+from tests.api.problem_assertions import assert_problem_code
 
 
 def _run_in_test_session(fn: Callable[[AsyncSession], Awaitable[None]]) -> None:
@@ -90,7 +91,7 @@ def test_member_activate_invalid_token_401(admin_login: TestClient) -> None:
         json={"token": "bad", "password": "pw"},
     )
     assert res.status_code == HTTPStatus.UNAUTHORIZED
-    assert res.json()["detail"] == "invalid_or_expired_activation_token"
+    assert_problem_code(res.json(), "invalid_or_expired_activation_token")
 
 
 def test_member_activate_pending_blocked_401(admin_login: TestClient) -> None:
@@ -118,7 +119,7 @@ def test_member_activate_pending_blocked_401(admin_login: TestClient) -> None:
         json={"token": token, "password": "pw"},
     )
     assert res.status_code == HTTPStatus.UNAUTHORIZED
-    assert res.json()["detail"] == "invalid_or_expired_activation_token"
+    assert_problem_code(res.json(), "invalid_or_expired_activation_token")
 
 
 def test_member_activate_already_used_409(admin_login: TestClient) -> None:
@@ -133,7 +134,7 @@ def test_member_activate_already_used_409(admin_login: TestClient) -> None:
         "/auth/member/activate", json={"token": token, "password": "pw2"}
     )
     assert second.status_code == HTTPStatus.CONFLICT
-    assert second.json()["detail"] == "activation_already_used"
+    assert_problem_code(second.json(), "activation_already_used")
 
 
 def test_member_activate_expired_token_401(
@@ -152,7 +153,7 @@ def test_member_activate_expired_token_401(
         json={"token": token, "password": "pw"},
     )
     assert res.status_code == HTTPStatus.UNAUTHORIZED
-    assert res.json()["detail"] == "invalid_or_expired_activation_token"
+    assert_problem_code(res.json(), "invalid_or_expired_activation_token")
 
 
 def test_member_login_inactive_blocked(client: TestClient) -> None:
@@ -184,7 +185,7 @@ def test_member_login_inactive_blocked(client: TestClient) -> None:
         json={"student_id": "inactive001", "password": "pw"},
     )
     assert res.status_code == HTTPStatus.FORBIDDEN
-    assert res.json()["detail"] == "member_not_active"
+    assert_problem_code(res.json(), "member_not_active")
 
 
 def test_support_contact_rate_limit(

--- a/tests/api/test_admin_roles_api.py
+++ b/tests/api/test_admin_roles_api.py
@@ -15,6 +15,7 @@ from apps.api.db import get_db
 from apps.api.errors import ApiError
 from apps.api.main import app
 from apps.api.services import members_service
+from tests.api.problem_assertions import assert_problem_code
 
 
 def _run_in_test_session(coro: Callable[[AsyncSession], Awaitable[None]]) -> None:
@@ -181,7 +182,7 @@ def test_admin_without_super_admin_cannot_create_member_direct(
         },
     )
     assert create_res.status_code == HTTPStatus.FORBIDDEN
-    assert create_res.json()["detail"] == "super_admin_required"
+    assert_problem_code(create_res.json(), "super_admin_required")
 
 
 def test_create_member_direct_returns_conflict_when_already_exists(
@@ -221,7 +222,7 @@ def test_admin_without_super_admin_cannot_patch_roles(client: TestClient) -> Non
         json={"roles": ["admin", "admin_posts"]},
     )
     assert patch_res.status_code == HTTPStatus.FORBIDDEN
-    assert patch_res.json()["detail"] == "super_admin_required"
+    assert_problem_code(patch_res.json(), "super_admin_required")
 
 
 def test_super_admin_cannot_self_demote(admin_login: TestClient) -> None:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from apps.api import models
 from apps.api.db import get_db
 from apps.api.main import app
+from tests.api.problem_assertions import assert_problem_code
 
 
 def _seed_admin(client: TestClient, student_id: str, password: str) -> int:
@@ -102,7 +103,7 @@ def test_login_success_and_protected_routes(client: TestClient) -> None:
 def test_login_failure(client: TestClient) -> None:
     res = client.post("/auth/login", json={"student_id": "none001", "password": "x"})
     assert res.status_code == HTTPStatus.UNAUTHORIZED
-    assert res.json()["detail"] == "login_failed"
+    assert_problem_code(res.json(), "login_failed")
     assert res.json()["code"] == "login_failed"
 
 
@@ -187,7 +188,7 @@ def test_login_pending_member_returns_pending_reason(client: TestClient) -> None
         json={"student_id": "pending001", "password": "pw"},
     )
     assert res.status_code == HTTPStatus.FORBIDDEN
-    assert res.json()["detail"] == "member_pending_approval"
+    assert_problem_code(res.json(), "member_pending_approval")
     assert res.json()["code"] == "member_pending_approval"
 
 
@@ -228,5 +229,5 @@ def test_login_inactive_with_wrong_password_returns_login_failed(
         json={"student_id": "inactive-oracle-001", "password": "wrong-password"},
     )
     assert res.status_code == HTTPStatus.UNAUTHORIZED
-    assert res.json()["detail"] == "login_failed"
+    assert_problem_code(res.json(), "login_failed")
     assert res.json()["code"] == "login_failed"

--- a/tests/api/test_d1_auth_role_authority.py
+++ b/tests/api/test_d1_auth_role_authority.py
@@ -16,6 +16,7 @@ from apps.api.errors import ApiError
 from apps.api.main import app
 from apps.api.repositories import members as members_repo
 from apps.api.services import members_service
+from tests.api.problem_assertions import assert_problem_code
 
 
 def _run_in_test_session(
@@ -207,7 +208,7 @@ def test_existing_session_uses_current_roles_and_status(client: TestClient) -> N
         json={"roles": ["member"]},
     )
     assert demoted.status_code == HTTPStatus.FORBIDDEN
-    assert demoted.json()["detail"] == "super_admin_required"
+    assert_problem_code(demoted.json(), "super_admin_required")
 
     event_write = client.post(
         "/events/",

--- a/tests/api/test_d4_posts_authority.py
+++ b/tests/api/test_d4_posts_authority.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from apps.api.post_visibility import BOARD_POST_CATEGORIES
+from tests.api.problem_assertions import assert_problem_code
 
 
 def test_public_hides_notice_draft_and_future(admin_login: TestClient) -> None:
@@ -416,8 +417,8 @@ def test_admin_hero_can_read_preview_without_post_management(
         f"/posts/{post_id}", json={"title": "수정 거부"}
     )
     assert update_attempt.status_code == HTTPStatus.FORBIDDEN
-    assert update_attempt.json()["detail"] == "admin_permission_required"
+    assert_problem_code(update_attempt.json(), "admin_permission_required")
 
     delete_attempt = admin_login.delete(f"/posts/{post_id}")
     assert delete_attempt.status_code == HTTPStatus.FORBIDDEN
-    assert delete_attempt.json()["detail"] == "admin_permission_required"
+    assert_problem_code(delete_attempt.json(), "admin_permission_required")

--- a/tests/api/test_d9_errors.py
+++ b/tests/api/test_d9_errors.py
@@ -2,20 +2,44 @@ from __future__ import annotations
 
 from http import HTTPStatus
 
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 
+from apps.api.main import app
+from apps.api.routers import notifications as router_mod
+from apps.api.services.notifications_service import PushProvider
 
-def test_http_exception_returns_problem_details(member_login: TestClient) -> None:
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_http_exception_separates_code_and_user_detail(
+    member_login: TestClient,
+) -> None:
     res = member_login.get("/admin/signup-requests")
     assert res.status_code == HTTPStatus.FORBIDDEN
     data = res.json()
     assert data["status"] == HTTPStatus.FORBIDDEN
     assert data["code"] == "admin_permission_required"
-    assert data["detail"] == "admin_permission_required"
-    assert "type" in data
+    assert data["detail"] == "이 작업을 수행할 운영 권한이 없습니다."
+    assert data["detail"] != data["code"]
+    assert data["type"] == "about:blank"
 
 
-def test_validation_error_returns_problem_details_shape(
+def test_framework_not_found_returns_problem_details(client: TestClient) -> None:
+    res = client.get("/this-route-does-not-exist-d9")
+    assert res.status_code == HTTPStatus.NOT_FOUND
+    data = res.json()
+    assert data["code"] == "not_found"
+    assert isinstance(data["detail"], str)
+    assert data["detail"] != "not_found"
+    assert data["status"] == HTTPStatus.NOT_FOUND
+
+
+def test_validation_error_uses_string_detail_and_errors_extension(
     admin_login: TestClient,
 ) -> None:
     e = admin_login.post(
@@ -32,6 +56,86 @@ def test_validation_error_returns_problem_details_shape(
     res = admin_login.post(f"/events/{e['id']}/rsvp", json={"status": "invalid"})
     assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     data = res.json()
-    assert data["status"] == HTTPStatus.UNPROCESSABLE_ENTITY
     assert data["code"] == "validation_error"
-    assert isinstance(data["detail"], list)
+    assert isinstance(data["detail"], str)
+    assert data["detail"] == "입력값을 확인해 주세요."
+    assert isinstance(data["errors"], list)
+    assert data["errors"]
+
+
+def test_validation_error_serializes_value_error_ctx(
+    client: TestClient,
+) -> None:
+    res = client.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s119001",
+            "email": "s119001@test.example.com",
+            "name": "전화검증",
+            "cohort": 2024,
+            "phone": "bad-phone",
+        },
+    )
+    assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    data = res.json()
+    assert data["code"] == "validation_error"
+    assert isinstance(data["detail"], str)
+    assert isinstance(data["errors"], list)
+    for item in data["errors"]:
+        ctx = item.get("ctx")
+        if ctx is not None:
+            assert all(isinstance(v, str) for v in ctx.values())
+
+
+@pytest.mark.anyio
+async def test_rate_limit_returns_problem_details(
+    admin_login: TestClient,
+    enable_rate_limit: None,
+) -> None:
+    class _DummyProvider(PushProvider):
+        def send(self, sub, payload):  # type: ignore[no-untyped-def]
+            return (True, 201)
+
+        async def send_async(self, sub, payload):  # type: ignore[no-untyped-def]
+            return (True, 201)
+
+    def _provider_override() -> _DummyProvider:
+        return _DummyProvider()
+
+    app.dependency_overrides[router_mod.get_push_provider] = _provider_override
+    try:
+        transport = httpx.ASGITransport(app=app, client=("1.2.3.4", 55555))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://local",
+        ) as hc:
+            login_res = await hc.post(
+                "/auth/login",
+                json={"student_id": "__seed__admin", "password": "__seed__"},
+            )
+            assert login_res.status_code == HTTPStatus.OK
+            sub_res = await hc.post(
+                "/notifications/subscriptions",
+                json={
+                    "endpoint": "https://example.com/ep/rl-d9",
+                    "p256dh": "k",
+                    "auth": "a",
+                },
+            )
+            assert sub_res.status_code == HTTPStatus.NO_CONTENT
+            limited_body: dict[str, object] | None = None
+            for _ in range(8):
+                response = await hc.post(
+                    "/notifications/admin/notifications/send",
+                    json={"title": "t", "body": "b"},
+                )
+                if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                    limited_body = response.json()
+                    break
+            assert limited_body is not None
+            assert limited_body["code"] == "rate_limit_exceeded"
+            assert limited_body["status"] == HTTPStatus.TOO_MANY_REQUESTS
+            assert isinstance(limited_body["detail"], str)
+            assert limited_body["detail"] != limited_body["code"]
+    finally:
+        app.dependency_overrides.pop(router_mod.get_push_provider, None)

--- a/tests/api/test_d9_errors.py
+++ b/tests/api/test_d9_errors.py
@@ -6,9 +6,17 @@ from http import HTTPStatus
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
 
-from apps.api.main import app
+from apps.api import models
+from apps.api.error_messages import (
+    USER_FACING_DETAILS,
+    code_and_detail_from_http_detail,
+)
+from apps.api.main import _handle_http_exception, app
 from apps.api.routers import notifications as router_mod
+from apps.api.routers.auth import require_member
 from apps.api.services.notifications_service import PushProvider
 
 
@@ -120,17 +128,92 @@ def test_openapi_operations_reference_problem_details_errors() -> None:
     assert checked > 0
 
 
+def test_code_and_detail_masks_internal_http_500_text() -> None:
+    code, detail = code_and_detail_from_http_detail(
+        "Member ID is None",
+        status=HTTPStatus.INTERNAL_SERVER_ERROR,
+    )
+    assert code == "internal_error"
+    assert detail == USER_FACING_DETAILS["internal_error"]
+    assert "Member" not in detail
+
+
+@pytest.mark.anyio
+async def test_http_exception_500_masks_internal_detail_and_request_id() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/comments/1",
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+            "http_version": "1.1",
+        }
+    )
+    request.state.request_id = "req-d9-http-500"
+    response = await _handle_http_exception(
+        request,
+        StarletteHTTPException(HTTPStatus.INTERNAL_SERVER_ERROR, "Member ID is None"),
+    )
+    body = json.loads(response.body)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert body["code"] == "internal_error"
+    assert body["detail"] == USER_FACING_DETAILS["internal_error"]
+    assert body["request_id"] == "req-d9-http-500"
+    assert response.headers["x-request-id"] == "req-d9-http-500"
+    assert "Member" not in body["detail"]
+
+
+def test_api_error_500_masks_internal_code_and_request_id(
+    member_login: TestClient,
+) -> None:
+    async def _member_without_id() -> models.Member:
+        return models.Member(
+            id=None,
+            student_id="ghost-member",
+            email="ghost@test.example.com",
+            name="Ghost",
+            cohort=2024,
+            roles="member",
+            status="active",
+        )
+
+    app.dependency_overrides[require_member] = _member_without_id
+    try:
+        res = member_login.patch(
+            "/board/posts/1",
+            json={"title": "t", "content": "c"},
+        )
+        assert res.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = res.json()
+        assert data["code"] == "internal_error"
+        assert data["detail"] == USER_FACING_DETAILS["internal_error"]
+        assert "member_id_missing" not in json.dumps(data)
+        request_id = res.headers.get("x-request-id")
+        assert request_id
+        assert data["request_id"] == request_id
+    finally:
+        app.dependency_overrides.pop(require_member, None)
+
+
 @pytest.mark.anyio
 async def test_rate_limit_returns_problem_details(
     admin_login: TestClient,
     enable_rate_limit: None,
 ) -> None:
     class _DummyProvider(PushProvider):
-        def send(self, sub, payload):  # type: ignore[no-untyped-def]
+        def send(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
             return (True, 201)
 
-        async def send_async(self, sub, payload):  # type: ignore[no-untyped-def]
-            return (True, 201)
+        async def send_async(
+            self, sub: models.PushSubscription, payload: dict[str, object]
+        ) -> tuple[bool, int | None]:
+            return self.send(sub, payload)
 
     def _provider_override() -> _DummyProvider:
         return _DummyProvider()

--- a/tests/api/test_d9_errors.py
+++ b/tests/api/test_d9_errors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+
+
+def test_http_exception_returns_problem_details(member_login: TestClient) -> None:
+    res = member_login.get("/admin/signup-requests")
+    assert res.status_code == HTTPStatus.FORBIDDEN
+    data = res.json()
+    assert data["status"] == HTTPStatus.FORBIDDEN
+    assert data["code"] == "admin_permission_required"
+    assert data["detail"] == "admin_permission_required"
+    assert "type" in data
+
+
+def test_validation_error_returns_problem_details_shape(
+    admin_login: TestClient,
+) -> None:
+    e = admin_login.post(
+        "/events/",
+        json={
+            "title": "Seminar",
+            "starts_at": "2030-03-01T10:00:00Z",
+            "ends_at": "2030-03-01T12:00:00Z",
+            "location": "Seoul",
+            "capacity": 10,
+        },
+    ).json()
+
+    res = admin_login.post(f"/events/{e['id']}/rsvp", json={"status": "invalid"})
+    assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    data = res.json()
+    assert data["status"] == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert data["code"] == "validation_error"
+    assert isinstance(data["detail"], list)

--- a/tests/api/test_d9_errors.py
+++ b/tests/api/test_d9_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from http import HTTPStatus
 
 import httpx
@@ -85,6 +86,38 @@ def test_validation_error_serializes_value_error_ctx(
         ctx = item.get("ctx")
         if ctx is not None:
             assert all(isinstance(v, str) for v in ctx.values())
+
+
+def test_openapi_operations_reference_problem_details_errors() -> None:
+    schema = app.openapi()
+    paths = schema.get("paths")
+    assert isinstance(paths, dict)
+    problem_ref = "#/components/responses/ProblemDetailsError"
+    checked = 0
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method not in {
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete",
+                "options",
+                "head",
+                "trace",
+            }:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            responses = operation.get("responses")
+            assert isinstance(responses, dict)
+            for status in ("400", "401", "403", "404", "409", "422", "429", "500"):
+                assert responses.get(status) == {"$ref": problem_ref}
+            assert "HTTPValidationError" not in json.dumps(responses)
+            checked += 1
+    assert checked > 0
 
 
 @pytest.mark.anyio

--- a/tests/api/test_profile_validation_v2.py
+++ b/tests/api/test_profile_validation_v2.py
@@ -109,5 +109,7 @@ def test_me_update_invalid_payload_returns_422(
     res = member_login.put("/me/", json=payload)
     assert res.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     body = res.json()
-    assert isinstance(body["detail"], list)
-    assert any(field in entry.get("loc", []) for entry in body["detail"])
+    assert body["code"] == "validation_error"
+    assert isinstance(body["detail"], str)
+    assert isinstance(body["errors"], list)
+    assert any(field in entry.get("loc", []) for entry in body["errors"])

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -173,6 +173,54 @@ def test_admin_signup_review_approve_and_reject(
     assert reject_body["reject_reason"] == "학번 확인 불가"
 
 
+def test_admin_signup_search_q_with_literal_wildcards(admin_login: TestClient) -> None:
+    target = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116900",
+            "email": "s116900@test.example.com",
+            "name": "100%_exact",
+            "cohort": 2024,
+            "phone": "010-2900-0001",
+        },
+    )
+    assert target.status_code == HTTPStatus.CREATED
+
+    bait = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116901",
+            "email": "s116901@test.example.com",
+            "name": "1000Zexact",
+            "cohort": 2024,
+            "phone": "010-2900-0002",
+        },
+    )
+    assert bait.status_code == HTTPStatus.CREATED
+
+    other = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": "s116902",
+            "email": "s116902@test.example.com",
+            "name": "다른 신청자",
+            "cohort": 2024,
+            "phone": "010-2900-0003",
+        },
+    )
+    assert other.status_code == HTTPStatus.CREATED
+
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "100%_exact", "status": "pending"},
+    )
+    assert found.status_code == HTTPStatus.OK
+    names = [item["name"] for item in found.json()["items"]]
+    assert "100%_exact" in names
+    assert "1000Zexact" not in names
+    assert "다른 신청자" not in names
+
+
 def test_admin_signup_reissue_token_and_logs(admin_login: TestClient) -> None:
     create_res = admin_login.post(
         "/auth/member/signup",

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -117,7 +117,9 @@ def test_admin_signup_review_approve_and_reject(
 
     forbidden_res = member_login.get("/admin/signup-requests")
     assert forbidden_res.status_code == HTTPStatus.FORBIDDEN
-    assert forbidden_res.json()["detail"] == "admin_permission_required"
+    forbidden_body = forbidden_res.json()
+    assert forbidden_body["code"] == "admin_permission_required"
+    assert forbidden_body["detail"] == "이 작업을 수행할 운영 권한이 없습니다."
 
     relogin_res = admin_login.post(
         "/auth/login",
@@ -221,6 +223,84 @@ def test_admin_signup_search_q_with_literal_wildcards(admin_login: TestClient) -
     assert "다른 신청자" not in names
 
 
+def _create_pending_signup(
+    admin_login: TestClient,
+    *,
+    student_id: str,
+    name: str,
+    phone: str,
+) -> None:
+    res = admin_login.post(
+        "/auth/member/signup",
+        json={
+            "student_id": student_id,
+            "email": f"{student_id}@test.example.com",
+            "name": name,
+            "cohort": 2024,
+            "phone": phone,
+        },
+    )
+    assert res.status_code == HTTPStatus.CREATED
+
+
+def test_admin_signup_search_percent_literal(admin_login: TestClient) -> None:
+    _create_pending_signup(
+        admin_login, student_id="s116910", name="리터럴%타깃", phone="010-2910-0001"
+    )
+    _create_pending_signup(
+        admin_login, student_id="s116911", name="리터럴Z타깃", phone="010-2910-0002"
+    )
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "리터럴%", "status": "pending"},
+    )
+    names = [item["name"] for item in found.json()["items"]]
+    assert "리터럴%타깃" in names
+    assert "리터럴Z타깃" not in names
+
+
+def test_admin_signup_search_underscore_literal(admin_login: TestClient) -> None:
+    _create_pending_signup(
+        admin_login, student_id="s116912", name="밑줄_타깃", phone="010-2912-0001"
+    )
+    _create_pending_signup(
+        admin_login, student_id="s116913", name="밑줄X타깃", phone="010-2912-0002"
+    )
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "밑줄_타깃", "status": "pending"},
+    )
+    names = [item["name"] for item in found.json()["items"]]
+    assert "밑줄_타깃" in names
+    assert "밑줄X타깃" not in names
+
+
+def test_admin_signup_search_whitespace_only_q_ignored(admin_login: TestClient) -> None:
+    _create_pending_signup(
+        admin_login, student_id="s116914", name="공백검색대상", phone="010-2914-0001"
+    )
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "   ", "status": "pending"},
+    )
+    assert found.status_code == HTTPStatus.OK
+    assert found.json()["total"] >= 1
+
+
+def test_admin_signup_search_trim_and_total_match(admin_login: TestClient) -> None:
+    _create_pending_signup(
+        admin_login, student_id="s116915", name="유니코드α검색", phone="010-2915-0001"
+    )
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "  유니코드α검색  ", "status": "pending"},
+    )
+    body = found.json()
+    names = [item["name"] for item in body["items"]]
+    assert "유니코드α검색" in names
+    assert body["total"] == len(body["items"])
+
+
 def test_admin_signup_reissue_token_and_logs(admin_login: TestClient) -> None:
     create_res = admin_login.post(
         "/auth/member/signup",
@@ -293,5 +373,7 @@ def test_member_signup_phone_required_422(client: TestClient) -> None:
     )
 
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-    detail = response.json()["detail"]
-    assert any("phone" in str(err.get("loc", "")) for err in detail)
+    body = response.json()
+    assert body["code"] == "validation_error"
+    assert isinstance(body["errors"], list)
+    assert any("phone" in str(err.get("loc", "")) for err in body["errors"])

--- a/tests/api/test_signup_requests_api.py
+++ b/tests/api/test_signup_requests_api.py
@@ -275,6 +275,22 @@ def test_admin_signup_search_underscore_literal(admin_login: TestClient) -> None
     assert "밑줄X타깃" not in names
 
 
+def test_admin_signup_search_backslash_literal(admin_login: TestClient) -> None:
+    _create_pending_signup(
+        admin_login, student_id="s116914", name="역슬래시\\타깃", phone="010-2914-0001"
+    )
+    _create_pending_signup(
+        admin_login, student_id="s116915", name="역슬래시X타깃", phone="010-2914-0002"
+    )
+    found = admin_login.get(
+        "/admin/signup-requests",
+        params={"q": "역슬래시\\타깃", "status": "pending"},
+    )
+    names = [item["name"] for item in found.json()["items"]]
+    assert "역슬래시\\타깃" in names
+    assert "역슬래시X타깃" not in names
+
+
 def test_admin_signup_search_whitespace_only_q_ignored(admin_login: TestClient) -> None:
     _create_pending_signup(
         admin_login, student_id="s116914", name="공백검색대상", phone="010-2914-0001"

--- a/tests/api/test_support_contact.py
+++ b/tests/api/test_support_contact.py
@@ -16,6 +16,7 @@ from apps.api.db import get_db
 from apps.api.main import app
 from apps.api.repositories import support_tickets as tickets_repo
 from apps.api.routers import support as support_router
+from tests.api.problem_assertions import assert_problem_code
 
 
 @pytest.fixture()
@@ -89,7 +90,7 @@ def test_admin_can_list_support_tickets(admin_login: TestClient) -> None:
 def test_member_cannot_list_support_tickets(member_login: TestClient) -> None:
     res = member_login.get("/support/admin/tickets?limit=20")
     assert res.status_code == HTTPStatus.FORBIDDEN
-    assert res.json()["detail"] == "admin_permission_required"
+    assert_problem_code(res.json(), "admin_permission_required")
 
 
 def test_active_admin_session_refreshes_backfilled_support_role(
@@ -252,7 +253,7 @@ def test_support_contact_db_failure_leaves_no_cooldown(
     with caplog.at_level("DEBUG"):
         failed = no_raise.post("/support/contact", json=payload)
     assert failed.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-    assert failed.json()["code"] == "support_ticket_persist_failed"
+    assert_problem_code(failed.json(), "internal_error")
     assert _count_support_tickets() == before
     assert support_router._recent == {}
 

--- a/tests/ops/test_router_layer_guard.py
+++ b/tests/ops/test_router_layer_guard.py
@@ -10,11 +10,51 @@ def test_router_layer_guard_passes_current_routers() -> None:
     assert violations == []
 
 
-def test_router_layer_guard_detects_repo_import(tmp_path: Path) -> None:
-    bad_router = tmp_path / "bad.py"
+def test_router_layer_guard_detects_repo_import_from(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad_from.py"
     bad_router.write_text(
         "from ..repositories import posts as posts_repo\n",
         encoding="utf-8",
     )
     violations = check_router_file(bad_router)
     assert any("repositories" in item for item in violations)
+
+
+def test_router_layer_guard_detects_repo_submodule_import(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad_submodule.py"
+    bad_router.write_text(
+        "from ..repositories.posts import get_post\n",
+        encoding="utf-8",
+    )
+    violations = check_router_file(bad_router)
+    assert any("repositories" in item for item in violations)
+
+
+def test_router_layer_guard_detects_repo_import_statement(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad_import.py"
+    bad_router.write_text(
+        "import apps.api.repositories.posts as posts_repo\n",
+        encoding="utf-8",
+    )
+    violations = check_router_file(bad_router)
+    assert any("repositories" in item for item in violations)
+
+
+def test_router_layer_guard_detects_models_import(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad_models.py"
+    bad_router.write_text(
+        "from ..models import Member\n",
+        encoding="utf-8",
+    )
+    violations = check_router_file(bad_router)
+    assert any("models" in item for item in violations)
+
+
+def test_router_layer_guard_detects_db_execute(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad_db.py"
+    bad_router.write_text(
+        "async def handler(db):\n    await db.execute('select 1')\n",
+        encoding="utf-8",
+    )
+    violations = check_router_file(bad_router)
+    assert any("db.execute" in item for item in violations)

--- a/tests/ops/test_router_layer_guard.py
+++ b/tests/ops/test_router_layer_guard.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ops.ci.router_layer_guard import check_router_file, check_router_layer
+
+
+def test_router_layer_guard_passes_current_routers() -> None:
+    violations = check_router_layer()
+    assert violations == []
+
+
+def test_router_layer_guard_detects_repo_import(tmp_path: Path) -> None:
+    bad_router = tmp_path / "bad.py"
+    bad_router.write_text(
+        "from ..repositories import posts as posts_repo\n",
+        encoding="utf-8",
+    )
+    violations = check_router_file(bad_router)
+    assert any("repositories" in item for item in violations)


### PR DESCRIPTION
## Summary
- #259: `HTTPException`/`RequestValidationError`/미처리 예외를 Problem Details 형식으로 통합 (`problem_details.py`, `error_messages.py`, `main.py`)
- #259: OpenAPI `components` + **모든 operation** `400/401/403/404/409/422/429/500` → `ProblemDetailsError` 연결 (legacy `HTTPValidationError` 제거)
- #261: posts/board/admin/support/notifications 라우터 repository 직접 호출 service 이동, `router_layer_guard` AST guard 강화
- #274: signup admin 검색 `escape_like` + `%`/`_`/`\` literal·trim·Unicode 회귀 테스트
- Web: `api.ts` Problem Details 파서, `error-map` 연동, generated TS DTO 갱신
- mock E2E spec API 포트 env 연동, `apps/web/e2e/env.example` 추가

## Live E2E (playwright-cli) — PASS
`make dev-up` (real Web `:3000` → API `:3001` → PostgreSQL) + `playwright-cli` 세션 분리 검증:

| 시나리오 | 결과 |
|---|---|
| 401 익명 `/admin/signup-requests` + `/auth/session` | PASS — `unauthorized`, 사용자 detail |
| 422 `/signup` 잘못된 전화번호 | PASS — `validation_error`, `errors[]`, UI 한국어 |
| 403 멤버 → admin signup | PASS — UI 권한 문구, API `admin_permission_required` + detail 분리 |
| 관리자 signup `100%_exact` literal 검색 | PASS — UI·real API 일치 |

## Test plan
- [x] `ops/ci/guards.py` + `router_layer_guard.py`
- [x] API pytest (D9 errors, signup wildcard/`\`, OpenAPI operation contract)
- [x] Mock regression E2E **11/11 PASS** (CI-parity `run_mock_e2e_local.sh`)
- [x] Live product E2E **4/4 PASS** (`playwright-cli`, real stack)
- [ ] GitHub `e2e.yml` CI (authoritative)

Closes #259, #261, #274