### PR TITLE
fix(web): 학번 입력에서 영문 s를 받을 수 있게 한다

### DIFF
--- a/apps/web/__tests__/login-page.test.tsx
+++ b/apps/web/__tests__/login-page.test.tsx
@@ -51,6 +51,23 @@ describe('LoginPage', () => {
     expect(screen.getByText('가입 신청 후 확인 중이라면 별도로 다시 신청하지 않아도 됩니다.')).toBeInTheDocument();
   });
 
+  it('학번은 s로 시작하는 값을 받고 숫자 키패드를 강제하지 않는다', async () => {
+    loginMock.mockResolvedValueOnce({ ok: 'ok' });
+    renderWithProviders(<LoginPage />);
+
+    const studentIdInput = screen.getByLabelText('학번') as HTMLInputElement;
+    expect(studentIdInput.inputMode).not.toBe('numeric');
+
+    fireEvent.change(studentIdInput, { target: { value: 's47053' } });
+    fireEvent.change(screen.getByLabelText('비밀번호'), { target: { value: 'pw' } });
+    fireEvent.click(screen.getByRole('button', { name: '로그인' }));
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith({ student_id: 's47053', password: 'pw' });
+    });
+    expect(studentIdInput.value).toBe('s47053');
+  });
+
   it('승인 대기 계정은 구체적인 안내 메시지를 표시한다', async () => {
     loginMock.mockRejectedValueOnce(
       new ApiError(403, 'member_pending_approval', 'member_pending_approval')

--- a/apps/web/__tests__/signup-page.test.tsx
+++ b/apps/web/__tests__/signup-page.test.tsx
@@ -55,6 +55,32 @@ describe('SignupPage', () => {
     );
   });
 
+  it('학번은 s로 시작하는 값을 받고 숫자 키패드를 강제하지 않는다', async () => {
+    createSignupRequestMock.mockResolvedValueOnce({
+      id: 12,
+      student_id: 's47053',
+      status: 'pending',
+    });
+    renderWithProviders(<SignupPage />);
+
+    const studentIdInput = screen.getByLabelText('학번') as HTMLInputElement;
+    expect(studentIdInput.inputMode).not.toBe('numeric');
+
+    fireEvent.change(studentIdInput, { target: { value: 's47053' } });
+    fireEvent.change(screen.getByLabelText('이름'), { target: { value: '홍길동' } });
+    fireEvent.change(screen.getByLabelText('이메일'), { target: { value: 'member@example.com' } });
+    fireEvent.change(screen.getByLabelText('기수'), { target: { value: '58' } });
+    fireEvent.change(screen.getByLabelText('연락처'), { target: { value: '01012345678' } });
+    fireEvent.click(screen.getByRole('button', { name: '가입 정보 보내기' }));
+
+    await waitFor(() => {
+      expect(createSignupRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({ student_id: 's47053' }),
+      );
+    });
+    expect(studentIdInput.value).toBe('s47053');
+  });
+
   it('입력 변경 시 이벤트 객체 수명과 무관하게 값이 반영된다', () => {
     renderWithProviders(<SignupPage />);
 

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -77,7 +77,9 @@ function LoginForm() {
         id="login-student-id"
         label="학번"
         autoComplete="username"
-        inputMode="numeric"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         aria-invalid={Boolean(loginError)}
         aria-describedby={loginError ? 'login-error' : undefined}
         value={studentId}

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -220,8 +220,10 @@ export default function SignupPage() {
             label="학번"
             layout="inline"
             required
-            inputMode="numeric"
             autoComplete="username"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             value={form.studentId}
             onChange={(e) => {
               const value = e.currentTarget.value;

--- a/docs/dev_log_260813.md
+++ b/docs/dev_log_260813.md
@@ -7,3 +7,4 @@
 - Ops/CI(D12): versions.md를 manifest exact-pin의 양방향 검사 projection으로 맞추고, docker·docker-compose Dependabot과 Actions 40자리 SHA pin을 추가 (#270/#271/#272)
 - Ops/CI(D12): Actions SHA 가드가 `.yaml` workflow와 같은 줄 `# vX.Y.Z` 주석까지 강제하고, CONTRIBUTING API 테스트를 `make test-api`로 맞춤
 - Web: 총동문회 소개에 `정규 행사` 메뉴와 서강경제대상 소개 페이지를 추가. 일정은 `/events`로 연결하고 2022–2025 수상자를 수록. 히어로는 마룬·금 메달 일러스트(`sogang-economics-award-hero.webp`)
+- Web: 학번이 `s`로 시작하는데 가입·로그인 필드가 숫자 키패드를 강제해 입력이 막히던 문제를 제거. `#238`(2026-07-13) 인증 여정 리뉴얼에서 생긴 회귀.


### PR DESCRIPTION
## Summary
- 가입·로그인 학번 필드가 `#238` 인증 여정 리뉴얼에서 `inputMode="numeric"`을 강제해 `s`로 시작하는 학번을 넣지 못했다.
- 숫자 키패드를 제거하고 자동대문자·자동수정을 꺼서 `s47053` 같은 학번을 그대로 받게 한다.
- 기수 필드의 숫자 키패드는 유지한다.

## Test plan
- [x] `pnpm -C apps/web test -- __tests__/signup-page.test.tsx __tests__/login-page.test.tsx`
- [ ] CI 통과 확인
- [ ] 가입 신청 학번 칸에 `s47053` 입력이 되는지 확인
- [ ] 로그인 학번 칸에도 동일하게 영문이 들어가는지 확인


Made with [Cursor](https://cursor.com)