### PR TITLE
docs(ops): openclaw를 운영 SSH·배포 기준으로 확정한다

### DIFF
--- a/docs/agent_runbook_vps.md
+++ b/docs/agent_runbook_vps.md
@@ -6,18 +6,43 @@
 
 ## 운영 토폴로지와 주 제어 흐름
 
-- API: Docker 컨테이너 `alumni-api`
+- SSH 호스트: `openclaw` 또는 `sogecon` (`ubuntu@168.107.27.33`), 레포 `/srv/sogecon-app`
+- DNS: `sogangeconomics.com` / `www.sogangeconomics.com` /
+  `api.sogangeconomics.com` → openclaw. 이 호스트가 운영이다.
+- API: Docker 컨테이너 `alumni-api` (`127.0.0.1:3001`)
+- Web: Docker 컨테이너 `alumni-web` (`127.0.0.1:3000`)
 - PostgreSQL: Docker 컨테이너 `sogecon-db`
-- Web: Docker가 아닌 systemd 서비스 `sogecon-web`; `/srv/www/sogecon/current`
-  standalone 릴리스에서 실행
-- `compose.yaml`은 로컬 dev/test 전용입니다. VPS 운영 컨테이너는
-  `docker run` 기반 운영 스크립트로 관리합니다.
+- nginx가 운영·프리뷰 vhost 모두 위 loopback 포트로 프록시한다.
+- `compose.yaml`은 로컬 dev/test 전용이다. 운영 컨테이너는
+  `scripts/deploy-vps.sh --local-build` → `ops/cloud-start.sh`로 관리한다.
 
-operator-confirmed current state는 migration 전까지 Web이 standalone
-systemd release이고 API/PostgreSQL이 Docker인 구성입니다. 대표가 결정한
-near-term target은 API/Web/PostgreSQL full Docker 구성입니다. 기존 D6
-`cloud-start.sh` full-container guard를 target entry point로 사용하며,
-standalone systemd release는 cutover 중 rollback fallback으로 보존합니다.
+Web 이미지의 공개 API 주소는 빌드타임 값이다. 운영 빌드 권위는 서버
+`.env.web`의 `NEXT_PUBLIC_WEB_API_BASE=https://api.sogangeconomics.com`이다.
+`--web-api-base`는 다른 호스트를 의도적으로 구울 때만 넘긴다. 프리뷰
+호스트(`sogecon-preview.ginishuh.kr`, `api-sogecon-preview.ginishuh.kr`)는
+같은 컨테이너를 가리킬 수 있으나 배포 빌드 기준이 아니다.
+
+standalone systemd(`sogecon-web`)는 full-Docker 이전 경로의 rollback
+fallback으로만 남긴다. 현재 운영 primary가 아니다.
+
+### 표준 재배포 (openclaw)
+
+`--web-api-base`를 넣지 않는다. `.env.web`이 운영 API 주소를 공급한다.
+
+```bash
+ssh openclaw   # 또는: ssh sogecon
+cd /srv/sogecon-app
+git fetch origin main
+git checkout --detach origin/main
+TAG=$(git rev-parse --short HEAD)
+bash scripts/deploy-vps.sh -t "$TAG" --local-build \
+  --network sogecon_net \
+  --uploads /var/lib/sogecon/uploads \
+  --api-health http://127.0.0.1:3001/healthz \
+  --web-health http://127.0.0.1:3000/
+curl -fsS https://api.sogangeconomics.com/healthz
+curl -fsS https://sogangeconomics.com/
+```
 
 ## 요구 사항
 - Docker 설치

--- a/docs/agent_runbook_vps_en.md
+++ b/docs/agent_runbook_vps_en.md
@@ -4,18 +4,45 @@ This runbook helps an on‑box agent (Codex CLI/Claude) deploy and redeploy the 
 
 ## Operational topology and primary control flow
 
-- API: Docker container `alumni-api`
+- SSH host: `openclaw` or `sogecon` (`ubuntu@168.107.27.33`), repo `/srv/sogecon-app`
+- DNS: `sogangeconomics.com` / `www.sogangeconomics.com` /
+  `api.sogangeconomics.com` → openclaw. This host is production.
+- API: Docker container `alumni-api` (`127.0.0.1:3001`)
+- Web: Docker container `alumni-web` (`127.0.0.1:3000`)
 - PostgreSQL: Docker container `sogecon-db`
