### PR TITLE
fix(web): 모바일 멀티 이미지 액션 hit target 보정

### DIFF
--- a/apps/web/__tests__/multi-image-upload.test.tsx
+++ b/apps/web/__tests__/multi-image-upload.test.tsx
@@ -8,7 +8,7 @@ describe('다중 이미지 썸네일 액션', () => {
     const onCoverChange = vi.fn();
     const onImagesChange = vi.fn();
 
-    render(
+    const { container } = render(
       <div style={{ width: 390 }}>
         <MultiImageUpload
           coverImage="/uploads/cover.webp"
@@ -18,6 +18,9 @@ describe('다중 이미지 썸네일 액션', () => {
         />
       </div>,
     );
+
+    expect(container.querySelector('.grid-cols-2')).not.toBeNull();
+    expect(container.querySelector('.grid-cols-3')).toBeNull();
 
     const setMain = screen.getByRole('button', { name: '메인 이미지로 지정' });
     const removeButtons = screen.getAllByRole('button', { name: '이미지 삭제' });

--- a/apps/web/components/multi-image-upload.tsx
+++ b/apps/web/components/multi-image-upload.tsx
@@ -62,14 +62,14 @@ function ImageThumbnail({
 }) {
   return (
     <div
-      className={`relative rounded-lg overflow-hidden border-2 transition-colors ${
+      className={`relative rounded-lg border-2 transition-colors ${
         isMain ? 'border-brand-primary ring-2 ring-brand-primary/30' : 'border-neutral-border'
       }`}
     >
       <div
         role="img"
         aria-label={isMain ? '메인 이미지' : '추가 이미지'}
-        className="w-full h-28 bg-cover bg-center"
+        className="h-28 w-full overflow-hidden rounded-t-md bg-cover bg-center"
         style={{ backgroundImage: `url(${src})` }}
       />
       {/* 메인 이미지 배지 */}
@@ -80,7 +80,7 @@ function ImageThumbnail({
       )}
       {/* 호버 시 액션 버튼들 */}
       {!disabled && (
-        <div className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-black/55 p-2">
+        <div className="absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-center gap-2 bg-black/55 p-2">
           {!isMain && (
             <button
               type="button"
@@ -343,7 +343,7 @@ export function MultiImageUpload({
         )}
       </div>
 
-      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 md:grid-cols-5">
         {allImages.map((url) => (
           <ImageThumbnail
             key={url}

--- a/apps/web/e2e/admin-preview.spec.ts
+++ b/apps/web/e2e/admin-preview.spec.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import puppeteer, { Browser, HTTPRequest, Page } from 'puppeteer';
 
 import { WEB_BASE_URL, isApiUrl } from './utils/env';
-import { setLocalMockSession, setupDirectoryMocks } from './utils/mockApi';
+import { setLocalAdminBoardExtraImage, setLocalMockSession, setupDirectoryMocks } from './utils/mockApi';
 import { configureMockServer } from './utils/mockServer';
 
 let browser: Browser | null = null;
@@ -25,6 +25,57 @@ async function clickButtonByText(currentPage: Page, text: string): Promise<void>
     if (!(button instanceof HTMLElement)) throw new Error(`버튼을 찾지 못했습니다: ${expectedText}`);
     button.click();
   }, text);
+}
+
+type ImageActionMetric = {
+  label: string | null;
+  width: number;
+  height: number;
+  clipped: boolean;
+};
+
+async function measureImageActions(currentPage: Page): Promise<ImageActionMetric[]> {
+  return currentPage.evaluate(() => {
+    const isClipped = (el: HTMLElement) => {
+      const rect = el.getBoundingClientRect();
+      let parent = el.parentElement;
+      while (parent) {
+        const style = getComputedStyle(parent);
+        const clips =
+          ['hidden', 'clip'].includes(style.overflowX)
+          || ['hidden', 'clip'].includes(style.overflowY);
+        if (clips) {
+          const prect = parent.getBoundingClientRect();
+          if (
+            rect.left < prect.left - 0.5
+            || rect.right > prect.right + 0.5
+            || rect.top < prect.top - 0.5
+            || rect.bottom > prect.bottom + 0.5
+          ) {
+            return true;
+          }
+        }
+        parent = parent.parentElement;
+      }
+      return false;
+    };
+
+    const setMain = document.querySelector<HTMLElement>('button[aria-label="메인 이미지로 지정"]');
+    const removes = Array.from(
+      document.querySelectorAll<HTMLElement>('button[aria-label="이미지 삭제"]'),
+    );
+    return [setMain, ...removes]
+      .filter((el): el is HTMLElement => el != null)
+      .map((el) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          label: el.getAttribute('aria-label'),
+          width: rect.width,
+          height: rect.height,
+          clipped: isClipped(el),
+        };
+      });
+  });
 }
 
 describe('Admin post preview (CDP E2E)', () => {
@@ -199,6 +250,48 @@ describe('Admin post preview (CDP E2E)', () => {
     await page.goto(`${WEB_BASE_URL}/admin/posts/44/preview`, { waitUntil: 'networkidle0' });
     const preview = await (await previewResponse).json() as { published_at: string | null };
     expect(preview.published_at).toBeNull();
+  });
+
+  it('좁은 모바일 viewport에서 이미지 액션이 잘리지 않고 44px·Tab 순서를 유지한다', async () => {
+    if (!page) throw new Error('Puppeteer page not initialized');
+    await configureMockServer('admin', { adminBoardExtraImage: true });
+    if (!process.env.E2E_MOCK_API_CONTROL_URL) {
+      setLocalMockSession('admin');
+      await setupDirectoryMocks(page);
+      setLocalAdminBoardExtraImage(true);
+    }
+
+    try {
+      await page.goto(`${WEB_BASE_URL}/admin/posts/44/edit`, { waitUntil: 'networkidle0' });
+      await page.waitForSelector('button[aria-label="메인 이미지로 지정"]');
+      await page.$eval('button[aria-label="메인 이미지로 지정"]', (el) => {
+        el.scrollIntoView({ block: 'center', inline: 'nearest' });
+      });
+
+      for (const width of [320, 390]) {
+        await page.setViewport({ width, height: 844, deviceScaleFactor: 2 });
+        await page.waitForSelector('button[aria-label="메인 이미지로 지정"]');
+        await page.$eval('button[aria-label="메인 이미지로 지정"]', (el) => {
+          el.scrollIntoView({ block: 'center', inline: 'nearest' });
+        });
+        const metrics = await measureImageActions(page);
+        expect(metrics.length).toBeGreaterThanOrEqual(3);
+        for (const metric of metrics) {
+          expect(metric.width, `${metric.label} @${width}`).toBeGreaterThanOrEqual(44);
+          expect(metric.height, `${metric.label} @${width}`).toBeGreaterThanOrEqual(44);
+          expect(metric.clipped, `${metric.label} @${width}`).toBe(false);
+        }
+      }
+
+      await page.focus('button[aria-label="메인 이미지로 지정"]');
+      expect(await page.evaluate(() => document.activeElement?.getAttribute('aria-label')))
+        .toBe('메인 이미지로 지정');
+      await page.keyboard.press('Tab');
+      expect(await page.evaluate(() => document.activeElement?.getAttribute('aria-label')))
+        .toBe('이미지 삭제');
+    } finally {
+      await page.setViewport({ width: 800, height: 600 });
+    }
   });
 
   it('관리자 board 편집에서 마지막 이미지를 삭제하면 null/빈 배열을 저장한다', async () => {

--- a/apps/web/e2e/mock-api-server.mjs
+++ b/apps/web/e2e/mock-api-server.mjs
@@ -239,7 +239,9 @@ const server = createServer(async (request, response) => {
     adminBoardPostContent = 'published_at 없이도 공개되는 board 글';
     adminBoardPostPinned = false;
     adminBoardPostCoverImage = 'https://example.com/e2e-admin-cover.png';
-    adminBoardPostImages = [adminBoardPostCoverImage];
+    adminBoardPostImages = body.adminBoardExtraImage
+      ? [adminBoardPostCoverImage, 'https://example.com/e2e-admin-extra.png']
+      : [adminBoardPostCoverImage];
     sendJson(response, 200, { ok: true, session: sessionKind }, origin);
     return;
   }

--- a/apps/web/e2e/utils/mockApi.ts
+++ b/apps/web/e2e/utils/mockApi.ts
@@ -219,6 +219,13 @@ function resetLocalOwnerPost(): void {
   localAdminBoardPostImages = ['https://example.com/e2e-admin-cover.png'];
 }
 
+export function setLocalAdminBoardExtraImage(enabled: boolean): void {
+  const cover = localAdminBoardPostCoverImage ?? 'https://example.com/e2e-admin-cover.png';
+  localAdminBoardPostImages = enabled
+    ? [cover, 'https://example.com/e2e-admin-extra.png']
+    : [cover];
+}
+
 function isLocalBoardPostsList(url: URL): boolean {
   const categories = [url.searchParams.get('category'), ...url.searchParams.getAll('categories')];
   return categories.some((category) => ['discussion', 'question', 'share', 'congrats'].includes(category ?? ''));

--- a/apps/web/e2e/utils/mockServer.ts
+++ b/apps/web/e2e/utils/mockServer.ts
@@ -1,13 +1,23 @@
 export type MockSession = 'anonymous' | 'member' | 'admin' | 'admin_hero';
 
-export async function configureMockServer(session: MockSession): Promise<void> {
+export type MockServerOptions = {
+  adminBoardExtraImage?: boolean;
+};
+
+export async function configureMockServer(
+  session: MockSession,
+  options?: MockServerOptions,
+): Promise<void> {
   const controlUrl = process.env.E2E_MOCK_API_CONTROL_URL;
   if (!controlUrl) return;
 
   const response = await fetch(`${controlUrl.replace(/\/$/, '')}/__e2e/config`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ session }),
+    body: JSON.stringify({
+      session,
+      adminBoardExtraImage: options?.adminBoardExtraImage === true,
+    }),
   });
   if (!response.ok) {
     throw new Error(`E2E mock API reset failed: HTTP ${response.status}`);

--- a/docs/dev_log_260813.md
+++ b/docs/dev_log_260813.md
@@ -2,4 +2,5 @@
 
 - Web(D11): 운영 소스 `console.*` 제거, 가입신청 토큰 로그 실패를 toast/화면 피드백으로 연결, eslint `no-console` 운영 glob 강제 (#268)
 - Web(D11): 히어로 비활성 슬라이드 `inert`·prev/next 공통화, 관리자 게시물 필터 Select+검색 label, 멀티 이미지 액션 상시 표시, 수첩 live region을 건수로 축소 (#269)
+- Web(D11): 멀티 이미지 기본 grid를 2열로 바꿔 320·390px에서 메인/삭제 44px hit target이 잘리지 않게 함 (#269 follow-up)
 - Web/API(D11): `notice-list`/`accordion`/`nav-dropdown` 삭제, Select를 공용 권위로 채택, 미사용 `create_post`·`get_member_by_email` 제거, `create_comment` 단일 생성 경로 (#273)


### PR DESCRIPTION
## Summary
- #300 리뷰 P2 후속. `#269` 모바일 이미지 액션 완료조건 보정.
- `MultiImageUpload` 기본 grid를 `grid-cols-3` → `grid-cols-2 sm:grid-cols-4 md:grid-cols-5`로 바꿔 320~390px에서 메인/삭제 44px 폭을 확보한다.
- 썸네일 `overflow-hidden`을 이미지 영역으로 옮겨 액션 바가 잘리지 않게 한다.
- mock E2E에서 실제 게시글 수정 화면을 320/390px로 열고 bounding box·overflow clipping·Tab 순서를 확인한다.

## Test plan
- [x] `pnpm -C apps/web exec vitest run __tests__/multi-image-upload.test.tsx`
- [x] mock regression E2E 12/12 PASS (`E2E_MOCK_API_PORT=3011`)
- [ ] CI green

Related: #269
Related: #300

Made with [Cursor](https://cursor.com)