### PR TITLE
fix(web): 개인정보 보호책임자를 실제 운영진으로 맞춘다

### DIFF
--- a/apps/web/__tests__/__snapshots__/legal-faq.test.tsx.snap
+++ b/apps/web/__tests__/__snapshots__/legal-faq.test.tsx.snap
@@ -277,7 +277,14 @@ exports[`FAQ & Policy static pages > renders FAQ page with grouped sections and 
               >
                 sogangecon.alumni@gmail.com
               </a>
-              ) 또는 대표 전화(02-715-1234)로 연락해 주세요. 평일 10:00-17:00에 응대하며, 주말 문의는 다음 영업일에 순차 처리합니다.
+              ) 또는 
+              <a
+                class="text-link"
+                href="/support/contact"
+              >
+                문의하기
+              </a>
+              로 연락해 주세요. 평일 10:00-17:00에 응대하며, 주말 문의는 다음 영업일에 순차 처리합니다.
             </dd>
           </div>
         </dl>
@@ -303,7 +310,14 @@ exports[`FAQ & Policy static pages > renders FAQ page with grouped sections and 
         >
           sogangecon.alumni@gmail.com
         </a>
-         또는 대표 번호 02-715-1234(ARS 2번)로 연락해 주세요. 평균 응답 시간은 영업일 기준 24시간 이내입니다.
+        또는 
+        <a
+          class="text-link"
+          href="/support/contact"
+        >
+          문의하기
+        </a>
+        로 남겨 주세요. 평균 응답 시간은 영업일 기준 24시간 이내입니다.
       </p>
     </section>
     <p
@@ -514,7 +528,7 @@ exports[`FAQ & Policy static pages > renders privacy policy with sections and co
           <p
             class="mt-3"
           >
-            위 동문 수첩 공개 외에 법령에 따른 수사기관 요청, 클라우드 인프라·문자 발송 등 운영 위탁이 있을 수 있습니다. 현재 위탁 현황은 AWS(인프라 운영), Twilio(알림 발송)이며, 위탁 계약 시 안전성 확보를 위한 조치를 명시합니다.
+            위 동문 수첩 공개 외에 법령에 따른 수사기관 요청, 서버 호스팅·안내 메일 발송 등 운영 위탁이 있을 수 있습니다. 현재 위탁 현황은 서버 호스팅과 Gmail(안내 메일 발송)이며, 위탁 계약 시 안전성 확보를 위한 조치를 명시합니다.
           </p>
         </div>
       </section>
@@ -640,7 +654,7 @@ exports[`FAQ & Policy static pages > renders privacy policy with sections and co
               <dd
                 class="text-neutral-muted"
               >
-                김서강 회장 (
+                허민철 회장 (
                 <a
                   class="text-link"
                   href="mailto:sogangecon.alumni@gmail.com"
@@ -659,14 +673,14 @@ exports[`FAQ & Policy static pages > renders privacy policy with sections and co
               <dd
                 class="text-neutral-muted"
               >
-                박은영 사무국장 (
+                황승환 사무국장 (
                 <a
                   class="text-link"
                   href="mailto:sogangecon.alumni@gmail.com"
                 >
                   sogangecon.alumni@gmail.com
                 </a>
-                , 02-715-1234)
+                )
               </dd>
             </div>
           </dl>

--- a/apps/web/__tests__/legal-faq.test.tsx
+++ b/apps/web/__tests__/legal-faq.test.tsx
@@ -14,6 +14,7 @@ describe('FAQ & Policy static pages', () => {
     expect(screen.getByRole('heading', { name: '계정 및 접근' })).toBeInTheDocument();
     expect(screen.getByText('문서 버전: 2026-08-23')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '이용약관' })).toHaveAttribute('href', '/terms');
+    expect(screen.queryByText(/02-715-1234/)).not.toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -21,7 +22,9 @@ describe('FAQ & Policy static pages', () => {
     const { asFragment } = render(<PrivacyPage />);
     expect(screen.getByRole('heading', { level: 1, name: '개인정보 처리방침' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '6. 개인정보 보호를 위한 기술적·관리적 대책' })).toBeInTheDocument();
-    expect(screen.getByText(/김서강 회장/)).toBeInTheDocument();
+    expect(screen.getByText(/허민철 회장/)).toBeInTheDocument();
+    expect(screen.getByText(/황승환 사무국장/)).toBeInTheDocument();
+    expect(screen.queryByText(/02-715-1234/)).not.toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: siteConfig.officeEmail }).length).toBeGreaterThan(0);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -125,8 +125,9 @@ const faqSections: FAQSection[] = [
         question: '문의는 어떤 채널을 이용하면 되나요?',
         answer: (
           <>
-            사무국 대표 메일(<a className="text-link" href={officeMailto}>{siteConfig.officeEmail}</a>) 또는 대표 전화(02-715-1234)로 연락해 주세요.
-            평일 10:00-17:00에 응대하며, 주말 문의는 다음 영업일에 순차 처리합니다.
+            사무국 대표 메일(<a className="text-link" href={officeMailto}>{siteConfig.officeEmail}</a>) 또는{' '}
+            <Link className="text-link" href="/support/contact">문의하기</Link>
+            로 연락해 주세요. 평일 10:00-17:00에 응대하며, 주말 문의는 다음 영업일에 순차 처리합니다.
           </>
         )
       }
@@ -171,8 +172,8 @@ export default function FAQPage() {
           추가로 궁금한 점이 있다면
         </h2>
         <p className="mt-2">
-          사무국 대표 메일 <a className="underline decoration-brand-accent decoration-2 underline-offset-4" href={officeMailto}>{siteConfig.officeEmail}</a> 또는
-          대표 번호 02-715-1234(ARS 2번)로 연락해 주세요. 평균 응답 시간은 영업일 기준 24시간 이내입니다.
+          사무국 대표 메일 <a className="underline decoration-brand-accent decoration-2 underline-offset-4" href={officeMailto}>{siteConfig.officeEmail}</a>
+          또는 <Link className="text-link" href="/support/contact">문의하기</Link>로 남겨 주세요. 평균 응답 시간은 영업일 기준 24시간 이내입니다.
         </p>
       </section>
 

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -82,8 +82,8 @@ const sections: PolicySection[] = [
           이 공개는 비밀번호 만들기와 분리된 동의 화면에서 받습니다. 운영자가 회원 동의 없이 공개 범위만 바꿀 수는 없습니다.
         </p>
         <p className="mt-3">
-          위 동문 수첩 공개 외에 법령에 따른 수사기관 요청, 클라우드 인프라·문자 발송 등 운영 위탁이 있을 수 있습니다.
-          현재 위탁 현황은 AWS(인프라 운영), Twilio(알림 발송)이며, 위탁 계약 시 안전성 확보를 위한 조치를 명시합니다.
+          위 동문 수첩 공개 외에 법령에 따른 수사기관 요청, 서버 호스팅·안내 메일 발송 등 운영 위탁이 있을 수 있습니다.
+          현재 위탁 현황은 서버 호스팅과 Gmail(안내 메일 발송)이며, 위탁 계약 시 안전성 확보를 위한 조치를 명시합니다.
         </p>
       </>
     )
@@ -130,7 +130,7 @@ const sections: PolicySection[] = [
         <div>
           <dt className="font-semibold text-neutral-ink">개인정보 보호책임자</dt>
           <dd className="text-neutral-muted">
-            김서강 회장 (
+            허민철 회장 (
             <a className="text-link" href={officeMailto}>{siteConfig.officeEmail}</a>
             )
           </dd>
@@ -138,9 +138,9 @@ const sections: PolicySection[] = [
         <div>
           <dt className="font-semibold text-neutral-ink">개인정보 보호담당자</dt>
           <dd className="text-neutral-muted">
-            박은영 사무국장 (
+            황승환 사무국장 (
             <a className="text-link" href={officeMailto}>{siteConfig.officeEmail}</a>
-            , 02-715-1234)
+            )
           </dd>
         </div>
       </dl>

--- a/docs/dev_log_260823.md
+++ b/docs/dev_log_260823.md
@@ -10,3 +10,4 @@
 - Changed: SMTP 전달 실패는 502, 로컬 `PUBLIC_SITE_URL` 기본값은 localhost, staging/prod는 빈 값·localhost·TLS 끄기를 거절한다.
 - Fixed: 안내 메일이 나간 뒤 감사 로그 저장이 실패해도 발송 성공으로 반환한다.
 - Fixed: staging/prod 설정 테스트가 공개 `PUBLIC_SITE_URL`을 넣도록 맞춘다.
+- Changed: 개인정보 처리방침 보호책임자·담당자를 허민철 회장·황승환 사무국장으로 맞추고, 가상 전화번호와 AWS/Twilio 문구를 뺀다.


### PR DESCRIPTION
## Summary
- 처리방침 보호책임자·담당자를 허민철 회장·황승환 사무국장으로 맞춥니다.
- 가상 전화번호 `02-715-1234`와 AWS/Twilio 위탁 문구를 빼고, 연락은 공용 메일과 문의하기로 안내합니다.

## Test plan
- [x] `vitest` legal-faq 스냅샷
- [x] 로컬 `/privacy`, `/faq`, `/support/contact` 확인
- [ ] CI green 후 운영 배포

Made with [Cursor](https://cursor.com)