-- Web: systemd service `sogecon-web`, running the standalone release at
-  `/srv/www/sogecon/current`; Web is not a Docker service on the current VPS.
-- `compose.yaml` is local dev/test only. VPS operational containers are managed
-  by `docker run` deployment scripts.
+- nginx proxies both production and leftover preview vhosts to those loopback
+  ports.
+- `compose.yaml` is local dev/test only. Production containers are managed with
+  `scripts/deploy-vps.sh --local-build` → `ops/cloud-start.sh`.
 
-The operator-confirmed current state is a systemd standalone Web release with
-Docker API/PostgreSQL until migration. The accepted near-term target is full
-Docker for API, Web, and PostgreSQL. The existing D6 full-container guards in
-`cloud-start.sh` are the target entry point; the standalone systemd release is
-preserved as a cutover rollback fallback, not the target primary architecture.
+The public API URL is baked at Web image build time. Production build
+authority is the server `.env.web` value
+`NEXT_PUBLIC_WEB_API_BASE=https://api.sogangeconomics.com`. Pass
+`--web-api-base` only when intentionally baking a different host. Preview
+hosts (`sogecon-preview.ginishuh.kr`, `api-sogecon-preview.ginishuh.kr`) may
+point at the same containers but are not the deploy build baseline.
+
+The standalone systemd unit (`sogecon-web`) is a pre-full-Docker rollback
+fallback only. It is not the current production primary.
+
+### Canonical redeploy (openclaw)
+
+Do not pass `--web-api-base`. `.env.web` supplies the production API URL.
+
+```bash
+ssh openclaw   # or: ssh sogecon
+cd /srv/sogecon-app
+git fetch origin main
+git checkout --detach origin/main
+TAG=$(git rev-parse --short HEAD)
+bash scripts/deploy-vps.sh -t "$TAG" --local-build \
+  --network sogecon_net \
+  --uploads /var/lib/sogecon/uploads \
+  --api-health http://127.0.0.1:3001/healthz \
+  --web-health http://127.0.0.1:3000/
+curl -fsS https://api.sogangeconomics.com/healthz
+curl -fsS https://sogangeconomics.com/
+```
 
 ## Requirements
 - Docker installed

--- a/docs/dev_log_260813.md
+++ b/docs/dev_log_260813.md
@@ -8,3 +8,4 @@
 - Ops/CI(D12): Actions SHA 가드가 `.yaml` workflow와 같은 줄 `# vX.Y.Z` 주석까지 강제하고, CONTRIBUTING API 테스트를 `make test-api`로 맞춤
 - Web: 총동문회 소개에 `정규 행사` 메뉴와 서강경제대상 소개 페이지를 추가. 일정은 `/events`로 연결하고 2022–2025 수상자를 수록. 히어로는 마룬·금 메달 일러스트(`sogang-economics-award-hero.webp`)
 - Web: 학번이 `s`로 시작하는데 가입·로그인 필드가 숫자 키패드를 강제해 입력이 막히던 문제를 제거. `#238`(2026-07-13) 인증 여정 리뉴얼에서 생긴 회귀.
+- Ops: openclaw를 운영 VPS로 확정. DNS(`sogangeconomics.com`/`api`)가 이 호스트를 가리키므로 배포 빌드 권위는 `.env.web`의 운영 API URL이고, 프리뷰 `--web-api-base`는 쓰지 않는다.

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Usage:
 #   bash scripts/deploy-vps.sh -t <tag> [--prefix local/sogecon] [--local-build|--pull-images] \
 #       [--env .env.api] [--web-env .env.web] \
-#       [--web-api-base https://api.example.com] \
+#       [--web-api-base https://api.example.com] \  # omit on openclaw prod; .env.web is authority
 #       [--skip-migrate] [--seed-admin] [--uploads /var/lib/sogecon/uploads] \
 #       [--network sogecon_net] [--api-health URL] [--web-health URL]
 


### PR DESCRIPTION
## Summary
- 운영 VPS를 openclaw로 확정한다. DNS(`sogangeconomics.com` / `api`)가 이미 이 호스트를 가리킨다.
- 웹 이미지 빌드는 서버 `.env.web`을 권위로 두고, 프리뷰 `--web-api-base`는 쓰지 않는다.
- SSH 별명 `sogecon`/`openclaw`는 로컬 `~/.ssh/config`이며 이 PR에 포함하지 않는다.

## Test plan
- [ ] CI 통과
- [ ] runbook의 표준 재배포가 `--web-api-base` 없이 `.env.web`을 쓰는지 확인


Made with [Cursor](https://cursor.com)